### PR TITLE
fix: crd updates will now be installed using helm upgrade

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,9 +172,16 @@ jobs:
             go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
 
             echo "Generating CRDs"
-            controller-gen crd paths=./src/... output:crd:dir=charts/renovate-operator/crds
+            controller-gen crd paths=./src/... output:crd:dir=charts/renovate-operator/crd
 
-            git add charts/renovate-operator/crds
+            echo "Adding Helm resource-policy annotation to CRDs"
+            for f in charts/renovate-operator/crd/*.mogenius.com_*.yaml; do
+              if ! grep -q "helm.sh/resource-policy" "$f"; then
+                sed -i 's/  annotations:/  annotations:\n    helm.sh\/resource-policy: keep/' "$f"
+              fi
+            done
+
+            git add charts/renovate-operator/crd/*.mogenius.com_*.yaml
 
             echo "Packaging Helm chart"
             helm package -d /tmp/ ./charts/renovate-operator

--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    helm.sh/resource-policy: keep
   name: renovatejobs.renovate-operator.mogenius.com
 spec:
   group: renovate-operator.mogenius.com

--- a/charts/renovate-operator/templates/crd-hook.yaml
+++ b/charts/renovate-operator/templates/crd-hook.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "renovate-operator.fullname" . }}-crd-hook
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "renovate-operator.fullname" . }}-crd-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "renovate-operator.fullname" . }}-crd-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "renovate-operator.fullname" . }}-crd-hook
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "renovate-operator.fullname" . }}-crd-hook
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "renovate-operator.fullname" . }}-crd
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "-5"
+data:
+  renovatejob.yaml: |
+{{ .Files.Get "crd/renovate-operator.mogenius.com_renovatejobs.yaml" | indent 4 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "renovate-operator.fullname" . }}-crd-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      serviceAccountName: {{ include "renovate-operator.fullname" . }}-crd-hook
+      restartPolicy: OnFailure
+      containers:
+        - name: kubectl
+          image: registry.k8s.io/kubectl:v1.35.0
+          command:
+            - kubectl
+            - apply
+            - -f
+            - /crd/renovatejob.yaml
+          volumeMounts:
+            - name: crd
+              mountPath: /crd
+      volumes:
+        - name: crd
+          configMap:
+            name: {{ include "renovate-operator.fullname" . }}-crd


### PR DESCRIPTION
addresses issue-134

hasRenovateConfig was added to the CRD schema in v2.4.0, but Helm never updates CRDs placed in the crds/ directory during helm upgrade — they are only applied on the very first install. Anyone upgrading from a pre-2.4.0 version would keep the old schema and the API server would prune + warn about the unknown field on every status update.

Fix — two-part change to [templates/renovate-operator.mogenius.com_renovatejobs.yaml](vscode-webview://12d98iame3n09difmq8e78qhs8occaukv8s2d6s66b0k9ncj1sar/charts/renovate-operator/templates/renovate-operator.mogenius.com_renovatejobs.yaml):

Moved the CRD from crds/ → templates/. Helm now applies it on both helm install and helm upgrade, keeping the schema in sync with the chart version.

Added helm.sh/resource-policy: keep annotation. This prevents helm uninstall from deleting the CRD (and all RenovateJob custom resources with it) — the standard safety net for operator CRDs.