### PR TITLE
OCI Support for Helm Chart with cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   IMAGE_NAME: ghcr.io/mogenius/renovate-operator
-  REGISTRY: ghcr.io 
+  REGISTRY: ghcr.io
   DOCKERFILE: Dockerfile
   HELMNAME: "renovate-operator"
 
@@ -98,18 +98,18 @@ jobs:
           provenance: false
 
       - name: Clean up Docker images
-        if: always()  # Also run in case of errors
+        if: always() # Also run in case of errors
         run: |
           # Entferne dangling images
           docker image prune -f
-          
-
 
   helm-chart:
     needs: [prepare, build-and-push-docker]
     runs-on: self-hosted
     permissions:
       contents: write
+      packages: write
+      id-token: write
     steps:
       - name: Generate a token
         id: generate-token
@@ -128,15 +128,18 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          
+
       - name: Install Helm
         uses: azure/setup-helm@v4.3.1
         id: install
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.2'
+          go-version: ">=1.23.2"
 
       - name: Run helm-docs
         uses: losisin/helm-docs-github-action@v1.6.2
@@ -166,12 +169,28 @@ jobs:
 
             git add charts/renovate-operator/crds
 
+            echo "Packaging Helm chart"
             helm package -d /tmp/ ./charts/renovate-operator
+
+            echo "Pushing to Helm repository"
             curl -XPOST -L -k --data-binary "@/tmp/${{ env.HELMNAME }}-$VERSION.tgz" https://${{ secrets.MO_HELMUSER }}:${{ secrets.MO_HELMPASS }}@helm.mogenius.com/api/public/charts
 
+            echo "Pushing to OCI registry"
+            echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io --username ${{ github.actor }} --password-stdin
+            CHART_DIGEST=$(helm push /tmp/${{ env.HELMNAME }}-$VERSION.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts 2>&1 | grep "Digest: sha256:" | awk '{print $2}')
+
+            if [ -z "$CHART_DIGEST" ]; then
+              echo "Failed to extract chart digest"
+              exit 1
+            fi
+            echo "Chart digest: $CHART_DIGEST"
+
+            echo "Signing Helm chart with cosign"
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+            cosign sign --yes ghcr.io/${{ github.repository_owner }}/helm-charts/${{ env.HELMNAME }}@${CHART_DIGEST}
+
             git commit -m "chore: update Chart.yaml and documentation for version $VERSION [skip ci]"
-            
+
             git pull --rebase
             git push origin main
           fi
-   

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ If you are already running Kubernetes, this project might be for you.
 
 ### Helm
 
+#### Option 1: OCI Registry
+
+```sh
+helm -n renovate-operator upgrade --install renovate-operator \
+  oci://ghcr.io/mogenius/helm-charts/renovate-operator \
+  --create-namespace --wait
+```
+
+#### Option 2: Helm Repository
+
 ```sh
 helm repo add mogenius https://helm.mogenius.com/public --force-update
 helm -n renovate-operator upgrade --install renovate-operator mogenius/renovate-operator --create-namespace --wait

--- a/charts/renovate-operator/Chart.yaml
+++ b/charts/renovate-operator/Chart.yaml
@@ -6,8 +6,9 @@ version: 1.9.0
 appVersion: 1.9.0
 home: https://mogenius.com
 icon: https://app.mogenius.com/assets/logos/logo-mogenius-signet-neg.svg
-sources: 
+sources:
   - https://helm.mogenius.com/public
+  - oci://ghcr.io/mogenius/helm-charts/renovate-operator
   - https://github.com/mogenius/renovate-operator
 maintainers:
   - email: ruediger@mogenius.com


### PR DESCRIPTION
## Summary
- Added cosign-based signing for Helm charts published to OCI registry
- Uses keyless signing with Sigstore

## Changes
- Added `id-token: write` permission for OIDC authentication
- Installed cosign in CI workflow
- Signs chart by digest after OCI push
- Updated documentation

## Test Plan
- [x] Merge and verify next release creates signed chart
- [x] Test signature verification with cosign

Closes #52