### PR TITLE
fix: Quote httproute fields

### DIFF
--- a/charts/renovate-operator/templates/httproute.yaml
+++ b/charts/renovate-operator/templates/httproute.yaml
@@ -29,7 +29,7 @@ spec:
       backendRefs:
         - name: {{ include "renovate-operator.fullname" . }}
           port: 8081
-          group: {{ .Values.route.group }}
-          kind: {{ .Values.route.kind }}
+          group: {{ .Values.route.group | quote }}
+          kind: {{ .Values.route.kind | quote }}
           weight: {{ .Values.route.weight }}
 {{- end }}

--- a/charts/renovate-operator/templates/webhook-httproute.yaml
+++ b/charts/renovate-operator/templates/webhook-httproute.yaml
@@ -29,7 +29,7 @@ spec:
       backendRefs:
         - name: {{ include "renovate-operator.fullname" . }}
           port: {{ .Values.webhook.port }}
-          group: {{ .Values.webhook.route.group }}
-          kind: {{ .Values.webhook.route.kind }}
+          group: {{ .Values.webhook.route.group | quote }}
+          kind: {{ .Values.webhook.route.kind | quote }}
           weight: {{ .Values.webhook.route.weight }}
 {{- end }}


### PR DESCRIPTION
### Problem

Fields like `.Values.route.group` can contain an empty string, which end up rendering as `group: null` instead of `group: ""`.

### Solution

Use Helm `quote` function to ensure correct empty string rendering.