### PR TITLE
Check for `approve-all-pending-prs` checkbox

### DIFF
--- a/src/webhook/renovateCheckbox.go
+++ b/src/webhook/renovateCheckbox.go
@@ -13,8 +13,11 @@ func isRenovateContent(description string) bool {
 		return true
 	}
 
-	// Dependency Dashboards created by Renovate contain this specific comment
+	// Dependency Dashboards created by Renovate contain these specific comments
 	if strings.Contains(description, "<!-- rebase-all-open-prs -->**Click on this checkbox to rebase all") {
+		return true
+	}
+	if strings.Contains(description, "<!-- approve-all-pending-prs -->\U0001f510 **Create all pending approval PRs at once** \U0001f510") {
 		return true
 	}
 	return false

--- a/src/webhook/renovateCheckbox_test.go
+++ b/src/webhook/renovateCheckbox_test.go
@@ -29,6 +29,11 @@ func TestRenovateCheckbox(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "valid dependency dashboard with approve-all-pending-prs checkbox",
+			current:  "Some update\n- [x] <!-- approve-all-pending-prs -->🔐 **Create all pending approval PRs at once** 🔐",
+			expected: true,
+		},
+		{
 			name:     "empty description",
 			current:  "",
 			expected: false,


### PR DESCRIPTION
When checking if a webhook event came from a Renovate Dashboard, the operator currently checks for the string `<!-- rebase-all-open-prs -->**Click on this checkbox to rebase all`. 

However, this string is not always present, particularly if you have Renovate configured with `dependencyDashboardApproval: true` so that PRs only open when you explicitly check them:

<img width="519" height="130" alt="image" src="https://github.com/user-attachments/assets/a5d2dc41-c6ee-414f-81ae-7a55eee026e5" />

---

This PR takes the naive approach of adding an additional matching string for `<!-- approve-all-pending-prs -->🔐 **Create all pending approval PRs at once** 🔐`, which always seems to be present in our environment for Dashboards which have at least one dependency update available.