### PR TITLE
feat: support custom labels and annotations on pod template

### DIFF
--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -20,6 +20,13 @@ spec:
     metadata:
       labels:
         app: {{ include "renovate-operator.fullname" . }}
+        {{- with .Values.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.deployment.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "renovate-operator.serviceAccountName" . }}
       {{- with .Values.securityContext.pod }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -18,6 +18,10 @@ deployment:
   annotations: {}
   # -- additional labels for the operator deployment
   labels: {}
+  # -- additional labels for the operator pods
+  podLabels: {}
+  # -- additional annotations for the operator pods
+  podAnnotations: {}
 
 config:
   # -- default backoff limit for renovate jobs


### PR DESCRIPTION
## Summary
- Adds `deployment.podLabels` and `deployment.podAnnotations` values to configure labels and annotations on the operator pod template

Closes #132