### PR TITLE
feat: Add httproute fields

### DIFF
--- a/charts/renovate-operator/templates/httproute.yaml
+++ b/charts/renovate-operator/templates/httproute.yaml
@@ -29,4 +29,7 @@ spec:
       backendRefs:
         - name: {{ include "renovate-operator.fullname" . }}
           port: 8081
+          group: {{ .Values.route.group }}
+          kind: {{ .Values.route.kind }}
+          weight: {{ .Values.route.weight }}
 {{- end }}

--- a/charts/renovate-operator/templates/webhook-httproute.yaml
+++ b/charts/renovate-operator/templates/webhook-httproute.yaml
@@ -29,4 +29,7 @@ spec:
       backendRefs:
         - name: {{ include "renovate-operator.fullname" . }}
           port: {{ .Values.webhook.port }}
+          group: {{ .Values.webhook.route.group }}
+          kind: {{ .Values.webhook.route.kind }}
+          weight: {{ .Values.webhook.route.weight }}
 {{- end }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -96,6 +96,12 @@ route:
   hostnames: []
   # -- parentRefs to place on the HTTPRoute
   parentRefs: []
+  # -- group to place on the HTTPRoute
+  group: ''
+  # -- kind to place on the HTTPRoute
+  kind: Service
+  # -- weight to place on the HTTPRoute
+  weight: 1
 
 webhook:
   enabled: false
@@ -128,7 +134,12 @@ webhook:
     hostnames: []
     # -- parentRefs to place on the HTTPRoute
     parentRefs: []
-
+    # -- group to place on the HTTPRoute
+    group: ''
+    # -- kind to place on the HTTPRoute
+    kind: Service
+    # -- weight to place on the HTTPRoute
+    weight: 1
 
 rbac:
   # -- if true no clusterrole and clusterrolebinding will be created, only role and rolebinding


### PR DESCRIPTION
### Problem

`Httproute` is not fully configurable so it's currently not possible to specific fields like `group`, `kind` or `weight`.

### Solution

Add those fields to `values.yaml` with default values and let the user override them when necessary.