### PR TITLE
feat(chart): add interval option to ServiceMonitor

### DIFF
--- a/charts/renovate-operator/templates/serviceMonitor.yaml
+++ b/charts/renovate-operator/templates/serviceMonitor.yaml
@@ -8,6 +8,9 @@ spec:
   endpoints:
   - path: /metrics
     port: metrics
+    {{- with .Values.metrics.serviceMonitor.interval }}
+    interval: {{ . | quote }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -130,6 +130,8 @@ metrics:
   serviceMonitor:
     # -- whether to create a ServiceMonitor for the operator metrics
     enabled: false
+    # -- scrape interval for the ServiceMonitor, defaults to Prometheus global scrape interval
+    interval: ~
   dashboard:
     # -- whether to create a Grafana dashboard for the operator metrics
     enabled: false


### PR DESCRIPTION
## Summary
- Adds a `metrics.serviceMonitor.interval` value to allow configuring the scrape interval on the ServiceMonitor endpoint
- Defaults to `nil`, which inherits the Prometheus global scrape interval
- Value is quoted to ensure proper string rendering

## Changes
- `charts/renovate-operator/values.yaml`: added `interval: ~` under `metrics.serviceMonitor`
- `charts/renovate-operator/templates/serviceMonitor.yaml`: conditionally renders `interval` field when set

## Usage
```yaml
metrics:
  enabled: true
  serviceMonitor:
    enabled: true
    interval: 120s  # optional, defaults to Prometheus global
```