### PR TITLE
feat: Add priority scheduling for Webhook/UI runs

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -3891,6 +3891,9 @@ spec:
                       type: string
                     name:
                       type: string
+                    priority:
+                      format: int32
+                      type: integer
                     renovateResultStatus:
                       type: string
                     status:

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -99,6 +99,7 @@ type ProjectStatus struct {
 	LastRun              metav1.Time           `json:"lastRun"`
 	Duration             *string               `json:"duration,omitempty"`
 	Status               RenovateProjectStatus `json:"status"`
+	Priority             int32                 `json:"priority,omitempty"`
 	RenovateResultStatus *string               `json:"renovateResultStatus,omitempty"`
 }
 

--- a/src/internal/crdManager/renovateJobManager.go
+++ b/src/internal/crdManager/renovateJobManager.go
@@ -70,6 +70,7 @@ type RenovateProjectStatus struct {
 	Name                 string                    `json:"name"`
 	Status               api.RenovateProjectStatus `json:"status"`
 	LastRun              time.Time                 `json:"lastRun,omitempty"`
+	Priority             int32                     `json:"priority,omitempty"`
 	RenovateResultStatus *string                   `json:"renovateResultStatus,omitempty"`
 	Duration             *string                   `json:"duration,omitempty"`
 }
@@ -116,6 +117,7 @@ func (r *renovateJobManager) GetProjectsByStatus(ctx context.Context, job Renova
 				Name:                 project.Name,
 				Status:               project.Status,
 				LastRun:              project.LastRun.Time,
+				Priority:             project.Priority,
 				RenovateResultStatus: project.RenovateResultStatus,
 				Duration:             project.Duration,
 			})
@@ -137,6 +139,7 @@ func (r *renovateJobManager) GetProjectsForRenovateJob(ctx context.Context, job 
 			Name:                 project.Name,
 			Status:               project.Status,
 			LastRun:              project.LastRun.Time,
+			Priority:             project.Priority,
 			RenovateResultStatus: project.RenovateResultStatus,
 			Duration:             project.Duration,
 		})
@@ -194,8 +197,9 @@ func (r *renovateJobManager) UpdateProjectStatus(ctx context.Context, project st
 		}
 		if index == -1 {
 			projectStatus := &api.ProjectStatus{
-				Name:   project,
-				Status: status.Status,
+				Name:     project,
+				Status:   status.Status,
+				Priority: status.Priority,
 			}
 			renovateJob.Status.Projects = append(renovateJob.Status.Projects, *projectStatus)
 		} else {

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -8,6 +8,7 @@ import (
 	"renovate-operator/config"
 	"renovate-operator/health"
 	"renovate-operator/metricStore"
+	"sort"
 	"sync"
 	"time"
 
@@ -165,118 +166,114 @@ func (e *renovateExecutor) reconcileProjects(ctx context.Context, renovateJob *a
 		}
 	}
 
+	jobId := crdManager.RenovateJobIdentifier{
+		Name:      renovateJob.Name,
+		Namespace: renovateJob.Namespace,
+	}
+
+	// Pass 1: process running projects to free slots
 	for i := range renovateJob.Status.Projects {
 		project := &renovateJob.Status.Projects[i]
-
-		jobId := crdManager.RenovateJobIdentifier{
-			Name:      renovateJob.Name,
-			Namespace: renovateJob.Namespace,
+		if project.Status != api.JobStatusRunning {
+			continue
 		}
 
-		switch project.Status {
-		//Job is completed -> do nothing
-		case api.JobStatusCompleted:
+		job, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
+			JobName:   utils.ExecutorJobName(renovateJob, project.Name),
+			JobType:   crdManager.ExecutorJobType,
+			Namespace: renovateJob.Namespace,
+		})
 
-		// Job is failed -> do nothing
-		case api.JobStatusFailed:
+		var newStatus api.RenovateProjectStatus
+		var durationStr string
+		if err != nil {
+			if errors.IsNotFound(err) {
+				newStatus = api.JobStatusFailed
+			} else {
+				return err
+			}
+		} else {
+			newStatus, durationStr, err = getJobStatus(job)
+			if err != nil {
+				return err
+			}
+		}
 
-		// Job is running -> verify thats true
-		case api.JobStatusRunning:
-			job, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
+		if newStatus != api.JobStatusRunning {
+			newProjectStatus := &types.RenovateStatusUpdate{
+				Status:   newStatus,
+				Duration: &durationStr,
+			}
+			hasIssues := false
+			if job != nil {
+				cp := clientProvider.StaticClientProvider()
+				if clientset, err := cp.K8sClientSet(); err == nil {
+					if logs, err := crdManager.GetLastJobLog(ctx, clientset, job); err == nil {
+						parseResult := parser.ParseRenovateLogs(logs)
+						hasIssues = parseResult.HasIssues
+						newProjectStatus.RenovateResultStatus = parseResult.RenovateResultStatus
+					} else {
+						e.logger.Error(err, "failed to get logs for metrics parsing", "project", project.Name)
+					}
+				} else {
+					e.logger.Error(err, "failed to create Kubernetes clientset for metrics parsing", "project", project.Name)
+				}
+			}
+
+			metricStore.SetRunFailed(renovateJob.Namespace, renovateJob.Name, project.Name, newStatus == api.JobStatusFailed)
+			metricStore.SetDependencyIssues(renovateJob.Namespace, renovateJob.Name, project.Name, hasIssues)
+			metricStore.CaptureRenovateProjectExecution(renovateJob.Namespace, renovateJob.Name, project.Name, string(newStatus))
+
+			err = e.manager.UpdateProjectStatus(ctx, project.Name, jobId, newProjectStatus)
+			runningProjects--
+			if err != nil {
+				return err
+			}
+
+			deleteSuccessfulJobs := config.GetValue("DELETE_SUCCESSFUL_JOBS")
+			if newStatus == api.JobStatusCompleted && deleteSuccessfulJobs == "true" && job != nil {
+				err = crdManager.DeleteJob(ctx, e.client, job)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Pass 2: sort by priority descending, then start scheduled projects in priority order
+	sort.SliceStable(renovateJob.Status.Projects, func(i, j int) bool {
+		return renovateJob.Status.Projects[i].Priority > renovateJob.Status.Projects[j].Priority
+	})
+
+	for i := range renovateJob.Status.Projects {
+		project := &renovateJob.Status.Projects[i]
+		if project.Status != api.JobStatusScheduled {
+			continue
+		}
+
+		if runningProjects < int(renovateJob.Spec.Parallelism) {
+			job := newRenovateJob(renovateJob, project.Name)
+			if err := controllerutil.SetControllerReference(renovateJob, job, e.scheme); err != nil {
+				return fmt.Errorf("failed to set controller reference: %w", err)
+			}
+
+			err := crdManager.CreateJobWithGeneration(ctx, e.client, job, crdManager.JobSelector{
 				JobName:   utils.ExecutorJobName(renovateJob, project.Name),
 				JobType:   crdManager.ExecutorJobType,
 				Namespace: renovateJob.Namespace,
 			})
-
-			var newStatus api.RenovateProjectStatus
-			var durationStr string
 			if err != nil {
-				if errors.IsNotFound(err) {
-					newStatus = api.JobStatusFailed
-				} else {
-					return err
-				}
-			} else {
-				newStatus, durationStr, err = getJobStatus(job)
-				if err != nil {
-					return err
-				}
+				return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)
+			}
+			runningProjects++
+
+			err = e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
+				Status: api.JobStatusRunning,
+			})
+			if err != nil {
+				return err
 			}
 
-			if newStatus != api.JobStatusRunning {
-				// Parse logs before potential job deletion to capture dependency issues
-				newProjectStatus := &types.RenovateStatusUpdate{
-					Status:   newStatus,
-					Duration: &durationStr, // Add this field if RenovateStatusUpdate supports it
-				}
-				hasIssues := false
-				if job != nil {
-					cp := clientProvider.StaticClientProvider()
-					if clientset, err := cp.K8sClientSet(); err == nil {
-						if logs, err := crdManager.GetLastJobLog(ctx, clientset, job); err == nil {
-							parseResult := parser.ParseRenovateLogs(logs)
-							hasIssues = parseResult.HasIssues
-
-							newProjectStatus.RenovateResultStatus = parseResult.RenovateResultStatus
-						} else {
-							e.logger.Error(err, "failed to get logs for metrics parsing", "project", project.Name)
-						}
-					} else {
-						e.logger.Error(err, "failed to create Kubernetes clientset for metrics parsing", "project", project.Name)
-					}
-				}
-
-				// Update metrics
-				metricStore.SetRunFailed(renovateJob.Namespace, renovateJob.Name, project.Name, newStatus == api.JobStatusFailed)
-				metricStore.SetDependencyIssues(renovateJob.Namespace, renovateJob.Name, project.Name, hasIssues)
-				metricStore.CaptureRenovateProjectExecution(renovateJob.Namespace, renovateJob.Name, project.Name, string(newStatus))
-
-				err = e.manager.UpdateProjectStatus(ctx, project.Name, jobId, newProjectStatus)
-				// one project less is currently running
-				runningProjects--
-				if err != nil {
-					return err
-				}
-
-				// if DELETE_SUCCESSFUL_JOBS is set -> delete the job
-				deleteSuccessfulJobs := config.GetValue("DELETE_SUCCESSFUL_JOBS")
-				if newStatus == api.JobStatusCompleted && deleteSuccessfulJobs == "true" && job != nil {
-					err = crdManager.DeleteJob(ctx, e.client, job)
-					if err != nil {
-						return err
-					}
-				}
-			}
-
-		// Job is scheduled -> execute (if possible)
-		case api.JobStatusScheduled:
-			// are there already enough projects running?
-			if runningProjects < int(renovateJob.Spec.Parallelism) {
-				// Create a new job for this project
-				job := newRenovateJob(renovateJob, project.Name)
-				if err := controllerutil.SetControllerReference(renovateJob, job, e.scheme); err != nil {
-					return fmt.Errorf("failed to set controller reference: %w", err)
-				}
-
-				// recreate the job
-				err := crdManager.CreateJobWithGeneration(ctx, e.client, job, crdManager.JobSelector{
-					JobName:   utils.ExecutorJobName(renovateJob, project.Name),
-					JobType:   crdManager.ExecutorJobType,
-					Namespace: renovateJob.Namespace,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)
-				}
-				runningProjects++
-
-				jobId := crdManager.RenovateJobIdentifier{Name: renovateJob.Name, Namespace: renovateJob.Namespace}
-				err = e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
-					Status: api.JobStatusRunning,
-				})
-				if err != nil {
-					return err
-				}
-			}
 		}
 	}
 

--- a/src/internal/types/renovateStatusUpdate.go
+++ b/src/internal/types/renovateStatusUpdate.go
@@ -8,6 +8,7 @@ import (
 
 type RenovateStatusUpdate struct {
 	Status               api.RenovateProjectStatus
+	Priority             int32
 	RenovateResultStatus *string
 	LastRun              *v1.Time
 	Duration             *string

--- a/src/internal/utils/projectStatus.go
+++ b/src/internal/utils/projectStatus.go
@@ -27,6 +27,9 @@ func validateProjectStatusScheduled(projectStatus *api.ProjectStatus, desiredSta
 	// cannot schedule a project that is currently running
 	if projectStatus.Status != api.JobStatusRunning {
 		projectStatus.Status = api.JobStatusScheduled
+		if desiredStatus.Priority > projectStatus.Priority {
+			projectStatus.Priority = desiredStatus.Priority
+		}
 	}
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	return projectStatus
@@ -36,6 +39,7 @@ func validateProjectStatusRunning(projectStatus *api.ProjectStatus, desiredStatu
 	// can only set a project to running if it is currently scheduled
 	if projectStatus.Status == api.JobStatusScheduled {
 		projectStatus.Status = api.JobStatusRunning
+		projectStatus.Priority = 0
 	}
 	projectStatus.Duration = nil
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
@@ -46,6 +50,7 @@ func validateProjectStatusCompleted(projectStatus *api.ProjectStatus, desiredSta
 	// can only set a running project to completed
 	if projectStatus.Status == api.JobStatusRunning {
 		projectStatus.Status = api.JobStatusCompleted
+		projectStatus.Priority = 0
 		projectStatus.LastRun = v1.Now()
 	}
 	projectStatus.Duration = desiredStatus.Duration
@@ -56,6 +61,7 @@ func validateProjectStatusFailed(projectStatus *api.ProjectStatus, desiredStatus
 	// can only set a running project to failed
 	if projectStatus.Status == api.JobStatusRunning {
 		projectStatus.Status = api.JobStatusFailed
+		projectStatus.Priority = 0
 		projectStatus.LastRun = v1.Now()
 	}
 	projectStatus.Duration = desiredStatus.Duration

--- a/src/internal/utils/projectStatus_test.go
+++ b/src/internal/utils/projectStatus_test.go
@@ -62,3 +62,57 @@ func TestGetUpdateStatusForProject(t *testing.T) {
 		})
 	}
 }
+
+func TestGetUpdateStatusForProject_Priority(t *testing.T) {
+	t.Run("Schedule with priority=1 sets priority", func(t *testing.T) {
+		proj := &api.ProjectStatus{Name: "p", Status: api.JobStatusCompleted}
+		result := GetUpdateStatusForProject(proj, &types.RenovateStatusUpdate{Status: api.JobStatusScheduled, Priority: 1})
+		if result.Priority != 1 {
+			t.Errorf("expected priority 1, got %d", result.Priority)
+		}
+		if result.Status != api.JobStatusScheduled {
+			t.Errorf("expected status scheduled, got %v", result.Status)
+		}
+	})
+
+	t.Run("Schedule with priority=2 sets priority", func(t *testing.T) {
+		proj := &api.ProjectStatus{Name: "p", Status: api.JobStatusCompleted}
+		result := GetUpdateStatusForProject(proj, &types.RenovateStatusUpdate{Status: api.JobStatusScheduled, Priority: 2})
+		if result.Priority != 2 {
+			t.Errorf("expected priority 2, got %d", result.Priority)
+		}
+	})
+
+	t.Run("Transition to running resets priority to 0", func(t *testing.T) {
+		proj := &api.ProjectStatus{Name: "p", Status: api.JobStatusScheduled, Priority: 2}
+		result := GetUpdateStatusForProject(proj, &types.RenovateStatusUpdate{Status: api.JobStatusRunning})
+		if result.Priority != 0 {
+			t.Errorf("expected priority 0 after running transition, got %d", result.Priority)
+		}
+		if result.Status != api.JobStatusRunning {
+			t.Errorf("expected status running, got %v", result.Status)
+		}
+	})
+
+	t.Run("Re-scheduling with lower priority preserves existing higher priority", func(t *testing.T) {
+		proj := &api.ProjectStatus{Name: "p", Status: api.JobStatusScheduled, Priority: 2}
+		result := GetUpdateStatusForProject(proj, &types.RenovateStatusUpdate{Status: api.JobStatusScheduled, Priority: 0})
+		if result.Priority != 2 {
+			t.Errorf("expected priority to remain 2, got %d", result.Priority)
+		}
+		if result.Status != api.JobStatusScheduled {
+			t.Errorf("expected status to remain scheduled, got %v", result.Status)
+		}
+	})
+
+	t.Run("Cannot schedule a running project, priority unchanged", func(t *testing.T) {
+		proj := &api.ProjectStatus{Name: "p", Status: api.JobStatusRunning, Priority: 1}
+		result := GetUpdateStatusForProject(proj, &types.RenovateStatusUpdate{Status: api.JobStatusScheduled, Priority: 2})
+		if result.Status != api.JobStatusRunning {
+			t.Errorf("expected status to remain running, got %v", result.Status)
+		}
+		if result.Priority != 1 {
+			t.Errorf("expected priority to remain 1, got %d", result.Priority)
+		}
+	})
+}

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -67,6 +67,7 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 				Name:                 p.Name,
 				Status:               p.Status,
 				LastRun:              p.LastRun.Time,
+				Priority:             p.Priority,
 				RenovateResultStatus: p.RenovateResultStatus,
 				Duration:             p.Duration,
 			})
@@ -167,7 +168,8 @@ func (s *Server) runRenovateForProject(w http.ResponseWriter, r *http.Request) {
 			Namespace: params.namespace,
 		},
 		&types.RenovateStatusUpdate{
-			Status: api.JobStatusScheduled,
+			Status:   api.JobStatusScheduled,
+			Priority: 2,
 		},
 	)
 	if err != nil {
@@ -177,7 +179,7 @@ func (s *Server) runRenovateForProject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeSuccess(w, SuccessResult{Message: "Renovate job triggered for project"})
-	s.logger.V(2).Info("Successfully triggered Renovate for project", "project", params.project, "renovateJob", params.name, "namespace", params.namespace)
+	s.logger.V(2).Info("Successfully triggered Renovate for project", "project", params.project, "renovateJob", params.name, "namespace", params.namespace, "priority", 2)
 }
 
 func (s *Server) runDiscoveryForProject(w http.ResponseWriter, r *http.Request) {

--- a/src/webhook/github.go
+++ b/src/webhook/github.go
@@ -57,7 +57,7 @@ func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Process the webhook payload
-	s.logger.Info("received github event", "repository", payload.Repository.FullName, "action", payload.Action)
+	s.logger.Info("received github event", "repository", payload.Repository.FullName, "action", payload.Action, "priority", 1)
 	err = s.manager.UpdateProjectStatus(
 		r.Context(),
 		payload.Repository.FullName,
@@ -66,7 +66,8 @@ func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
 			Namespace: namespace,
 		},
 		&types.RenovateStatusUpdate{
-			Status: api.JobStatusScheduled,
+			Status:   api.JobStatusScheduled,
+			Priority: 1,
 		},
 	)
 	if err != nil {

--- a/src/webhook/gitlab.go
+++ b/src/webhook/gitlab.go
@@ -61,7 +61,7 @@ func (s *Server) gitLabWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Process the webhook payload
-	s.logger.Info("received GitLab event", "repository", payload.Project.PathWithNamespace, "action", payload.ObjectAttributes.Action)
+	s.logger.Info("received GitLab event", "repository", payload.Project.PathWithNamespace, "action", payload.ObjectAttributes.Action, "priority", 1)
 	err = s.manager.UpdateProjectStatus(
 		r.Context(),
 		payload.Project.PathWithNamespace,
@@ -70,7 +70,8 @@ func (s *Server) gitLabWebhook(w http.ResponseWriter, r *http.Request) {
 			Namespace: namespace,
 		},
 		&types.RenovateStatusUpdate{
-			Status: api.JobStatusScheduled,
+			Status:   api.JobStatusScheduled,
+			Priority: 1,
 		},
 	)
 	if err != nil {

--- a/src/webhook/mock_test.go
+++ b/src/webhook/mock_test.go
@@ -54,6 +54,9 @@ func (m *mockWebhookManager) GetRenovateJob(ctx context.Context, name, namespace
 func (m *mockWebhookManager) ReconcileProjects(ctx context.Context, jobId crdmanager.RenovateJobIdentifier, projects []string) error {
 	return nil
 }
+func (m *mockWebhookManager) UpdateProjectConfigStatus(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier, status *string) error {
+	return nil
+}
 func (m *mockWebhookManager) LoadRenovateJob(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
 	return nil, nil
 }

--- a/src/webhook/server.go
+++ b/src/webhook/server.go
@@ -85,7 +85,8 @@ func (s *Server) runRenovate(w http.ResponseWriter, r *http.Request) {
 			Namespace: namespace,
 		},
 		&types.RenovateStatusUpdate{
-			Status: api.JobStatusScheduled,
+			Status:   api.JobStatusScheduled,
+			Priority: 1,
 		},
 	)
 	if err != nil {
@@ -95,7 +96,7 @@ func (s *Server) runRenovate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
-	s.logger.V(2).Info("Successfully triggered Renovate for project", "project", project, "renovateJob", job, "namespace", namespace)
+	s.logger.V(2).Info("Successfully triggered Renovate for project", "project", project, "renovateJob", job, "namespace", namespace, "priority", 1)
 }
 
 func (server *Server) authMiddleware(next http.Handler) http.Handler {


### PR DESCRIPTION
# Problem
When the number of scheduled jobs far exceeds the parallelism setting, you can end up taking a significant amount of time to work through the backlog.  This can end up blocking runs of user-interactive calls like Webhooks (clicked on the dashboard/PR) and UI (clicked the trigger).

# Solution
Add priority processing.
1. Update the Status to have a Priority value.  Priority ordering of UI > webhook > cron
2. Process higher priority items first  

This is still a relatively naive approach, as a sufficient number of UI or Webhook events could prevent any processing of cron scheduled runs.  I think that risk is relatively low however, as anyone that is hitting this type of throughput issue should have a high enough parallelism to process everything.

## Notable changes: 
- Added a Priority value to the Status struct
- Split the executor loop into two stages, one to clean up completed runs and a second to start new runs after sorting by priority

# Testing
- Verified with parallelism of 3
- Cron schedule set 50+ jobs to schedule
- successfully queued a job via WebUI with priority 2, and it ran as expected
- successfully queued a job via Webhook with priority 1, and it ran as expected