### PR TITLE
fix: additional valid issue content

### DIFF
--- a/src/webhook/renovateCheckbox.go
+++ b/src/webhook/renovateCheckbox.go
@@ -15,8 +15,12 @@ func isRenovateContent(description string) bool {
 		"<!-- rebase-branch=",
 		"<!-- approve-all-pending-prs -->",
 		"<!-- approvePr-branch=",
-		"<!-- approve-branch",
+		"<!-- approve-branch=",
+		"<!-- recreate-branch=",
+		"<!-- unschedule-branch=",
 		"<!-- create-config-migration-pr -->",
+		"<!-- create-all-awaiting-schedule-prs -->",
+		"<!-- manual job -->",
 	}
 
 	for _, pattern := range patternList {

--- a/src/webhook/renovateCheckbox_test.go
+++ b/src/webhook/renovateCheckbox_test.go
@@ -72,6 +72,28 @@ func TestRenovateCheckbox(t *testing.T) {
  								- [x] <!-- rebase-branch=renovate/python-reqs -->[chore: update python reqs](../pull/255)`,
 			expected: true,
 		},
+		{
+			name: "manual job",
+			current: `\n- [x] <!-- manual job -->Check this box to trigger a request for Renovate to run again on this repository\n`,
+			expected: true,
+		},
+		{
+			name: "unschedule-branch checked",
+			current: `\n- [x] <!-- unschedule-branch=renovate/lock-file-maintenance -->chore(deps): lock file maintenance\n`,
+			expected: true,
+		},
+		{
+			name: "create-all-awaiting-schedule-prs checked",
+			current: `\n- [x] <!-- create-all-awaiting-schedule-prs -->🔐 **Create all awaiting schedule PRs at once** 🔐\n`,
+			expected: true,
+		},
+		{
+			name: "recreate-branch checked",
+			current: `## PR Closed (Blocked)
+						The following updates are blocked by an existing closed PR. To recreate the PR, click on a checkbox below.
+						- [x] <!-- recreate-branch=renovate/harbor-1-18-x -->[fix(deps): update helm release harbor to v1.18.2](pulls/98)`,
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`<!-- manual job -->` is used by official bot to trigger a job without approving something. It's useful when no pending updates are exits.

```md
This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more.

## Awaiting Schedule

The following updates are awaiting their schedule. To get an update now, click on a checkbox below.

 - [ ] <!-- unschedule-branch=renovate/visualon-builder -->chore(deps): update ghcr.visualon.de/visualon/builder docker tag to v14.2.56


---

- [ ] <!-- manual job -->Check this box to trigger a request for Renovate to run again on this repository

```