### PR TITLE
feat: enable timezone support

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -28,7 +28,7 @@ jobs:
 
         go mod download
 
-        go build ./...
+        go build -tags timetzdata ./...
   test:
     needs: [build]
     runs-on: self-hosted

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY src/go.mod src/go.sum ./
 RUN go mod download
 COPY src .
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#v} \
-    go build -trimpath -gcflags="all=-l" -ldflags="-s -w -X main.Version=${VERSION}" -o renovate-operator ./cmd/main.go
+    go build -tags timetzdata -trimpath -gcflags="all=-l" -ldflags="-s -w -X main.Version=${VERSION}" -o renovate-operator ./cmd/main.go
 
 FROM --platform=$BUILDPLATFORM alpine:latest as js-downloader
 WORKDIR /workspace

--- a/Justfile
+++ b/Justfile
@@ -14,14 +14,14 @@ run *args: build jsInstall
 build: generate
     #!/usr/bin/env sh
     VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo "dev")
-    cd src && go build -trimpath -gcflags="all=-l" -ldflags="-s -w -X main.Version=${VERSION}" -o ../dist/native/renovate-operator ./cmd/main.go
+    cd src && go build -tags timetzdata -trimpath -gcflags="all=-l" -ldflags="-s -w -X main.Version=${VERSION}" -o ../dist/native/renovate-operator ./cmd/main.go
 
 # Build binaries for all targets
 build-all: build-linux-amd64 build-linux-arm64 build-linux-armv7
 
 # Build binary for target linux-amd64
 build-linux-amd64: generate
-    cd src && GOOS=linux GOARCH=amd64 go build -trimpath -gcflags="all=-l" -ldflags="-s -w" -o ../dist/amd64/renovate-operator ./cmd/main.go
+    cd src && GOOS=linux GOARCH=amd64 go build -tags timetzdata -trimpath -gcflags="all=-l" -ldflags="-s -w" -o ../dist/amd64/renovate-operator ./cmd/main.go
 
 # Build docker image for target linux-amd64
 build-docker-linux-amd64:
@@ -37,7 +37,7 @@ build-docker-linux-amd64:
 
 # Build binary for target linux-arm64
 build-linux-arm64: generate
-    cd src && GOOS=linux GOARCH=arm64 go build -trimpath -gcflags="all=-l" -ldflags="-s -w" -o ../dist/arm64/renovate-operator ./cmd/main.go
+    cd src && GOOS=linux GOARCH=arm64 go build -tags timetzdata -trimpath -gcflags="all=-l" -ldflags="-s -w" -o ../dist/arm64/renovate-operator ./cmd/main.go
 
 # Build docker image for target linux-arm64
 build-docker-linux-arm64:
@@ -53,7 +53,7 @@ build-docker-linux-arm64:
 
 # Build binary for target linux-armv7
 build-linux-armv7: generate
-    cd src && GOOS=linux GOARCH=arm GOARM=7 go build -trimpath -gcflags="all=-l" -ldflags="-s -w" -o ../dist/armv7/renovate-operator ./cmd/main.go
+    cd src && GOOS=linux GOARCH=arm GOARM=7 go build -tags timetzdata -trimpath -gcflags="all=-l" -ldflags="-s -w" -o ../dist/armv7/renovate-operator ./cmd/main.go
 
 # Build docker image for target linux-armv7
 build-docker-linux-armv7:


### PR DESCRIPTION
This PR adds proper timezone support for the operator when running in minimal container images like `scratch`.

These changes embed the IANA timezone database into the binary using the Go time/tzdata package and the timetzdata build tag. This allows calls like:
```yaml
schedule: "CRON_TZ=Europe/Berlin 5 * * * *"
```
to work without errors such as:
```
unknown time zone Europe/Berlin
```

The change does not alter any runtime behavior except making timezone loading work reliably in environments without a system zoneinfo database.

There is a small increase in binary size (~500KB), but no additional runtime dependencies.

Reference:
https://pkg.go.dev/time/tzdata