### PR TITLE
feat: set DNSPolicy in JobSpec

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -956,6 +956,9 @@ spec:
               discoveryFilter:
                 description: Filter to select which projects to process
                 type: string
+              dnsPolicy:
+                description: DNS Policy for the renovate pods
+                type: string
               extraEnv:
                 description: Additional environment variables to set in the renovate
                   container

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -51,6 +51,8 @@ type RenovateJobSpec struct {
 	ExtraVolumeMounts []corev1.VolumeMount `json:"extraVolumeMounts,omitempty"`
 	// Image pull secrets for the renovate pods
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	// DNS Policy for the renovate pods
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
 }
 
 // configuration regarding serviceaccounts for the resulting pod

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -92,6 +92,7 @@ func newDiscoveryJob(job *api.RenovateJob) *batchv1.Job {
 					SecurityContext:              getPodSecurityContext(job.Spec),
 					AutomountServiceAccountToken: getAutoMountServiceAccountToken(job.Spec),
 					RestartPolicy:                v1.RestartPolicyOnFailure,
+					DNSPolicy:                    getDNSPolicy(job.Spec),
 					NodeSelector:                 job.Spec.NodeSelector,
 					Affinity:                     job.Spec.Affinity,
 					Tolerations:                  job.Spec.Tolerations,
@@ -178,6 +179,7 @@ func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
 					SecurityContext:              getPodSecurityContext(job.Spec),
 					AutomountServiceAccountToken: getAutoMountServiceAccountToken(job.Spec),
 					RestartPolicy:                v1.RestartPolicyOnFailure,
+					DNSPolicy:                    getDNSPolicy(job.Spec),
 					NodeSelector:                 job.Spec.NodeSelector,
 					Affinity:                     job.Spec.Affinity,
 					Tolerations:                  job.Spec.Tolerations,
@@ -304,6 +306,14 @@ func getDefaultImagePullSecrets() []v1.LocalObjectReference {
 		return nil
 	}
 	return secrets
+}
+
+func getDNSPolicy(spec api.RenovateJobSpec) v1.DNSPolicy {
+	if spec.DNSPolicy != "" {
+		return spec.DNSPolicy
+	}
+
+	return v1.DNSClusterFirst
 }
 
 // mergeEnvVars combines extraEnv and predefinedEnv, giving priority to extraEnv

--- a/src/internal/renovate/jobDefinitions_test.go
+++ b/src/internal/renovate/jobDefinitions_test.go
@@ -64,6 +64,23 @@ func TestSecurityContextHelpers(t *testing.T) {
 		t.Fatalf("expected empty service account name, got %s", name)
 	}
 }
+
+func TestGetDNSPolicy(t *testing.T) {
+	t.Run("returns DNSClusterFirst when DNSPolicy is empty", func(t *testing.T) {
+		spec := api.RenovateJobSpec{}
+		if got := getDNSPolicy(spec); got != v1.DNSClusterFirst {
+			t.Fatalf("expected %s, got %s", v1.DNSClusterFirst, got)
+		}
+	})
+
+	t.Run("returns spec DNSPolicy when set", func(t *testing.T) {
+		spec := api.RenovateJobSpec{DNSPolicy: v1.DNSClusterFirst}
+		if got := getDNSPolicy(spec); got != v1.DNSClusterFirst {
+			t.Fatalf("expected %s, got %s", v1.DNSClusterFirst, got)
+		}
+	})
+}
+
 func TestNewJobs_WithSettings(t *testing.T) {
 	job := &api.RenovateJob{
 		ObjectMeta: metav1.ObjectMeta{Name: "rj", Namespace: "ns"},


### PR DESCRIPTION
There are scenarios where the default DNSPolicy of "ClusterFirst" won't work.  In my case, I need renovate to use the "Default" DNSPolicy to bypass CoreDNS and the rewrites I'm doing there to MitM docker.io for Docker-in-Docker workloads.

This maintains the default "ClusterFirst" behavior, but adds the ability to specify an alternate DNSPolicy if required.
