### PR TITLE
feat: add (HTTP)route support to helm chart

### DIFF
--- a/charts/renovate-operator/templates/route.yaml
+++ b/charts/renovate-operator/templates/route.yaml
@@ -1,6 +1,24 @@
 {{- with .Values.route }}
 {{- range $routeName, $routeConfig := . }}
 {{- if (default true $routeConfig.enabled) }}
+{{- $rules := $routeConfig.rules }}
+{{- if not $rules }}
+{{- $backendRefs := list (dict
+    "name" (include "renovate-operator.fullname" $)
+    "port" 8081
+    "weight" 1
+) }}
+{{- if $.Values.webhook.enabled }}
+{{- $backendRefs = append $backendRefs (dict
+    "name" (printf "%s-webhook" (include "renovate-operator.fullname" $))
+    "port" $.Values.webhook.port
+    "weight" 1
+) }}
+{{- end }}
+{{- $rules = list (dict "backendRefs" $backendRefs) }}
+{{- end }}
+
+
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: {{ $routeConfig.kind | default "HTTPRoute" }}
@@ -10,43 +28,38 @@ metadata:
   labels:
     app: {{ include "renovate-operator.fullname" $ }}
     {{- with $routeConfig.labels }}
-    {{- toYaml . | nindent 2 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-  {{- with (default dict $routeConfig.annotations) }}
+    {{- with (default dict $routeConfig.annotations) }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+
 spec:
   {{- if $routeConfig.parentRefs }}
   parentRefs:
     {{- toYaml $routeConfig.parentRefs | nindent 4 }}
   {{- end }}
+
   {{- if $routeConfig.hostnames }}
   hostnames:
     {{- range $routeConfig.hostnames }}
     - {{ tpl . $ | quote }}
     {{- end }}
   {{- end }}
-  {{- if $routeConfig.rules }}
   rules:
-    {{- range $ruleIndex, $rule := $routeConfig.rules }}
-    - {{- if $rule.name }}
+    {{- range $ruleIndex, $rule := $rules }}
+    - backendRefs:
+        {{- toYaml $rule.backendRefs | nindent 8 }}
+      {{- if $rule.filters }}
+      {{- if $rule.name }}
       name: {{ $rule.name | quote }}
       {{- end }}
       {{- if $rule.matches }}
       matches:
         {{- toYaml $rule.matches | nindent 8 }}
       {{- end }}
-      {{- if $rule.backendRefs }}
-      backendRefs:
-        {{- toYaml $rule.backendRefs | nindent 8 }}
-      {{- else }}
-      backendRefs:
-        - name: {{ include "renovate-operator.fullname" $ }}
-          port: 8081
-          weight: 1
-      {{- end }}
-      {{- if $rule.filters }}
+
       filters:
         {{- toYaml $rule.filters | nindent 8 }}
       {{- end }}
@@ -55,6 +68,7 @@ spec:
         {{- toYaml $rule.timeouts | nindent 8 }}
       {{- end }}
     {{- end }}
-  {{- end }}
+
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -42,7 +42,7 @@ route:
   {}
   # main:
   #   # -- Enables or disables the route
-  #   enabled: false
+  #   enabled: true
 
   #   # -- Set the route kind
   #   # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
@@ -90,7 +90,7 @@ route:
   #       timeouts: {}
 
 webhook:
-  enabled: false
+  enabled: true
   port: 8082
   ingress:
     # -- whether to enable the ingress for the webhook server


### PR DESCRIPTION
With ingress-nginx being deprecated soon it'd be nice to be able to template out httproutes.