### PR TITLE
feat: add metrics for Renovate job failures and dependency issues

### DIFF
--- a/charts/renovate-operator/templates/dashboard.yaml
+++ b/charts/renovate-operator/templates/dashboard.yaml
@@ -501,6 +501,245 @@ data:
           ],
           "title": "Renovate Executions - Failed",
           "type": "barchart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 13
+          },
+          "id": 7,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "count(renovate_operator_run_failed{\"renovate-namespace\"=~\"$RenovateNamespace\", \"renovate-job\"=~\"$RenovateJob\"} == 1) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Currently Failed Runs",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 13
+          },
+          "id": 8,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "count(renovate_operator_dependency_issues{\"renovate-namespace\"=~\"$RenovateNamespace\", \"renovate-job\"=~\"$RenovateJob\"} == 1) or vector(0)",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Projects with Dependency Issues",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "project"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 300
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 9,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "renovate_operator_run_failed{\"renovate-namespace\"=~\"$RenovateNamespace\", \"renovate-job\"=~\"$RenovateJob\"} == 1 or renovate_operator_dependency_issues{\"renovate-namespace\"=~\"$RenovateNamespace\", \"renovate-job\"=~\"$RenovateJob\"} == 1",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Projects with Issues",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Value": true,
+                  "__name__": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value": 5,
+                  "__name__": 1,
+                  "project": 4,
+                  "renovate-job": 3,
+                  "renovate-namespace": 2
+                },
+                "renameByName": {
+                  "project": "Project",
+                  "renovate-job": "Renovate Job",
+                  "renovate-namespace": "Namespace"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "preload": false,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -11,6 +11,44 @@ metrics:
 
 ## Exported Metrics
 
-| Name                                       | Type    | Description                                | Labels                                                    |
-|--------------------------------------------|---------|--------------------------------------------|-----------------------------------------------------------|
-| renovate_operator_project_executions_total | Counter | Total number of executed Renovate projects | `renovate-namespace`, `renovate-job`, `project`, `status` |
+| Name                                       | Type    | Description                                                              | Labels                                                    |
+|--------------------------------------------|---------|--------------------------------------------------------------------------|-----------------------------------------------------------|
+| renovate_operator_project_executions_total | Counter | Total number of executed Renovate projects                               | `renovate-namespace`, `renovate-job`, `project`, `status` |
+| renovate_operator_run_failed               | Gauge   | Whether the last Renovate run for this project failed (1=failed, 0=success) | `renovate-namespace`, `renovate-job`, `project`           |
+| renovate_operator_dependency_issues        | Gauge   | Whether the last Renovate run had WARN/ERROR log entries (1=issues, 0=clean) | `renovate-namespace`, `renovate-job`, `project`           |
+
+## Dependency Issues Detection
+
+The `renovate_operator_dependency_issues` metric detects issues by parsing Renovate's JSON log output. This includes:
+
+- Configuration validation warnings
+- Dependency lookup failures
+- Rate limiting issues
+- Invalid `renovate.json` configuration
+
+**Important**: This metric requires Renovate to output logs in JSON format. The operator sets `LOG_FORMAT=json` by default for all Renovate jobs. If you override this via `extraEnv` in your RenovateJob spec, the `renovate_operator_dependency_issues` metric will not function correctly and will always report 0.
+
+## Example Prometheus Alerting Rules
+
+```yaml
+groups:
+  - name: renovate-operator
+    rules:
+      - alert: RenovateRunFailed
+        expr: renovate_operator_run_failed == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Renovate run failed for {{ $labels.project }}"
+          description: "The last Renovate run for project {{ $labels.project }} in job {{ $labels.renovate_job }} failed."
+
+      - alert: RenovateDependencyIssues
+        expr: renovate_operator_dependency_issues == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Renovate detected dependency issues for {{ $labels.project }}"
+          description: "The last Renovate run for project {{ $labels.project }} in job {{ $labels.renovate_job }} had warnings or errors. Check the Dependency Dashboard or Renovate logs for details."
+```

--- a/src/go.mod
+++ b/src/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -68,7 +68,8 @@ func CreateJob(ctx context.Context, client crclient.Client, job *batchv1.Job) er
 	return client.Create(ctx, job)
 }
 
-func getLastJobLog(ctx context.Context, clientset kubernetes.Interface, job *batchv1.Job) (string, error) {
+// GetLastJobLog retrieves the logs from the most recent pod of a job
+func GetLastJobLog(ctx context.Context, clientset kubernetes.Interface, job *batchv1.Job) (string, error) {
 	ns := job.Namespace
 
 	// Use Job's label selector

--- a/src/internal/parser/logParser.go
+++ b/src/internal/parser/logParser.go
@@ -1,0 +1,52 @@
+package parser
+
+import (
+	"bufio"
+	"encoding/json"
+	"strings"
+)
+
+// LogParseResult contains the result of parsing Renovate logs
+type LogParseResult struct {
+	HasIssues bool // true if any WARN (level 40) or ERROR (level 50) found
+}
+
+// renovateLogEntry represents a single line in Renovate's JSON log output
+type renovateLogEntry struct {
+	Level int `json:"level"`
+}
+
+// ParseRenovateLogs parses Renovate JSON logs (NDJSON format) and detects warnings/errors.
+// Returns HasIssues=true if any log entry has level >= 40 (WARN or ERROR).
+// If logs are not in JSON format or empty, returns HasIssues=false.
+func ParseRenovateLogs(logs string) *LogParseResult {
+	result := &LogParseResult{
+		HasIssues: false,
+	}
+
+	if logs == "" {
+		return result
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(logs))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var entry renovateLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			// Line is not valid JSON, skip it
+			continue
+		}
+
+		// Renovate log levels: 10=trace, 20=debug, 30=info, 40=warn, 50=error, 60=fatal
+		if entry.Level >= 40 {
+			result.HasIssues = true
+			return result // Early return, we found at least one issue
+		}
+	}
+
+	return result
+}

--- a/src/internal/parser/logParser_test.go
+++ b/src/internal/parser/logParser_test.go
@@ -1,0 +1,88 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParseRenovateLogs(t *testing.T) {
+	tests := []struct {
+		name      string
+		logs      string
+		wantIssue bool
+	}{
+		{
+			name:      "empty logs",
+			logs:      "",
+			wantIssue: false,
+		},
+		{
+			name:      "only info level logs",
+			logs:      `{"level":30,"msg":"Repository started"}` + "\n" + `{"level":30,"msg":"Dependency extraction complete"}`,
+			wantIssue: false,
+		},
+		{
+			name:      "debug level logs",
+			logs:      `{"level":20,"msg":"Some debug message"}` + "\n" + `{"level":10,"msg":"Trace message"}`,
+			wantIssue: false,
+		},
+		{
+			name:      "warning level log",
+			logs:      `{"level":30,"msg":"Info message"}` + "\n" + `{"level":40,"msg":"Warning: config validation issue"}`,
+			wantIssue: true,
+		},
+		{
+			name:      "error level log",
+			logs:      `{"level":30,"msg":"Info message"}` + "\n" + `{"level":50,"msg":"Error: failed to lookup dependency"}`,
+			wantIssue: true,
+		},
+		{
+			name:      "fatal level log",
+			logs:      `{"level":60,"msg":"Fatal error occurred"}`,
+			wantIssue: true,
+		},
+		{
+			name:      "mixed valid and invalid JSON lines",
+			logs:      "some non-json output\n" + `{"level":30,"msg":"Info"}` + "\nnot json either",
+			wantIssue: false,
+		},
+		{
+			name:      "non-JSON logs only",
+			logs:      "This is plain text output\nAnother line of text",
+			wantIssue: false,
+		},
+		{
+			name:      "JSON without level field",
+			logs:      `{"msg":"No level field"}` + "\n" + `{"other":"field"}`,
+			wantIssue: false,
+		},
+		{
+			name:      "real world example with warning",
+			logs:      `{"level":30,"time":1706011234567,"msg":"Repository started","repository":"owner/repo"}` + "\n" + `{"level":40,"time":1706011234568,"msg":"Configuration validation warning","repository":"owner/repo"}` + "\n" + `{"level":30,"time":1706011234569,"msg":"Repository finished","repository":"owner/repo"}`,
+			wantIssue: true,
+		},
+		{
+			name:      "level exactly 40 (boundary)",
+			logs:      `{"level":40,"msg":"Warning level"}`,
+			wantIssue: true,
+		},
+		{
+			name:      "level exactly 39 (below boundary)",
+			logs:      `{"level":39,"msg":"Just below warning"}`,
+			wantIssue: false,
+		},
+		{
+			name:      "empty lines in logs",
+			logs:      "\n\n" + `{"level":30,"msg":"Info"}` + "\n\n",
+			wantIssue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseRenovateLogs(tt.logs)
+			if result.HasIssues != tt.wantIssue {
+				t.Errorf("ParseRenovateLogs() HasIssues = %v, want %v", result.HasIssues, tt.wantIssue)
+			}
+		})
+	}
+}

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -16,6 +16,10 @@ import (
 func newDiscoveryJob(job *api.RenovateJob) *batchv1.Job {
 	predefinedEnvVars := []v1.EnvVar{
 		{
+			Name:  "LOG_FORMAT",
+			Value: "json",
+		},
+		{
 			Name:  "NODE_NO_WARNINGS",
 			Value: "1",
 		},
@@ -106,6 +110,14 @@ func newDiscoveryJob(job *api.RenovateJob) *batchv1.Job {
 
 // create a Job spec for renovate run on project...
 func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
+	// Default env vars - user can override via ExtraEnv since these are prepended
+	predefinedEnvVars := []v1.EnvVar{
+		{
+			Name:  "LOG_FORMAT",
+			Value: "json",
+		},
+	}
+
 	envFromSecrets := []v1.EnvFromSource{}
 	if job.Spec.SecretRef != "" {
 		envFromSecrets = append(envFromSecrets, v1.EnvFromSource{
@@ -149,7 +161,7 @@ func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
 							Command:         []string{"renovate"},
 							Args:            []string{"--base-dir", "/tmp", project},
 							Image:           job.Spec.Image,
-							Env:             job.Spec.ExtraEnv,
+							Env:             append(predefinedEnvVars, job.Spec.ExtraEnv...),
 							EnvFrom:         envFromSecrets,
 							Resources:       job.Spec.Resources,
 							VolumeMounts:    append(volumeMounts, job.Spec.ExtraVolumeMounts...),

--- a/src/internal/renovate/jobDefinitions_test.go
+++ b/src/internal/renovate/jobDefinitions_test.go
@@ -38,6 +38,52 @@ var (
 	}
 )
 
+func TestLogFormatCanBeOverridden(t *testing.T) {
+	err := config.InitializeConfigModule([]config.ConfigItemDescription{
+		{Key: "JOB_TIMEOUT_SECONDS", Optional: true, Default: "10"},
+	})
+	if err != nil {
+		t.Fatalf("failed to initialize config: %v", err)
+	}
+
+	job := &api.RenovateJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
+		Spec: api.RenovateJobSpec{
+			Image: "renovate:latest",
+			ExtraEnv: []v1.EnvVar{
+				{Name: "LOG_FORMAT", Value: "text"},
+			},
+		},
+	}
+
+	// Test discovery job - user override should come after default
+	dj := newDiscoveryJob(job)
+	djContainer := &dj.Spec.Template.Spec.Containers[0]
+	// Find the last LOG_FORMAT env var (user override wins)
+	var lastLogFormat string
+	for _, env := range djContainer.Env {
+		if env.Name == "LOG_FORMAT" {
+			lastLogFormat = env.Value
+		}
+	}
+	if lastLogFormat != "text" {
+		t.Errorf("expected user override LOG_FORMAT=text to be last, got %s", lastLogFormat)
+	}
+
+	// Test executor job - user override should come after default
+	rj := newRenovateJob(job, "myproject")
+	rjContainer := &rj.Spec.Template.Spec.Containers[0]
+	lastLogFormat = ""
+	for _, env := range rjContainer.Env {
+		if env.Name == "LOG_FORMAT" {
+			lastLogFormat = env.Value
+		}
+	}
+	if lastLogFormat != "text" {
+		t.Errorf("expected user override LOG_FORMAT=text to be last, got %s", lastLogFormat)
+	}
+}
+
 func TestSecurityContextHelpers(t *testing.T) {
 	var spec api.RenovateJobSpec
 
@@ -164,6 +210,7 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	expectTtlSecondsAfterFinished(t, dj, nil)
 
 	// env vars
+	expectEnvVar(t, djContainer, "LOG_FORMAT", "json")
 	expectEnvVar(t, djContainer, "RENOVATE_AUTODISCOVER_FILTER", "org/*")
 	expectEnvVar(t, djContainer, "RENOVATE_AUTODISCOVER_TOPICS", "renovate")
 	expectEnvFromSecret(t, djContainer, "sref")
@@ -193,6 +240,7 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	expectTtlSecondsAfterFinished(t, rj, ptr.To(int32(360)))
 
 	// env vars
+	expectEnvVar(t, rjContainer, "LOG_FORMAT", "json")
 	expectEnvFromSecret(t, rjContainer, "sref")
 	// volumes
 	expectVolumeMounts(t, rjContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})
@@ -232,7 +280,8 @@ func TestNewJob_WithoutSettings(t *testing.T) {
 	expectImage(t, djContainer, "renovate:dev")
 	expectTtlSecondsAfterFinished(t, dj, nil)
 
-	// no env vars
+	// env vars - only defaults, no optional ones
+	expectEnvVar(t, djContainer, "LOG_FORMAT", "json")
 	for _, env := range djContainer.Env {
 		if env.Name == "RENOVATE_AUTODISCOVER_FILTER" {
 			t.Errorf("did not expect RENOVATE_AUTODISCOVER_FILTER env var")
@@ -269,7 +318,8 @@ func TestNewJob_WithoutSettings(t *testing.T) {
 	expectImage(t, rjContainer, "renovate:dev")
 	expectTtlSecondsAfterFinished(t, rj, nil)
 
-	// no env vars
+	// env vars - only defaults
+	expectEnvVar(t, rjContainer, "LOG_FORMAT", "json")
 	if len(rjContainer.EnvFrom) != 0 {
 		t.Errorf("expected no EnvFrom, got %+v", rjContainer.EnvFrom)
 	}

--- a/src/metricStore/metrics.go
+++ b/src/metricStore/metrics.go
@@ -12,10 +12,26 @@ var (
 			Help: "Total number of executed Renovate projects",
 		},
 		[]string{"renovate-namespace", "renovate-job", "project", "status"})
+
+	runFailed = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_run_failed",
+			Help: "Whether the last Renovate run for this project failed (1=failed, 0=success)",
+		},
+		[]string{"renovate-namespace", "renovate-job", "project"})
+
+	dependencyIssues = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_dependency_issues",
+			Help: "Whether the last Renovate run had WARN/ERROR log entries (1=issues found, 0=clean)",
+		},
+		[]string{"renovate-namespace", "renovate-job", "project"})
 )
 
 func Register(registry ctrlmetrics.RegistererGatherer) {
 	registry.MustRegister(projectRuns)
+	registry.MustRegister(runFailed)
+	registry.MustRegister(dependencyIssues)
 }
 
 func CaptureRenovateProjectExecution(namespace, job, project, status string) {
@@ -25,4 +41,31 @@ func CaptureRenovateProjectExecution(namespace, job, project, status string) {
 		project,
 		status,
 	).Inc()
+}
+
+// SetRunFailed sets the run_failed gauge for a project
+func SetRunFailed(namespace, job, project string, failed bool) {
+	value := 0.0
+	if failed {
+		value = 1.0
+	}
+	runFailed.WithLabelValues(namespace, job, project).Set(value)
+}
+
+// SetDependencyIssues sets the dependency_issues gauge for a project
+func SetDependencyIssues(namespace, job, project string, hasIssues bool) {
+	value := 0.0
+	if hasIssues {
+		value = 1.0
+	}
+	dependencyIssues.WithLabelValues(namespace, job, project).Set(value)
+}
+
+// DeleteProjectMetrics removes all metrics for a project that was removed from discovery
+func DeleteProjectMetrics(namespace, job, project string) {
+	runFailed.DeleteLabelValues(namespace, job, project)
+	dependencyIssues.DeleteLabelValues(namespace, job, project)
+	// Note: projectRuns counter has an additional "status" label, so we delete both possible values
+	projectRuns.DeleteLabelValues(namespace, job, project, "completed")
+	projectRuns.DeleteLabelValues(namespace, job, project, "failed")
 }

--- a/src/metricStore/metrics_test.go
+++ b/src/metricStore/metrics_test.go
@@ -1,0 +1,142 @@
+package metricStore
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSetRunFailed(t *testing.T) {
+	tests := []struct {
+		name     string
+		failed   bool
+		expected float64
+	}{
+		{
+			name:     "set to failed",
+			failed:   true,
+			expected: 1.0,
+		},
+		{
+			name:     "set to success",
+			failed:   false,
+			expected: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetRunFailed("test-ns", "test-job", "test-project", tt.failed)
+
+			value := testutil.ToFloat64(runFailed.WithLabelValues("test-ns", "test-job", "test-project"))
+			if value != tt.expected {
+				t.Errorf("SetRunFailed() = %v, want %v", value, tt.expected)
+			}
+
+			// Cleanup
+			runFailed.DeleteLabelValues("test-ns", "test-job", "test-project")
+		})
+	}
+}
+
+func TestSetDependencyIssues(t *testing.T) {
+	tests := []struct {
+		name      string
+		hasIssues bool
+		expected  float64
+	}{
+		{
+			name:      "has issues",
+			hasIssues: true,
+			expected:  1.0,
+		},
+		{
+			name:      "no issues",
+			hasIssues: false,
+			expected:  0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetDependencyIssues("test-ns", "test-job", "test-project", tt.hasIssues)
+
+			value := testutil.ToFloat64(dependencyIssues.WithLabelValues("test-ns", "test-job", "test-project"))
+			if value != tt.expected {
+				t.Errorf("SetDependencyIssues() = %v, want %v", value, tt.expected)
+			}
+
+			// Cleanup
+			dependencyIssues.DeleteLabelValues("test-ns", "test-job", "test-project")
+		})
+	}
+}
+
+func TestCaptureRenovateProjectExecution(t *testing.T) {
+	// Capture a completed execution
+	CaptureRenovateProjectExecution("test-ns", "test-job", "test-project", "completed")
+
+	value := testutil.ToFloat64(projectRuns.WithLabelValues("test-ns", "test-job", "test-project", "completed"))
+	if value != 1.0 {
+		t.Errorf("CaptureRenovateProjectExecution() = %v, want 1.0", value)
+	}
+
+	// Capture another one - counter should increment
+	CaptureRenovateProjectExecution("test-ns", "test-job", "test-project", "completed")
+
+	value = testutil.ToFloat64(projectRuns.WithLabelValues("test-ns", "test-job", "test-project", "completed"))
+	if value != 2.0 {
+		t.Errorf("CaptureRenovateProjectExecution() after second call = %v, want 2.0", value)
+	}
+
+	// Cleanup
+	projectRuns.DeleteLabelValues("test-ns", "test-job", "test-project", "completed")
+}
+
+func TestDeleteProjectMetrics(t *testing.T) {
+	// Use unique labels to avoid interference with other tests
+	ns, job, proj := "delete-test-ns", "delete-test-job", "delete-test-project"
+
+	// Setup: create metrics for a project
+	SetRunFailed(ns, job, proj, true)
+	SetDependencyIssues(ns, job, proj, true)
+	CaptureRenovateProjectExecution(ns, job, proj, "completed")
+	CaptureRenovateProjectExecution(ns, job, proj, "failed")
+
+	// Verify metrics exist
+	if testutil.ToFloat64(runFailed.WithLabelValues(ns, job, proj)) != 1.0 {
+		t.Error("runFailed metric should exist before deletion")
+	}
+	if testutil.ToFloat64(dependencyIssues.WithLabelValues(ns, job, proj)) != 1.0 {
+		t.Error("dependencyIssues metric should exist before deletion")
+	}
+	if testutil.ToFloat64(projectRuns.WithLabelValues(ns, job, proj, "completed")) != 1.0 {
+		t.Error("projectRuns completed metric should exist before deletion")
+	}
+	if testutil.ToFloat64(projectRuns.WithLabelValues(ns, job, proj, "failed")) != 1.0 {
+		t.Error("projectRuns failed metric should exist before deletion")
+	}
+
+	// Count metrics before deletion
+	runFailedCountBefore := testutil.CollectAndCount(runFailed)
+	dependencyIssuesCountBefore := testutil.CollectAndCount(dependencyIssues)
+	projectRunsCountBefore := testutil.CollectAndCount(projectRuns)
+
+	// Delete metrics
+	DeleteProjectMetrics(ns, job, proj)
+
+	// Count metrics after deletion - should be fewer
+	runFailedCountAfter := testutil.CollectAndCount(runFailed)
+	dependencyIssuesCountAfter := testutil.CollectAndCount(dependencyIssues)
+	projectRunsCountAfter := testutil.CollectAndCount(projectRuns)
+
+	if runFailedCountAfter >= runFailedCountBefore {
+		t.Errorf("runFailed metric count should decrease after deletion: before=%d, after=%d", runFailedCountBefore, runFailedCountAfter)
+	}
+	if dependencyIssuesCountAfter >= dependencyIssuesCountBefore {
+		t.Errorf("dependencyIssues metric count should decrease after deletion: before=%d, after=%d", dependencyIssuesCountBefore, dependencyIssuesCountAfter)
+	}
+	if projectRunsCountAfter >= projectRunsCountBefore {
+		t.Errorf("projectRuns metric count should decrease after deletion: before=%d, after=%d", projectRunsCountBefore, projectRunsCountAfter)
+	}
+}


### PR DESCRIPTION
- Introduced new Prometheus metrics: `renovate_operator_run_failed` and `renovate_operator_dependency_issues` to track job failures and dependency issues.
- Updated Grafana dashboard configuration to visualize these metrics.
- Enhanced Renovate log parsing to detect dependency issues and update metrics accordingly.
- Added tests to ensure correct log format handling and metric updates.

Kind of related to: #35 