### PR TITLE
fix: add dynamic buffer size for log parsing

### DIFF
--- a/src/internal/parser/logParser.go
+++ b/src/internal/parser/logParser.go
@@ -42,6 +42,7 @@ func ParseRenovateLogs(logs string) *LogParseResult {
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(logs))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024) // 64KB initial, 1MB max
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {

--- a/src/internal/parser/logParser_test.go
+++ b/src/internal/parser/logParser_test.go
@@ -151,7 +151,7 @@ func TestParseRenovateLogsConfigDetection(t *testing.T) {
 		{
 			name:          "real world: onboarded false with scanner-breaking stats line",
 			logs:          `{"level":30,"msg":"Repository started"}` + "\n" + `{"level":30,"msg":"stats","stats":{"data":"` + strings.Repeat("x", 70000) + `"}}` + "\n" + `{"level":30,"cloned":true,"onboarded":false,"msg":"Repository finished"}`,
-			wantHasConfig: nil,
+			wantHasConfig: boolPtr(false),
 		},
 	}
 


### PR DESCRIPTION
Issue #117

Allow Buffer to grow to 1MB to read larger log lines. 