### PR TITLE
feat: Label-based Job Management with Generation Tracking

### DIFF
--- a/src/internal/crdManager/renovateJobManager.go
+++ b/src/internal/crdManager/renovateJobManager.go
@@ -263,7 +263,11 @@ func (r *renovateJobManager) GetLogsForProject(ctx context.Context, job Renovate
 
 	executorJobName := utils.ExecutorJobName(renovateJob, project)
 
-	executorJob, err := GetJob(ctx, r.client, executorJobName, job.Namespace)
+	executorJob, err := GetJobByLabel(ctx, r.client, JobSelector{
+		JobName:   executorJobName,
+		JobType:   ExecutorJobType,
+		Namespace: job.Namespace,
+	})
 	if err != nil {
 		return "failed to get job", err
 	}

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	batchv1 "k8s.io/api/batch/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -95,17 +94,6 @@ func (m *mockRenovateJobManager) IsWebhookTokenValid(ctx context.Context, job cr
 }
 func (r *mockRenovateJobManager) IsWebhookSignatureValid(ctx context.Context, job crdmanager.RenovateJobIdentifier, signature string, body []byte) (bool, error) {
 	return true, nil
-}
-func (m *mockRenovateJobManager) GetJob(jobId crdmanager.RenovateJobIdentifier, projectName string) (*batchv1.Job, error) {
-	return nil, nil
-}
-
-func (m *mockRenovateJobManager) CreateJob(job *batchv1.Job) (*batchv1.Job, error) {
-	return nil, nil
-}
-
-func (m *mockRenovateJobManager) DeleteJob(jobId crdmanager.RenovateJobIdentifier, projectName string) error {
-	return nil
 }
 
 // Mock DiscoveryAgent

--- a/src/webhook/mock_test.go
+++ b/src/webhook/mock_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	api "renovate-operator/api/v1alpha1"
 	crdmanager "renovate-operator/internal/crdManager"
-
-	batchv1 "k8s.io/api/batch/v1"
 )
 
 // Mock RenovateJobManager for webhook integration tests
@@ -66,7 +64,4 @@ func (m *mockWebhookManager) GetProjectsByStatus(ctx context.Context, job crdman
 }
 func (m *mockWebhookManager) UpdateProjectStatusBatched(ctx context.Context, fn func(p api.ProjectStatus) bool, jobId crdmanager.RenovateJobIdentifier, status api.RenovateProjectStatus) error {
 	return nil
-}
-func (m *mockWebhookManager) GetJob(jobId crdmanager.RenovateJobIdentifier, projectName string) (*batchv1.Job, error) {
-	return nil, nil
 }


### PR DESCRIPTION
Refactors job management from name-based to label-based lookups with generation tracking, eliminating race conditions and enabling zero-downtime updates.

- New API: `GetJobByLabel()` and `CreateJobWithGeneration()` replace name-based lookups
- Generation labels: Unix timestamp-based versioning tracks job generations
- Async cleanup: Old generations deleted in background after new job creation
- Job naming: Use GenerateName for Kubernetes-generated unique names
- Standard labels: JOB_LABEL_TYPE, JOB_LABEL_NAME, JOB_GENERATION on all jobs
