### PR TITLE
fix(chart): move github repo url as first url

### DIFF
--- a/charts/renovate-operator/Chart.yaml
+++ b/charts/renovate-operator/Chart.yaml
@@ -7,9 +7,9 @@ appVersion: 2.8.1
 home: https://mogenius.com
 icon: https://app.mogenius.com/assets/logos/logo-mogenius-signet-neg.svg
 sources:
+  - https://github.com/mogenius/renovate-operator
   - https://helm.mogenius.com/public
   - oci://ghcr.io/mogenius/helm-charts/renovate-operator
-  - https://github.com/mogenius/renovate-operator
 maintainers:
   - email: ruediger@mogenius.com
     name: Rüdiger Küpper @mogenius


### PR DESCRIPTION
This allows renovate to properly detect the source repo. Those sources will be checked in defined order.

https://github.com/renovatebot/renovate/blob/8c1899d0c15793116a4956398f3965c0a658d3cf/lib/modules/datasource/docker/common.ts#L351-L379