### PR TITLE
feat: Add authorization support to OIDC authentication

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -3105,6 +3105,13 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              allowedGroups:
+                description: |-
+                  Groups allowed to view this RenovateJob when authentication is enabled.
+                  If empty or not set, the job is hidden from all users.
+                items:
+                  type: string
+                type: array
               metadata:
                 description: Metadata that shall be applied to the resulting pod
                 properties:

--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -136,6 +136,18 @@ spec:
             - name: OIDC_LOGOUT_URL
               value: {{ .Values.auth.oidc.logoutUrl | quote }}
             {{- end }}
+            {{- if .Values.auth.oidc.allowedGroupPrefix }}
+            - name: OIDC_ALLOWED_GROUP_PREFIX
+              value: {{ .Values.auth.oidc.allowedGroupPrefix | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.allowedGroupPattern }}
+            - name: OIDC_ALLOWED_GROUP_PATTERN
+              value: {{ .Values.auth.oidc.allowedGroupPattern | quote }}
+            {{- end }}
+            {{- if .Values.auth.oidc.additionalScopes }}
+            - name: OIDC_ADDITIONAL_SCOPES
+              value: {{ .Values.auth.oidc.additionalScopes | join "," | quote }}
+            {{- end }}
             {{- else if .Values.auth.github.enabled }}
             - name: GITHUB_CLIENT_ID
               value: {{ .Values.auth.github.clientId | quote }}
@@ -155,6 +167,12 @@ spec:
             {{- if $githubRedirectUrl }}
             - name: GITHUB_REDIRECT_URL
               value: {{ $githubRedirectUrl | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if or .Values.auth.oidc.enabled .Values.auth.github.enabled }}
+            {{- if .Values.auth.defaultAllowedGroups }}
+            - name: DEFAULT_ALLOWED_GROUPS
+              value: {{ .Values.auth.defaultAllowedGroups | quote }}
             {{- end }}
             {{- end }}
             {{- with .Values.extraEnv }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -142,6 +142,8 @@ webhook:
     weight: 1
 
 auth:
+  # -- comma-separated list of default groups for RenovateJobs without explicit allowedGroups (empty = jobs hidden by default, secure)
+  defaultAllowedGroups: ""
   oidc:
     # -- whether to enable OIDC authentication for the UI
     enabled: false
@@ -161,6 +163,14 @@ auth:
     insecureSkipVerify: false
     # -- optional: OIDC end_session_endpoint URL for provider logout (auto-discovered if available)
     logoutUrl: ""
+    # -- optional: only accept groups with this prefix (e.g., "renovate-")
+    # -- Leave empty to accept all groups. High-security environments should set this.
+    allowedGroupPrefix: ""
+    # -- optional: only accept groups matching this regex pattern (e.g., "^(team-|platform-).*")
+    # -- Leave empty to accept all groups. Can be combined with allowedGroupPrefix.
+    allowedGroupPattern: ""
+    # -- optional: additional OIDC scopes to request (e.g., "groups" for Keycloak)
+    additionalScopes: []
   github:
     # -- whether to enable GitHub OAuth authentication for the UI (mutually exclusive with OIDC)
     enabled: false
@@ -231,7 +241,7 @@ logging:
   # -- log level for the operator, one of 'debug', 'info', 'error', 'panic'or any integer value > 0
   level: "info"
   # -- log format for the operator, one of: json, console
-  format: "json" 
+  format: "json"
 
 metrics:
   enabled: false

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -24,6 +24,9 @@ auth:
     redirectUrl: ""                            # Optional: auto-detected from ingress
     insecureSkipVerify: false                  # Do not use in production
     logoutUrl: ""                              # Optional: auto-discovered via OIDC metadata
+    allowedGroupPrefix: ""                     # Optional: only accept groups with this prefix
+    allowedGroupPattern: ""                    # Optional: only accept groups matching this regex
+    additionalScopes: []                        # Optional: extra OIDC scopes (e.g., ["groups"])
 ```
 
 ### Secret
@@ -46,6 +49,21 @@ https://<your-operator-host>/auth/callback
 ```
 
 Required scopes: `openid`, `email`, `profile`
+
+#### Additional Scopes
+
+By default, only the standard OIDC scopes (`openid`, `email`, `profile`) are requested. Some providers support additional custom scopes — for example, Keycloak supports a `groups` scope to include group membership in the ID token.
+
+To request extra scopes, set `additionalScopes`:
+
+```yaml
+auth:
+  oidc:
+    additionalScopes:
+      - groups
+```
+
+**Azure AD / Entra ID**: Do **not** add `groups` here. Azure AD does not support `groups` as an OIDC scope and will reject the request with `AADSTS650053`. Instead, configure the `groups` claim in **App Registration → Token Configuration → Add groups claim**. The operator will read groups from the ID token regardless of whether the scope is requested.
 
 ---
 
@@ -96,6 +114,68 @@ Sessions are stored as AES-256-GCM encrypted cookies and expire after **24 hours
 If you run multiple operator replicas, you **must** set a static session secret. Otherwise each pod generates its own key and users will be logged out when requests hit a different replica.
 
 Set the session secret via `sessionSecretKey` pointing to a key in your existing secret, or the operator will auto-generate one per startup.
+
+---
+
+## Group-Based Authorization
+
+When authentication is enabled, you can control which users can view and manage specific RenovateJobs based on their group membership.
+
+### How It Works
+
+- **Auth disabled**: All RenovateJobs are visible to everyone
+- **Auth enabled**: Jobs are filtered based on user groups
+  - Jobs without `allowedGroups` use the global `defaultAllowedGroups`
+  - If neither are set, the job is hidden (secure by default)
+  - Users can only see jobs where they have at least one matching group
+
+### Configuration
+
+#### Default Allowed Groups
+
+Set default groups for all RenovateJobs without explicit `allowedGroups`:
+
+```yaml
+auth:
+  defaultAllowedGroups: "team-platform,team-infra"
+```
+
+#### Per-Job Authorization
+
+Add `allowedGroups` to individual RenovateJob resources:
+
+```yaml
+apiVersion: renovate-operator.mogenius.com/v1alpha1
+kind: RenovateJob
+metadata:
+  name: my-renovate-job
+spec:
+  schedule: "0 2 * * *"
+  allowedGroups:
+    - team-platform
+    - team-devops
+  # ... other fields
+```
+
+#### OIDC Group Filtering
+
+Filter which groups from your OIDC provider are accepted:
+
+```yaml
+auth:
+  oidc:
+    # ... other OIDC settings ...
+    allowedGroupPrefix: "renovate-"              # Only accept groups starting with "renovate-"
+    allowedGroupPattern: "^(team-|platform-).*"  # Only accept groups matching regex
+```
+
+This is useful when your identity provider returns many groups but you only want to use certain ones for authorization.
+
+### Security Considerations
+
+- **Secure by default**: Jobs without any groups configured (neither explicit nor default) are hidden when auth is enabled
+- **Group validation**: Groups are normalized (lowercased, trimmed) and validated for security
+- **Audit logging**: All authorization decisions are logged for security auditing
 
 ---
 

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -55,6 +55,10 @@ type RenovateJobSpec struct {
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// DNS Policy for the renovate pods
 	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+	// Groups allowed to view this RenovateJob when authentication is enabled.
+	// If empty or not set, the job is hidden from all users.
+	// +optional
+	AllowedGroups []string `json:"allowedGroups,omitempty"`
 }
 
 // configuration regarding serviceaccounts for the resulting pod

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,6 +35,18 @@ var Version = "dev" // default version, will be overridden by ld build flag in D
 func adaptKubeConfig(cfg *rest.Config) {
 	cfg.QPS = 50
 	cfg.Burst = 100
+}
+
+func splitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 func main() {
@@ -173,6 +186,26 @@ func main() {
 			Key:      "GITHUB_SESSION_SECRET",
 			Optional: true,
 		},
+		{
+			Key:      "DEFAULT_ALLOWED_GROUPS",
+			Optional: true,
+			Default:  "",
+		},
+		{
+			Key:      "OIDC_ALLOWED_GROUP_PREFIX",
+			Optional: true,
+			Default:  "",
+		},
+		{
+			Key:      "OIDC_ALLOWED_GROUP_PATTERN",
+			Optional: true,
+			Default:  "",
+		},
+		{
+			Key:      "OIDC_ADDITIONAL_SCOPES",
+			Optional: true,
+			Default:  "",
+		},
 	})
 	assert.NoError(err, "failed to initialize config module")
 
@@ -233,17 +266,30 @@ func main() {
 		oidcCtx, oidcCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer oidcCancel()
 		oidcAuth, oidcErr := ui.NewOIDCAuth(oidcCtx, ui.OIDCConfig{
-			IssuerURL:          oidcIssuer,
-			ClientID:           oidcClientID,
-			ClientSecret:       oidcClientSecret,
-			RedirectURL:        config.GetValue("OIDC_REDIRECT_URL"),
-			SessionSecret:      config.GetValue("OIDC_SESSION_SECRET"),
-			InsecureSkipVerify: config.GetValue("OIDC_INSECURE_SKIP_VERIFY") == "true",
-			LogoutURL:          config.GetValue("OIDC_LOGOUT_URL"),
+			IssuerURL:           oidcIssuer,
+			ClientID:            oidcClientID,
+			ClientSecret:        oidcClientSecret,
+			RedirectURL:         config.GetValue("OIDC_REDIRECT_URL"),
+			SessionSecret:       config.GetValue("OIDC_SESSION_SECRET"),
+			InsecureSkipVerify:  config.GetValue("OIDC_INSECURE_SKIP_VERIFY") == "true",
+			LogoutURL:           config.GetValue("OIDC_LOGOUT_URL"),
+			AllowedGroupPrefix:  config.GetValue("OIDC_ALLOWED_GROUP_PREFIX"),
+			AllowedGroupPattern: config.GetValue("OIDC_ALLOWED_GROUP_PATTERN"),
+			AdditionalScopes:    splitAndTrim(config.GetValue("OIDC_ADDITIONAL_SCOPES"), ","),
 		}, ctrl.Log.WithName("oidc"))
 		assert.NoError(oidcErr, "failed to initialize OIDC provider")
 		authProvider = oidcAuth
 		ctrl.Log.WithName("auth").Info("OIDC authentication enabled", "issuer", oidcIssuer)
+
+		// Log group filtering configuration
+		if config.GetValue("OIDC_ALLOWED_GROUP_PREFIX") != "" {
+			ctrl.Log.WithName("auth").Info("OIDC group prefix filter enabled",
+				"prefix", config.GetValue("OIDC_ALLOWED_GROUP_PREFIX"))
+		}
+		if config.GetValue("OIDC_ALLOWED_GROUP_PATTERN") != "" {
+			ctrl.Log.WithName("auth").Info("OIDC group pattern filter enabled",
+				"pattern", config.GetValue("OIDC_ALLOWED_GROUP_PATTERN"))
+		}
 	} else if githubClientID != "" && githubClientSecret != "" {
 		ghAuth, ghErr := ui.NewGitHubOAuth(ui.GitHubOAuthConfig{
 			ClientID:      githubClientID,
@@ -258,8 +304,27 @@ func main() {
 		ctrl.Log.WithName("auth").Info("No authentication configured, UI access is unauthenticated")
 	}
 
+	// Parse default allowed groups (comma-separated)
+	var defaultAllowedGroups []string
+	defaultGroupsStr := config.GetValue("DEFAULT_ALLOWED_GROUPS")
+	if defaultGroupsStr != "" {
+		for _, group := range splitAndTrim(defaultGroupsStr, ",") {
+			if group != "" {
+				normalized := strings.ToLower(strings.TrimSpace(group))
+				defaultAllowedGroups = append(defaultAllowedGroups, normalized)
+			}
+		}
+		ctrl.Log.WithName("auth").Info("Default allowed groups configured", "groups", defaultAllowedGroups)
+	}
+
+	if authProvider != nil && !authProvider.SupportsGroups() && len(defaultAllowedGroups) > 0 {
+		ctrl.Log.WithName("auth").Error(nil,
+			"auth provider does not support group claims -- DEFAULT_ALLOWED_GROUPS is configured but will have no effect, all jobs will be hidden from all users",
+			"ignored_groups", defaultAllowedGroups)
+	}
+
 	// UI and webhook servers run on all replicas
-	uiServer := ui.NewServer(jobMgr, discovery, cronManager, ctrl.Log.WithName("ui-server"), health, Version, authProvider)
+	uiServer := ui.NewServer(jobMgr, discovery, cronManager, ctrl.Log.WithName("ui-server"), health, Version, authProvider, defaultAllowedGroups)
 	uiServer.Run()
 
 	if config.GetValue("WEBHOOK_SERVER_ENABLED") != "false" {

--- a/src/ui/auth.go
+++ b/src/ui/auth.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -24,11 +25,25 @@ const (
 	sessionDuration     = 24 * time.Hour
 )
 
+type contextKey string
+
+const sessionContextKey contextKey = "session"
+
 type sessionData struct {
-	Email       string `json:"email"`
-	Name        string `json:"name"`
-	Expiry      int64  `json:"exp"`
-	AccessToken string `json:"at,omitempty"`
+	Email       string   `json:"email"`
+	Name        string   `json:"name"`
+	Expiry      int64    `json:"exp"`
+	AccessToken string   `json:"at,omitempty"`
+	Groups      []string `json:"groups"`
+}
+
+// getSessionFromContext retrieves the session from the request context.
+func getSessionFromContext(r *http.Request) *sessionData {
+	session, ok := r.Context().Value(sessionContextKey).(*sessionData)
+	if !ok {
+		return nil
+	}
+	return session
 }
 
 // AuthProvider is the interface that both OIDC and GitHub OAuth implement.
@@ -39,6 +54,7 @@ type AuthProvider interface {
 	HandleLogout(w http.ResponseWriter, r *http.Request)
 	HandleAuthStatus(w http.ResponseWriter, r *http.Request)
 	AuthMiddleware(next http.Handler) http.Handler
+	SupportsGroups() bool
 }
 
 // baseAuth contains shared session and middleware logic for all auth providers.
@@ -52,6 +68,7 @@ func newEncryptionKey(sessionSecret string) ([32]byte, error) {
 	if sessionSecret != "" {
 		key = sha256.Sum256([]byte(sessionSecret))
 	} else {
+		// Generate cryptographically secure random key
 		if _, err := io.ReadFull(rand.Reader, key[:]); err != nil {
 			return key, fmt.Errorf("failed to generate encryption key: %w", err)
 		}
@@ -108,6 +125,12 @@ func (b *baseAuth) authMiddleware(next http.Handler) http.Handler {
 				}
 				return
 			}
+			// Audit log failed authentication attempt
+			b.logger.V(1).Info("Unauthenticated request rejected",
+				"path", path,
+				"method", r.Method,
+				"remote_addr", r.RemoteAddr,
+				"user_agent", r.UserAgent())
 
 			// API requests get 401
 			if strings.HasPrefix(path, "/api/") {
@@ -127,7 +150,9 @@ func (b *baseAuth) authMiddleware(next http.Handler) http.Handler {
 			http.SetCookie(w, &http.Cookie{Name: authCompletedCookie, Value: "", Path: "/", MaxAge: -1, HttpOnly: true})
 		}
 
-		next.ServeHTTP(w, r)
+		// Add session to context
+		ctx := context.WithValue(r.Context(), sessionContextKey, session)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
@@ -164,6 +189,7 @@ func (b *baseAuth) buildCompleteURL(email, name string, opts ...func(*sessionDat
 	session := sessionData{
 		Email:  email,
 		Name:   name,
+		Groups: []string{},
 		Expiry: time.Now().Add(sessionDuration).Unix(),
 	}
 	for _, opt := range opts {

--- a/src/ui/auth_test.go
+++ b/src/ui/auth_test.go
@@ -1,0 +1,206 @@
+package ui
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func TestGetSession_ValidWithGroups(t *testing.T) {
+	auth := &baseAuth{
+		logger: logr.Discard(),
+	}
+	key, err := newEncryptionKey("test-secret-key-with-32-chars!!!")
+	if err != nil {
+		t.Fatalf("Failed to create encryption key: %v", err)
+	}
+	auth.encryptionKey = key
+
+	// Create a session with groups
+	sessionData := sessionData{
+		Email:  "test@example.com",
+		Name:   "Test User",
+		Groups: []string{"team-a"},
+		Expiry: time.Now().Add(1 * time.Hour).Unix(),
+	}
+
+	encrypted, err := auth.encryptSession(sessionData)
+	if err != nil {
+		t.Fatalf("Failed to encrypt session: %v", err)
+	}
+
+	// Create request with session cookie
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  sessionCookieName,
+		Value: encrypted,
+	})
+
+	session, err := auth.getSession(req)
+	if err != nil {
+		t.Fatalf("getSession failed: %v", err)
+	}
+
+	if session.Email != "test@example.com" {
+		t.Errorf("Expected email test@example.com, got %s", session.Email)
+	}
+	if len(session.Groups) != 1 || session.Groups[0] != "team-a" {
+		t.Errorf("Groups not retrieved correctly: %v", session.Groups)
+	}
+}
+
+func TestEncryptDecryptSession_PreservesGroups(t *testing.T) {
+	auth := &baseAuth{
+		logger: logr.Discard(),
+	}
+	key, err := newEncryptionKey("test-secret-key-with-32-chars!!!")
+	if err != nil {
+		t.Fatalf("Failed to create encryption key: %v", err)
+	}
+	auth.encryptionKey = key
+
+	originalSession := sessionData{
+		Email:  "test@example.com",
+		Name:   "Test User",
+		Groups: []string{"team-a", "team-b", "team-c"},
+		Expiry: time.Now().Add(1 * time.Hour).Unix(),
+	}
+
+	encrypted, err := auth.encryptSession(originalSession)
+	if err != nil {
+		t.Fatalf("Failed to encrypt session: %v", err)
+	}
+
+	decrypted, err := auth.decryptSession(encrypted)
+	if err != nil {
+		t.Fatalf("Failed to decrypt session: %v", err)
+	}
+
+	if len(decrypted.Groups) != len(originalSession.Groups) {
+		t.Errorf("Groups length mismatch: expected %d, got %d", len(originalSession.Groups), len(decrypted.Groups))
+	}
+
+	for i, group := range originalSession.Groups {
+		if decrypted.Groups[i] != group {
+			t.Errorf("Group %d mismatch: expected %s, got %s", i, group, decrypted.Groups[i])
+		}
+	}
+}
+
+// TestCookieDeletionFlags verifies proper flags on cookie deletion
+func TestCookieDeletionFlags(t *testing.T) {
+	auth := &baseAuth{
+		logger: logr.Discard(),
+	}
+
+	w := httptest.NewRecorder()
+	auth.clearSessionCookie(w)
+
+	cookies := w.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("Expected 1 cookie, got %d", len(cookies))
+	}
+
+	cookie := cookies[0]
+	if cookie.Name != sessionCookieName {
+		t.Errorf("Expected cookie name %s, got %s", sessionCookieName, cookie.Name)
+	}
+	if cookie.MaxAge != -1 {
+		t.Errorf("Expected MaxAge -1, got %d", cookie.MaxAge)
+	}
+	if !cookie.HttpOnly {
+		t.Error("Expected HttpOnly to be true")
+	}
+}
+
+func TestGetSessionFromContext_WithSession(t *testing.T) {
+	session := &sessionData{
+		Email:  "test@example.com",
+		Name:   "Test User",
+		Groups: []string{"team-a"},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := context.WithValue(req.Context(), sessionContextKey, session)
+	req = req.WithContext(ctx)
+
+	retrievedSession := getSessionFromContext(req)
+	if retrievedSession == nil {
+		t.Fatal("Expected session, got nil")
+	}
+
+	if retrievedSession.Email != "test@example.com" {
+		t.Errorf("Expected email test@example.com, got %s", retrievedSession.Email)
+	}
+	if len(retrievedSession.Groups) != 1 || retrievedSession.Groups[0] != "team-a" {
+		t.Errorf("Groups not retrieved correctly: %v", retrievedSession.Groups)
+	}
+}
+
+func TestGetSessionFromContext_NoSession(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	retrievedSession := getSessionFromContext(req)
+	if retrievedSession != nil {
+		t.Errorf("Expected nil session, got %+v", retrievedSession)
+	}
+}
+
+func TestAuthMiddleware_StoresSessionInContext(t *testing.T) {
+	auth := &baseAuth{
+		logger: logr.Discard(),
+	}
+	key, err := newEncryptionKey("test-secret-key-with-32-chars!!!")
+	if err != nil {
+		t.Fatalf("Failed to create encryption key: %v", err)
+	}
+	auth.encryptionKey = key
+
+	// Create a valid session cookie
+	session := sessionData{
+		Email:  "test@example.com",
+		Name:   "Test User",
+		Groups: []string{"team-a"},
+		Expiry: time.Now().Add(1 * time.Hour).Unix(),
+	}
+
+	encrypted, err := auth.encryptSession(session)
+	if err != nil {
+		t.Fatalf("Failed to encrypt session: %v", err)
+	}
+
+	// Create a handler that checks if session is in context
+	var capturedSession *sessionData
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedSession = getSessionFromContext(r)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Wrap with auth middleware
+	middleware := auth.authMiddleware(testHandler)
+
+	// Create request with session cookie
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  sessionCookieName,
+		Value: encrypted,
+	})
+
+	w := httptest.NewRecorder()
+	middleware.ServeHTTP(w, req)
+
+	if capturedSession == nil {
+		t.Fatal("Session was not stored in context")
+	}
+
+	if capturedSession.Email != "test@example.com" {
+		t.Errorf("Expected email test@example.com, got %s", capturedSession.Email)
+	}
+	if len(capturedSession.Groups) != 1 || capturedSession.Groups[0] != "team-a" {
+		t.Errorf("Groups not in context correctly: %v", capturedSession.Groups)
+	}
+}

--- a/src/ui/github_oauth.go
+++ b/src/ui/github_oauth.go
@@ -152,6 +152,10 @@ func (g *GitHubOAuth) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
 	g.handleAuthStatus(w, r)
 }
 
+func (g *GitHubOAuth) SupportsGroups() bool {
+	return false
+}
+
 func (g *GitHubOAuth) fetchGitHubUser(accessToken string) (email, name string, err error) {
 	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
 	if err != nil {

--- a/src/ui/group_validation.go
+++ b/src/ui/group_validation.go
@@ -1,0 +1,182 @@
+package ui
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	maxGroupNameLength = 256
+	maxGroupsPerUser   = 100
+)
+
+var (
+	// validGroupNamePattern allows alphanumeric, dash, underscore, @, dot, forward slash, comma, equals, space
+	// This covers most OIDC providers: Azure AD (including DN format and display names), Okta, Google, Keycloak, etc.
+	validGroupNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._@/,= -]+$`)
+)
+
+// validateGroupName performs basic format validation on a single group name.
+// Prevents injection attacks and DoS via excessively long names.
+func validateGroupName(name string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("empty group name")
+	}
+
+	if len(name) > maxGroupNameLength {
+		return fmt.Errorf("group name too long: %d characters (max: %d)", len(name), maxGroupNameLength)
+	}
+
+	if !validGroupNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid characters in group name (allowed: a-z A-Z 0-9 . _ @ / , = - space)")
+	}
+
+	return nil
+}
+
+// sanitizeGroups performs LAYER 1 validation: basic format checking and DoS prevention.
+// Filters out invalid groups and limits total count to prevent memory exhaustion.
+func sanitizeGroups(groups []string, logger logr.Logger) []string {
+	// Prevent memory DoS by limiting total groups
+	if len(groups) > maxGroupsPerUser {
+		logger.Info("User has excessive groups, truncating for safety",
+			"original_count", len(groups),
+			"limit", maxGroupsPerUser)
+		groups = groups[:maxGroupsPerUser]
+	}
+
+	validated := make([]string, 0, len(groups))
+	for _, group := range groups {
+		// Trim whitespace before validation (formatting is not part of the group name)
+		group = strings.TrimSpace(group)
+
+		if err := validateGroupName(group); err != nil {
+			logger.V(1).Info("Skipping invalid group from OIDC claim",
+				"group", group,
+				"error", err.Error())
+			continue
+		}
+		validated = append(validated, group)
+	}
+
+	return validated
+}
+
+// normalizeGroups normalizes all groups by removing whitespace and using lowercase
+func normalizeGroups(groups []string) []string {
+	if groups == nil {
+		return nil
+	}
+	normalized := make([]string, 0, len(groups))
+	for _, group := range groups {
+		normalized = append(normalized, strings.ToLower(strings.TrimSpace(group)))
+	}
+	return normalized
+}
+
+// normalizeAndValidateGroups performs LAYER 2 validation: normalization and deduplication.
+// Handles case sensitivity, whitespace, and duplicate groups.
+func normalizeAndValidateGroups(groups []string, logger logr.Logger) []string {
+	seen := make(map[string]bool, len(groups))
+	validated := make([]string, 0, len(groups))
+
+	normalizedGroups := normalizeGroups(groups)
+
+	for _, group := range normalizedGroups {
+
+		if group == "" {
+			continue
+		}
+
+		// Deduplicate (e.g., "Team-A" and "team-a" become one)
+		if seen[group] {
+			logger.V(2).Info("Skipping duplicate group", group)
+			continue
+		}
+
+		seen[group] = true
+
+		validated = append(validated, group)
+	}
+
+	return validated
+}
+
+// GroupFilterConfig defines optional filtering rules for LAYER 3 validation.
+type GroupFilterConfig struct {
+	// AllowedPrefix filters groups to only those starting with this prefix.
+	// Example: "renovate-" only allows "renovate-team-a", "renovate-admin"
+	AllowedPrefix string
+
+	// AllowedPattern is a regex pattern that groups must match.
+	// Example: "^(team-|platform-|admin-).*" allows team-*, platform-*, admin-*
+	AllowedPattern *regexp.Regexp
+}
+
+// filterGroupsByPolicy performs LAYER 3 validation: policy-based filtering.
+// Applies optional prefix and pattern restrictions for high-security environments.
+func filterGroupsByPolicy(groups []string, config GroupFilterConfig, logger logr.Logger) []string {
+	// If no policy configured, return all groups
+	if config.AllowedPrefix == "" && config.AllowedPattern == nil {
+		return groups
+	}
+
+	filtered := make([]string, 0, len(groups))
+
+	for _, group := range groups {
+		// Check prefix requirement
+		if config.AllowedPrefix != "" {
+			if !strings.HasPrefix(group, config.AllowedPrefix) {
+				logger.V(2).Info("Filtering group without required prefix",
+					"group", group,
+					"required_prefix", config.AllowedPrefix)
+				continue
+			}
+		}
+
+		// Check pattern requirement
+		if config.AllowedPattern != nil {
+			if !config.AllowedPattern.MatchString(group) {
+				logger.V(2).Info("Filtering group not matching pattern",
+					"group", group,
+					"pattern", config.AllowedPattern.String())
+				continue
+			}
+		}
+
+		filtered = append(filtered, group)
+	}
+
+	return filtered
+}
+
+// ValidateAndNormalizeGroups performs all 3 layers of group validation.
+// Returns sanitized, normalized, and policy-filtered groups safe for authorization.
+func ValidateAndNormalizeGroups(groups []string, config GroupFilterConfig, logger logr.Logger) []string {
+	// LAYER 1: Basic sanitization - remove malformed groups, limit count
+	sanitized := sanitizeGroups(groups, logger)
+
+	// LAYER 2: Normalization - lowercase, trim, deduplicate
+	normalized := normalizeAndValidateGroups(sanitized, logger)
+
+	// LAYER 3: Policy filtering - apply prefix/pattern restrictions
+	validated := filterGroupsByPolicy(normalized, config, logger)
+
+	// Warn if all groups were filtered out (potential misconfiguration)
+	if len(groups) > 0 && len(validated) == 0 {
+		logger.Info("WARNING: All user groups filtered out by validation",
+			"original_count", len(groups),
+			"after_sanitization", len(sanitized),
+			"after_normalization", len(normalized),
+			"after_policy", len(validated))
+	} else if len(groups) != len(validated) {
+		logger.V(1).Info("Group validation filtered some groups",
+			"original", len(groups),
+			"final", len(validated))
+	}
+
+	return validated
+}

--- a/src/ui/group_validation_test.go
+++ b/src/ui/group_validation_test.go
@@ -1,0 +1,334 @@
+package ui
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestValidateGroupName(t *testing.T) {
+	tests := []struct {
+		name      string
+		groupName string
+		wantErr   bool
+	}{
+		{"valid alphanumeric", "team-alpha-123", false},
+		{"valid with underscore", "team_alpha", false},
+		{"valid with dot", "team.alpha", false},
+		{"valid with at", "team@company.com", false},
+		{"valid with slash", "org/team", false},
+		{"empty string", "", true},
+		{"too long", string(make([]byte, 257)), true},
+		{"valid with spaces", "team alpha", false},
+		{"valid with multiple internal spaces", "All Company Users", false},
+		{"invalid characters special", "team$alpha", true},
+		{"invalid characters newline", "team\nalpha", true},
+		{"invalid characters null", "team\x00alpha", true},
+		{"unicode characters", "团队-A", true}, // Not in allowed set
+		{"just valid characters", "abcABC123._@/,= -", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGroupName(tt.groupName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateGroupName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSanitizeGroups(t *testing.T) {
+	logger := logr.Discard()
+
+	tests := []struct {
+		name   string
+		groups []string
+		want   int // expected number of groups after sanitization
+	}{
+		{
+			name:   "all valid groups",
+			groups: []string{"team-a", "team-b", "team-c"},
+			want:   3,
+		},
+		{
+			name:   "mixed valid and invalid",
+			groups: []string{"team-a", "team$invalid", "team-c"},
+			want:   2,
+		},
+		{
+			name:   "empty group filtered out",
+			groups: []string{"team-a", "", "team-c"},
+			want:   2,
+		},
+		{
+			name:   "too long group filtered",
+			groups: []string{"team-a", string(make([]byte, 257)), "team-c"},
+			want:   2,
+		},
+		{
+			name:   "excessive groups truncated",
+			groups: make([]string, 150), // More than maxGroupsPerUser
+			want:   100,                  // Should be truncated to max
+		},
+		{
+			name:   "all invalid groups",
+			groups: []string{"team$a", "team\nc", "team\x00z"},
+			want:   0,
+		},
+		{
+			name:   "group with spaces is valid",
+			groups: []string{"team$a", "team b", "team\nc"},
+			want:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// For excessive groups test, fill with valid names
+			if len(tt.groups) == 150 {
+				for i := range tt.groups {
+					tt.groups[i] = "team-" + string(rune('a'+i%26))
+				}
+			}
+
+			result := sanitizeGroups(tt.groups, logger)
+			if len(result) != tt.want {
+				t.Errorf("sanitizeGroups() returned %d groups, want %d", len(result), tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeAndValidateGroups(t *testing.T) {
+	logger := logr.Discard()
+
+	tests := []struct {
+		name   string
+		groups []string
+		want   []string
+	}{
+		{
+			name:   "lowercase normalization",
+			groups: []string{"Team-A", "TEAM-B", "team-c"},
+			want:   []string{"team-a", "team-b", "team-c"},
+		},
+		{
+			name:   "whitespace trimming",
+			groups: []string{" team-a ", "  team-b", "team-c  "},
+			want:   []string{"team-a", "team-b", "team-c"},
+		},
+		{
+			name:   "deduplication after normalization",
+			groups: []string{"team-a", "Team-A", "TEAM-A"},
+			want:   []string{"team-a"},
+		},
+		{
+			name:   "empty strings filtered",
+			groups: []string{"team-a", "", "   ", "team-b"},
+			want:   []string{"team-a", "team-b"},
+		},
+		{
+			name:   "mixed case with whitespace",
+			groups: []string{" Team-A ", "team-a", "TEAM-B "},
+			want:   []string{"team-a", "team-b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeAndValidateGroups(tt.groups, logger)
+			if len(result) != len(tt.want) {
+				t.Errorf("normalizeAndValidateGroups() returned %d groups, want %d", len(result), len(tt.want))
+			}
+			for i := range result {
+				if result[i] != tt.want[i] {
+					t.Errorf("normalizeAndValidateGroups()[%d] = %s, want %s", i, result[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFilterGroupsByPolicy(t *testing.T) {
+	logger := logr.Discard()
+
+	tests := []struct {
+		name   string
+		groups []string
+		config GroupFilterConfig
+		want   []string
+	}{
+		{
+			name:   "no policy - all groups pass",
+			groups: []string{"team-a", "platform-b", "admin-c"},
+			config: GroupFilterConfig{},
+			want:   []string{"team-a", "platform-b", "admin-c"},
+		},
+		{
+			name:   "prefix filter",
+			groups: []string{"renovate-team-a", "team-b", "renovate-admin"},
+			config: GroupFilterConfig{AllowedPrefix: "renovate-"},
+			want:   []string{"renovate-team-a", "renovate-admin"},
+		},
+		{
+			name:   "pattern filter",
+			groups: []string{"team-a", "platform-b", "admin-c", "other-d"},
+			config: GroupFilterConfig{AllowedPattern: regexp.MustCompile(`^(team-|platform-).*`)},
+			want:   []string{"team-a", "platform-b"},
+		},
+		{
+			name:   "prefix and pattern combined",
+			groups: []string{"renovate-team-a", "renovate-other", "team-b"},
+			config: GroupFilterConfig{
+				AllowedPrefix:  "renovate-",
+				AllowedPattern: regexp.MustCompile(`^renovate-team-.*`),
+			},
+			want: []string{"renovate-team-a"},
+		},
+		{
+			name:   "all groups filtered out",
+			groups: []string{"team-a", "team-b"},
+			config: GroupFilterConfig{AllowedPrefix: "renovate-"},
+			want:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterGroupsByPolicy(tt.groups, tt.config, logger)
+			if len(result) != len(tt.want) {
+				t.Errorf("filterGroupsByPolicy() returned %d groups, want %d", len(result), len(tt.want))
+			}
+			for i := range result {
+				if result[i] != tt.want[i] {
+					t.Errorf("filterGroupsByPolicy()[%d] = %s, want %s", i, result[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAndNormalizeGroups(t *testing.T) {
+	logger := logr.Discard()
+
+	tests := []struct {
+		name   string
+		groups []string
+		config GroupFilterConfig
+		want   []string
+	}{
+		{
+			name:   "full pipeline - sanitize, normalize, no policy",
+			groups: []string{"Team-A", " team-b ", "team$invalid", "TEAM-A"},
+			config: GroupFilterConfig{},
+			want:   []string{"team-a", "team-b"},
+		},
+		{
+			name:   "full pipeline with prefix filter",
+			groups: []string{"Renovate-Team-A", " renovate-team-b ", "team-c", "RENOVATE-ADMIN"},
+			config: GroupFilterConfig{AllowedPrefix: "renovate-"},
+			want:   []string{"renovate-team-a", "renovate-team-b", "renovate-admin"},
+		},
+		{
+			name: "full pipeline with pattern filter",
+			groups: []string{
+				"Team-Alpha", "Platform-Beta", " admin-gamma ", "other-delta",
+				"TEAM-EPSILON", "invalid$group",
+			},
+			config: GroupFilterConfig{AllowedPattern: regexp.MustCompile(`^(team-|platform-).*`)},
+			want:   []string{"team-alpha", "platform-beta", "team-epsilon"},
+		},
+		{
+			name:   "real-world Azure AD groups",
+			groups: []string{
+				" CN=Team-Renovate-Admins,OU=Groups,DC=example,DC=com ",
+				"team-renovate-users",
+				"TEAM-RENOVATE-VIEWERS",
+			},
+			config: GroupFilterConfig{AllowedPattern: regexp.MustCompile(`^(cn=)?team-renovate-.*`)},
+			want:   []string{"cn=team-renovate-admins,ou=groups,dc=example,dc=com", "team-renovate-users", "team-renovate-viewers"},
+		},
+		{
+			name:   "real-world OIDC groups with spaces",
+			groups: []string{"All Users", "Engineering Team", " Team Alpha ", "team-no-spaces"},
+			config: GroupFilterConfig{},
+			want:   []string{"all users", "engineering team", "team alpha", "team-no-spaces"},
+		},
+		{
+			name:   "all groups filtered out (warning case)",
+			groups: []string{"team-a", "team-b", "team-c"},
+			config: GroupFilterConfig{AllowedPrefix: "platform-"},
+			want:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateAndNormalizeGroups(tt.groups, tt.config, logger)
+			if len(result) != len(tt.want) {
+				t.Errorf("ValidateAndNormalizeGroups() returned %d groups, want %d\nGot: %v\nWant: %v",
+					len(result), len(tt.want), result, tt.want)
+				return
+			}
+			for i := range result {
+				if result[i] != tt.want[i] {
+					t.Errorf("ValidateAndNormalizeGroups()[%d] = %s, want %s", i, result[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAndNormalizeGroups_EdgeCases(t *testing.T) {
+	logger := logr.Discard()
+
+	t.Run("nil groups", func(t *testing.T) {
+		result := ValidateAndNormalizeGroups(nil, GroupFilterConfig{}, logger)
+		if len(result) != 0 {
+			t.Errorf("Expected empty result for nil input, got %v", result)
+		}
+	})
+
+	t.Run("empty groups", func(t *testing.T) {
+		result := ValidateAndNormalizeGroups([]string{}, GroupFilterConfig{}, logger)
+		if len(result) != 0 {
+			t.Errorf("Expected empty result for empty input, got %v", result)
+		}
+	})
+
+	t.Run("single group", func(t *testing.T) {
+		result := ValidateAndNormalizeGroups([]string{"Team-A"}, GroupFilterConfig{}, logger)
+		if len(result) != 1 || result[0] != "team-a" {
+			t.Errorf("Expected [team-a], got %v", result)
+		}
+	})
+
+	t.Run("maximum valid groups", func(t *testing.T) {
+		groups := make([]string, 100)
+		for i := range groups {
+			groups[i] = "team-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		}
+		result := ValidateAndNormalizeGroups(groups, GroupFilterConfig{}, logger)
+		if len(result) != 100 {
+			t.Errorf("Expected 100 groups, got %d", len(result))
+		}
+	})
+}
+
+// TestRegexCompiledOnce verifies regex is compiled at package level
+func TestRegexCompiledOnce(t *testing.T) {
+	// This test verifies the regex pattern exists as a package variable
+	if validGroupNamePattern == nil {
+		t.Error("validGroupNamePattern should be compiled at package level")
+	}
+
+	// Verify it's the same instance on multiple calls
+	err1 := validateGroupName("test-group")
+	err2 := validateGroupName("test-group")
+
+	if err1 != nil || err2 != nil {
+		t.Error("Valid group names should pass validation")
+	}
+}

--- a/src/ui/oidc.go
+++ b/src/ui/oidc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,13 +16,16 @@ import (
 )
 
 type OIDCConfig struct {
-	IssuerURL          string
-	ClientID           string
-	ClientSecret       string
-	RedirectURL        string
-	SessionSecret      string
-	InsecureSkipVerify bool
-	LogoutURL          string
+	IssuerURL           string
+	ClientID            string
+	ClientSecret        string
+	RedirectURL         string
+	SessionSecret       string
+	InsecureSkipVerify  bool
+	LogoutURL           string
+	AllowedGroupPrefix  string
+	AllowedGroupPattern string
+	AdditionalScopes    []string
 }
 
 type OIDCAuth struct {
@@ -32,6 +36,7 @@ type OIDCAuth struct {
 	httpClient         *http.Client
 	endSessionURL      string
 	postLogoutRedirect string
+	groupFilterConfig  GroupFilterConfig
 }
 
 func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, logger logr.Logger) (*OIDCAuth, error) {
@@ -53,12 +58,31 @@ func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, logger logr.Logger) (*OIDC
 		return nil, fmt.Errorf("failed to create OIDC provider: %w", err)
 	}
 
+	scopes := buildOIDCScopes(cfg.AdditionalScopes)
+	if len(cfg.AdditionalScopes) > 0 {
+		logger.Info("requesting additional OIDC scopes", "scopes", cfg.AdditionalScopes)
+	}
+
+	if cfg.AllowedGroupPrefix != "" || cfg.AllowedGroupPattern != "" {
+		hasGroupsScope := false
+		for _, s := range scopes {
+			if s == "groups" {
+				hasGroupsScope = true
+				break
+			}
+		}
+		if !hasGroupsScope {
+			logger.Info("WARNING: group filtering is configured but 'groups' is not in additionalScopes. " +
+				"If your OIDC provider requires the 'groups' scope to include group claims, add it to additionalScopes.")
+		}
+	}
+
 	oauth2Cfg := oauth2.Config{
 		ClientID:     cfg.ClientID,
 		ClientSecret: cfg.ClientSecret,
 		RedirectURL:  cfg.RedirectURL,
 		Endpoint:     provider.Endpoint(),
-		Scopes:       []string{oidc.ScopeOpenID, "email", "profile"},
+		Scopes:       scopes,
 	}
 
 	verifier := provider.Verifier(&oidc.Config{ClientID: cfg.ClientID})
@@ -86,6 +110,17 @@ func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, logger logr.Logger) (*OIDC
 		return nil, err
 	}
 
+	// Parse group filter pattern if provided
+	var groupFilterConfig GroupFilterConfig
+	groupFilterConfig.AllowedPrefix = cfg.AllowedGroupPrefix
+	if cfg.AllowedGroupPattern != "" {
+		pattern, err := regexp.Compile(cfg.AllowedGroupPattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid group pattern regex: %w", err)
+		}
+		groupFilterConfig.AllowedPattern = pattern
+	}
+
 	return &OIDCAuth{
 		baseAuth:           baseAuth{encryptionKey: key, logger: logger},
 		provider:           provider,
@@ -94,6 +129,7 @@ func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, logger logr.Logger) (*OIDC
 		httpClient:         httpClient,
 		endSessionURL:      endSessionURL,
 		postLogoutRedirect: postLogoutRedirect,
+		groupFilterConfig:  groupFilterConfig,
 	}, nil
 }
 
@@ -143,8 +179,9 @@ func (o *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var claims struct {
-		Email string `json:"email"`
-		Name  string `json:"name"`
+		Email  string   `json:"email"`
+		Name   string   `json:"name"`
+		Groups []string `json:"groups,omitempty"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		o.logger.Error(err, "failed to parse claims")
@@ -152,7 +189,24 @@ func (o *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	completeURL, err := o.buildCompleteURL(claims.Email, claims.Name)
+	// Log received groups for debugging
+	o.logger.V(1).Info("OIDC claims received",
+		"user", claims.Email,
+		"name", claims.Name,
+		"groups", claims.Groups)
+
+	// Apply 3-layer group validation
+	validatedGroups := ValidateAndNormalizeGroups(claims.Groups, o.groupFilterConfig, o.logger)
+
+	if len(claims.Groups) > 0 && len(validatedGroups) == 0 {
+		o.logger.Info("WARNING: User authenticated but all groups filtered out",
+			"user", claims.Email,
+			"original_groups", claims.Groups)
+	}
+
+	completeURL, err := o.buildCompleteURL(claims.Email, claims.Name, func(s *sessionData) {
+		s.Groups = validatedGroups
+	})
 	if err != nil {
 		o.logger.Error(err, "failed to build complete URL")
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -183,4 +237,25 @@ func (o *OIDCAuth) HandleLogout(w http.ResponseWriter, r *http.Request) {
 
 func (o *OIDCAuth) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
 	o.handleAuthStatus(w, r)
+}
+
+func (o *OIDCAuth) SupportsGroups() bool {
+	return true
+}
+
+// buildOIDCScopes returns the base OIDC scopes plus any additional scopes, deduplicated.
+func buildOIDCScopes(additionalScopes []string) []string {
+	seen := map[string]struct{}{
+		oidc.ScopeOpenID: {},
+		"email":          {},
+		"profile":        {},
+	}
+	scopes := []string{oidc.ScopeOpenID, "email", "profile"}
+	for _, s := range additionalScopes {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			scopes = append(scopes, s)
+		}
+	}
+	return scopes
 }

--- a/src/ui/oidc_test.go
+++ b/src/ui/oidc_test.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestBuildOIDCScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		additional []string
+		want       []string
+	}{
+		{
+			name:       "no additional scopes",
+			additional: nil,
+			want:       []string{"openid", "email", "profile"},
+		},
+		{
+			name:       "empty slice",
+			additional: []string{},
+			want:       []string{"openid", "email", "profile"},
+		},
+		{
+			name:       "single additional scope",
+			additional: []string{"groups"},
+			want:       []string{"openid", "email", "profile", "groups"},
+		},
+		{
+			name:       "multiple additional scopes",
+			additional: []string{"groups", "roles"},
+			want:       []string{"openid", "email", "profile", "groups", "roles"},
+		},
+		{
+			name:       "duplicate of base scope is deduplicated",
+			additional: []string{"openid"},
+			want:       []string{"openid", "email", "profile"},
+		},
+		{
+			name:       "duplicate of email scope is deduplicated",
+			additional: []string{"email"},
+			want:       []string{"openid", "email", "profile"},
+		},
+		{
+			name:       "duplicate within additional scopes",
+			additional: []string{"groups", "groups"},
+			want:       []string{"openid", "email", "profile", "groups"},
+		},
+		{
+			name:       "mix of duplicates and new scopes",
+			additional: []string{"openid", "groups", "email", "roles", "groups"},
+			want:       []string{"openid", "email", "profile", "groups", "roles"},
+		},
+		{
+			name:       "offline_access scope",
+			additional: []string{"offline_access"},
+			want:       []string{"openid", "email", "profile", "offline_access"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildOIDCScopes(tt.additional)
+			if len(result) != len(tt.want) {
+				t.Errorf("buildOIDCScopes() returned %d scopes, want %d\nGot:  %v\nWant: %v",
+					len(result), len(tt.want), result, tt.want)
+				return
+			}
+			for i := range result {
+				if result[i] != tt.want[i] {
+					t.Errorf("buildOIDCScopes()[%d] = %q, want %q", i, result[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -30,6 +30,178 @@ type ExecutionOptions struct {
 	Debug bool `json:"debug,omitempty"`
 }
 
+// filterRenovateJobsByGroups filters jobs based on user groups and job's allowedGroups.
+// Authorization rules:
+// - When auth is disabled (authEnabled == false): all jobs visible
+// - When auth is enabled (authEnabled == true):
+//   - Jobs without allowedGroups use defaultAllowedGroups (from operator config)
+//   - If defaultAllowedGroups is also empty, job is HIDDEN (secure by default)
+//   - Jobs with allowedGroups shown only if user has at least one matching group
+//   - Users without groups see no jobs
+//   - If session is nil (edge case/bug), return empty list for security
+func filterRenovateJobsByGroups(jobs []api.RenovateJob, authEnabled bool, session *sessionData, defaultAllowedGroups []string) []api.RenovateJob {
+	// If auth is disabled, return all jobs
+	if !authEnabled {
+		return jobs
+	}
+
+	// If auth is enabled but no session, return empty for security (defense in depth)
+	if session == nil {
+		return []api.RenovateJob{}
+	}
+
+	userGroups := session.Groups
+	if userGroups == nil {
+		userGroups = []string{}
+	}
+
+	filtered := make([]api.RenovateJob, 0, len(jobs))
+	for _, job := range jobs {
+		// Determine effective allowed groups for this job
+		effectiveAllowedGroups := normalizeGroups(job.Spec.AllowedGroups)
+		if len(effectiveAllowedGroups) == 0 {
+			// Use default groups if job has no explicit allowedGroups
+			effectiveAllowedGroups = defaultAllowedGroups
+		}
+
+		// If no effective groups (neither job-specific nor defaults), hide the job
+		if len(effectiveAllowedGroups) == 0 {
+			continue
+		}
+
+		// Check if user has any matching group
+		if hasIntersection(userGroups, effectiveAllowedGroups) {
+			filtered = append(filtered, job)
+		}
+	}
+	return filtered
+}
+
+// hasIntersection returns true if there's at least one common element between two string slices.
+// Uses a map for O(n+m) performance, optimized for scenarios with large group lists.
+func hasIntersection(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+
+	// Use the smaller slice for the map to reduce memory
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+
+	set := make(map[string]struct{}, len(a))
+	for _, item := range a {
+		set[item] = struct{}{}
+	}
+
+	for _, item := range b {
+		if _, exists := set[item]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+// authorizeAndGetJob checks authorization and returns the job if authorized.
+// Returns (job, true) if authorized, (nil, false) otherwise.
+// This avoids duplicate K8s API calls by returning the job for reuse.
+func (s *Server) authorizeAndGetJob(r *http.Request, namespace, jobName string) (*api.RenovateJob, bool) {
+	// If auth is disabled, fetch and return the job
+	if s.auth == nil {
+		job, err := s.manager.GetRenovateJob(r.Context(), jobName, namespace)
+		if err != nil || job == nil {
+			return nil, false
+		}
+		return job, true
+	}
+
+	// Get session from context
+	session := getSessionFromContext(r)
+	if session == nil {
+		// Auth enabled but no session - deny access (should not happen due to middleware)
+		s.logger.Info("Authorization denied: no session in context",
+			"action", "job_access",
+			"resource", jobName,
+			"namespace", namespace,
+			"path", r.URL.Path,
+			"remote_addr", r.RemoteAddr)
+		return nil, false
+	}
+
+	// Get the job
+	job, err := s.manager.GetRenovateJob(r.Context(), jobName, namespace)
+	if err != nil || job == nil {
+		// Return false for both "not found" and "error" to prevent information disclosure
+		s.logger.V(1).Info("Authorization check: job not found or error",
+			"user", session.Email,
+			"resource", jobName,
+			"namespace", namespace,
+			"error", err)
+		return nil, false
+	}
+
+	// Determine effective allowed groups for this job
+	effectiveAllowedGroups := normalizeGroups(job.Spec.AllowedGroups)
+	if len(effectiveAllowedGroups) == 0 {
+		// Use default groups if job has no explicit allowedGroups
+		effectiveAllowedGroups = s.defaultAllowedGroups
+	}
+
+	// If no effective groups (neither job-specific nor defaults), deny access
+	if len(effectiveAllowedGroups) == 0 {
+		s.logger.Info("Authorization denied: job has no allowed groups",
+			"user", session.Email,
+			"user_groups", session.Groups,
+			"resource", jobName,
+			"namespace", namespace,
+			"path", r.URL.Path,
+			"remote_addr", r.RemoteAddr)
+		return nil, false
+	}
+
+	// Check if user has any matching group
+	userGroups := session.Groups
+	if userGroups == nil {
+		userGroups = []string{}
+	}
+
+	authorized := hasIntersection(userGroups, effectiveAllowedGroups)
+
+	// Audit log the authorization decision
+	if authorized {
+		s.logger.V(1).Info("Authorization granted",
+			"user", session.Email,
+			"user_groups", session.Groups,
+			"resource", jobName,
+			"namespace", namespace,
+			"allowed_groups", effectiveAllowedGroups,
+			"path", r.URL.Path,
+			"method", r.Method,
+			"remote_addr", r.RemoteAddr)
+		return job, true
+	}
+
+	s.logger.Info("Authorization denied: no matching groups",
+		"user", session.Email,
+		"user_groups", session.Groups,
+		"resource", jobName,
+		"namespace", namespace,
+		"allowed_groups", effectiveAllowedGroups,
+		"path", r.URL.Path,
+		"method", r.Method,
+		"remote_addr", r.RemoteAddr)
+
+	return nil, false
+}
+
+// authorizeJobAccess checks if the current user is authorized to access the given RenovateJob.
+// Returns true if authorized, false otherwise. Includes comprehensive audit logging.
+// For endpoints that need the job after authorization, use authorizeAndGetJob to avoid duplicate fetches.
+func (s *Server) authorizeJobAccess(r *http.Request, namespace, jobName string) bool {
+	_, authorized := s.authorizeAndGetJob(r, namespace, jobName)
+	return authorized
+}
+
 func (s *Server) registerApiV1Routes(router *mux.Router) {
 	apiV1 := router.PathPrefix("/api/v1").Subrouter()
 	apiV1.HandleFunc("/version", s.getVersion).Methods("GET")
@@ -56,6 +228,12 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 		internalServerError(w, err, "failed to load renovatejobs")
 		return
 	}
+
+	// Filter jobs based on user's groups
+	authEnabled := s.auth != nil
+	session := getSessionFromContext(r)
+	renovateJobs = filterRenovateJobsByGroups(renovateJobs, authEnabled, session, s.defaultAllowedGroups)
+
 	result := make([]RenovateJobInfo, 0)
 	for i := range renovateJobs {
 		renovateJob := &renovateJobs[i]
@@ -102,10 +280,17 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result)
 }
+
 func (s *Server) getRenovateJobLogs(w http.ResponseWriter, r *http.Request) {
 	namespace := r.URL.Query().Get("namespace")
 	renovate := r.URL.Query().Get("renovate")
 	project := r.URL.Query().Get("project")
+
+	// Authorization check
+	if !s.authorizeJobAccess(r, namespace, renovate) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
 
 	logs, err := s.manager.GetLogsForProject(
 		r.Context(),
@@ -128,7 +313,8 @@ func getRenovateJsonBody(r *http.Request) (*struct {
 	name      string
 	namespace string
 	project   string
-}, error) {
+}, error,
+) {
 	var renovateJob, namespace, project string
 	if r.Header.Get("Content-Type") == "application/json" {
 		var params struct {
@@ -176,6 +362,12 @@ func (s *Server) runRenovateForProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Authorization check
+	if !s.authorizeJobAccess(r, params.namespace, params.name) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
 	err = s.manager.UpdateProjectStatus(
 		r.Context(),
 		params.project,
@@ -209,13 +401,19 @@ func (s *Server) runDiscoveryForProject(w http.ResponseWriter, r *http.Request) 
 		badRequestError(w, err, "missing parameters")
 		return
 	}
-	ctx := r.Context()
 
-	job, err := s.manager.GetRenovateJob(ctx, params.name, params.namespace)
-	if err != nil || job == nil {
-		internalServerError(w, err, "failed to get renovate job")
+	// Authorization check (returns job to avoid duplicate K8s API call)
+	job, authorized := s.authorizeAndGetJob(r, params.namespace, params.name)
+	if !authorized {
+		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
+	if job == nil {
+		internalServerError(w, nil, "failed to get renovate job")
+		return
+	}
+
+	ctx := r.Context()
 	// discovery mus only run once
 	status, err := s.discovery.GetDiscoveryJobStatus(ctx, job, "")
 	if err == nil && status == api.JobStatusRunning {
@@ -293,9 +491,14 @@ func (s *Server) discoveryStatusForProject(w http.ResponseWriter, r *http.Reques
 	namespace := r.URL.Query().Get("namespace")
 	renovate := r.URL.Query().Get("renovate")
 
-	job, err := s.manager.GetRenovateJob(ctx, renovate, namespace)
-	if err != nil || job == nil {
-		internalServerError(w, err, "failed to get renovate job")
+	// Authorization check (returns job to avoid duplicate K8s API call)
+	job, authorized := s.authorizeAndGetJob(r, namespace, renovate)
+	if !authorized {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	if job == nil {
+		internalServerError(w, nil, "failed to get renovate job")
 		return
 	}
 	status, err := s.discovery.GetDiscoveryJobStatus(ctx, job, "")
@@ -306,7 +509,6 @@ func (s *Server) discoveryStatusForProject(w http.ResponseWriter, r *http.Reques
 			internalServerError(w, err, "failed to get discovery job status")
 			return
 		}
-
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -10,6 +10,7 @@ import (
 	crdmanager "renovate-operator/internal/crdManager"
 	"renovate-operator/internal/types"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -154,6 +155,9 @@ func TestGetRenovateJobLogs_Success(t *testing.T) {
 		getLogsForProjectFunc: func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier, project string) (string, error) {
 			return "test logs", nil
 		},
+		getRenovateJobFunc: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+			return &api.RenovateJob{}, nil
+		},
 	}
 
 	server := &Server{
@@ -220,6 +224,9 @@ func TestRunRenovateForProject_Success(t *testing.T) {
 	mockManager := &mockRenovateJobManager{
 		updateProjectStatusFunc: func(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
 			return nil
+		},
+		getRenovateJobFunc: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+			return &api.RenovateJob{}, nil
 		},
 	}
 
@@ -400,5 +407,503 @@ func TestRunDiscoveryForProject_AlreadyRunning(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+// Additional mock types needed for authorization tests
+type mockScheduler struct{}
+
+func (m *mockScheduler) Start()                                                {}
+func (m *mockScheduler) Stop()                                                 {}
+func (m *mockScheduler) AddSchedule(expr string, name string, fn func()) error { return nil }
+func (m *mockScheduler) AddScheduleReplaceExisting(expr string, name string, fn func()) error {
+	return nil
+}
+func (m *mockScheduler) RemoveSchedule(name string) {}
+func (m *mockScheduler) GetNextRunOnSchedule(schedule string) time.Time {
+	return time.Now().Add(24 * time.Hour)
+}
+
+func TestFilterRenovateJobsByGroups(t *testing.T) {
+	tests := []struct {
+		name        string
+		jobs        []api.RenovateJob
+		authEnabled bool
+		session     *sessionData
+		wantLen     int
+		wantJobs    []string // job names expected in result
+	}{
+		{
+			name: "auth disabled - all jobs visible",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "job2"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-b"}}},
+			},
+			authEnabled: false,
+			session:     nil,
+			wantLen:     2,
+			wantJobs:    []string{"job1", "job2"},
+		},
+		{
+			name: "auth enabled but no session - empty list (security)",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a"}}},
+			},
+			authEnabled: true,
+			session:     nil,
+			wantLen:     0,
+			wantJobs:    []string{},
+		},
+		{
+			name: "user with matching group sees job",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a"}}},
+			},
+			authEnabled: true,
+			session:     &sessionData{Groups: []string{"team-a"}},
+			wantLen:     1,
+			wantJobs:    []string{"job1"},
+		},
+		{
+			name: "user without matching group sees nothing",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a"}}},
+			},
+			authEnabled: true,
+			session:     &sessionData{Groups: []string{"team-b"}},
+			wantLen:     0,
+			wantJobs:    []string{},
+		},
+		{
+			name: "user with no groups sees nothing",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a"}}},
+			},
+			authEnabled: true,
+			session:     &sessionData{Groups: nil},
+			wantLen:     0,
+			wantJobs:    []string{},
+		},
+		{
+			name: "job without allowedGroups hidden from all users",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: nil}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "job2"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{}}},
+			},
+			authEnabled: true,
+			session:     &sessionData{Groups: []string{"team-a"}},
+			wantLen:     0,
+			wantJobs:    []string{},
+		},
+		{
+			name: "user with multiple groups sees all matching jobs",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "job2"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-b"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "job3"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-c"}}},
+			},
+			authEnabled: true,
+			session:     &sessionData{Groups: []string{"team-a", "team-b"}},
+			wantLen:     2,
+			wantJobs:    []string{"job1", "job2"},
+		},
+		{
+			name: "job with multiple groups matches any user group",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a", "team-b", "team-c"}}},
+			},
+			authEnabled: true,
+			session:     &sessionData{Groups: []string{"team-b"}},
+			wantLen:     1,
+			wantJobs:    []string{"job1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterRenovateJobsByGroups(tt.jobs, tt.authEnabled, tt.session, nil)
+			if len(result) != tt.wantLen {
+				t.Errorf("filterRenovateJobsByGroups() len = %v, want %v", len(result), tt.wantLen)
+			}
+			// Verify expected jobs are in result
+			for _, wantName := range tt.wantJobs {
+				found := false
+				for _, job := range result {
+					if job.Name == wantName {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected job %s not found in result", wantName)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterRenovateJobsByGroups_WithDefaults(t *testing.T) {
+	tests := []struct {
+		name                 string
+		jobs                 []api.RenovateJob
+		authEnabled          bool
+		session              *sessionData
+		defaultAllowedGroups []string
+		wantLen              int
+		wantJobs             []string
+	}{
+		{
+			name: "job without allowedGroups uses defaults - user has default group",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: nil}},
+			},
+			authEnabled:          true,
+			session:              &sessionData{Groups: []string{"default-team"}},
+			defaultAllowedGroups: []string{"default-team"},
+			wantLen:              1,
+			wantJobs:             []string{"job1"},
+		},
+		{
+			name: "job without allowedGroups uses defaults - user lacks default group",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: nil}},
+			},
+			authEnabled:          true,
+			session:              &sessionData{Groups: []string{"team-a"}},
+			defaultAllowedGroups: []string{"default-team"},
+			wantLen:              0,
+			wantJobs:             []string{},
+		},
+		{
+			name: "job with explicit allowedGroups ignores defaults",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a"}}},
+			},
+			authEnabled:          true,
+			session:              &sessionData{Groups: []string{"default-team"}},
+			defaultAllowedGroups: []string{"default-team"},
+			wantLen:              0,
+			wantJobs:             []string{},
+		},
+		{
+			name: "job without allowedGroups and no defaults - hidden",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: nil}},
+			},
+			authEnabled:          true,
+			session:              &sessionData{Groups: []string{"team-a"}},
+			defaultAllowedGroups: nil,
+			wantLen:              0,
+			wantJobs:             []string{},
+		},
+		{
+			name: "multiple defaults - user has one",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: nil}},
+			},
+			authEnabled:          true,
+			session:              &sessionData{Groups: []string{"team-b"}},
+			defaultAllowedGroups: []string{"team-a", "team-b", "team-c"},
+			wantLen:              1,
+			wantJobs:             []string{"job1"},
+		},
+		{
+			name: "mixed jobs - some with explicit groups, some using defaults",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: nil}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "job2"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{"team-a"}}},
+			},
+			authEnabled:          true,
+			session:              &sessionData{Groups: []string{"team-a"}},
+			defaultAllowedGroups: []string{"default-team"},
+			wantLen:              1,
+			wantJobs:             []string{"job2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterRenovateJobsByGroups(tt.jobs, tt.authEnabled, tt.session, tt.defaultAllowedGroups)
+			if len(result) != tt.wantLen {
+				t.Errorf("filterRenovateJobsByGroups() len = %v, want %v", len(result), tt.wantLen)
+			}
+			// Verify expected jobs are in result
+			for _, wantName := range tt.wantJobs {
+				found := false
+				for _, job := range result {
+					if job.Name == wantName {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected job %s not found in result", wantName)
+				}
+			}
+		})
+	}
+}
+
+func TestHasIntersection(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want bool
+	}{
+		{"both empty", []string{}, []string{}, false},
+		{"one empty", []string{"a"}, []string{}, false},
+		{"no intersection", []string{"a", "b"}, []string{"c", "d"}, false},
+		{"exact match", []string{"a"}, []string{"a"}, true},
+		{"partial intersection", []string{"a", "b", "c"}, []string{"c", "d"}, true},
+		{"subset", []string{"a"}, []string{"a", "b", "c"}, true},
+		{"nil slices", nil, nil, false},
+		{"one nil", []string{"a"}, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasIntersection(tt.a, tt.b); got != tt.want {
+				t.Errorf("hasIntersection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetRenovateJobs_WithAuthorization(t *testing.T) {
+	tests := []struct {
+		name          string
+		jobs          []api.RenovateJob
+		sessionGroups []string
+		authEnabled   bool
+		wantCount     int
+	}{
+		{
+			name: "authenticated user with matching group",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "0 0 * * *", AllowedGroups: []string{"team-a"}}},
+			},
+			sessionGroups: []string{"team-a"},
+			authEnabled:   true,
+			wantCount:     1,
+		},
+		{
+			name: "authenticated user without matching group",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "0 0 * * *", AllowedGroups: []string{"team-a"}}},
+			},
+			sessionGroups: []string{"team-b"},
+			authEnabled:   true,
+			wantCount:     0,
+		},
+		{
+			name: "auth disabled - all jobs visible",
+			jobs: []api.RenovateJob{
+				{ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "0 0 * * *", AllowedGroups: []string{"team-a"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "job2", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "0 0 * * *", AllowedGroups: []string{"team-b"}}},
+			},
+			sessionGroups: nil,
+			authEnabled:   false,
+			wantCount:     2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := &mockRenovateJobManager{
+				listRenovateJobsFullFunc: func(ctx context.Context) ([]api.RenovateJob, error) {
+					return tt.jobs, nil
+				},
+			}
+
+			server := &Server{
+				manager:   mockManager,
+				logger:    logr.Discard(),
+				discovery: &mockDiscoveryAgent{},
+				scheduler: &mockScheduler{},
+			}
+
+			if tt.authEnabled {
+				// Set a dummy auth provider to enable auth
+				server.auth = &OIDCAuth{}
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/renovatejobs", nil)
+
+			if tt.authEnabled && tt.sessionGroups != nil {
+				session := &sessionData{
+					Email:  "test@example.com",
+					Groups: tt.sessionGroups,
+				}
+				ctx := context.WithValue(req.Context(), sessionContextKey, session)
+				req = req.WithContext(ctx)
+			}
+
+			w := httptest.NewRecorder()
+			server.getRenovateJobs(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+			}
+
+			var result []RenovateJobInfo
+			if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			if len(result) != tt.wantCount {
+				t.Errorf("Expected %d jobs, got %d", tt.wantCount, len(result))
+			}
+		})
+	}
+}
+
+func TestGetRenovateJobLogs_Authorization(t *testing.T) {
+	tests := []struct {
+		name           string
+		job            *api.RenovateJob
+		userGroups     []string
+		authEnabled    bool
+		wantStatusCode int
+	}{
+		{
+			name: "authorized user can access logs",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-a"},
+			authEnabled:    true,
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "unauthorized user gets 403",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-b"},
+			authEnabled:    true,
+			wantStatusCode: http.StatusForbidden,
+		},
+		{
+			name: "auth disabled - all users can access",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-b"},
+			authEnabled:    false,
+			wantStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := &mockRenovateJobManager{
+				getRenovateJobFunc: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+					return tt.job, nil
+				},
+				getLogsForProjectFunc: func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier, project string) (string, error) {
+					return "test logs", nil
+				},
+			}
+
+			server := &Server{
+				manager: mockManager,
+				logger:  logr.Discard(),
+			}
+
+			if tt.authEnabled {
+				server.auth = &OIDCAuth{}
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/logs?namespace=default&renovate=job1&project=test", nil)
+
+			if tt.authEnabled {
+				session := &sessionData{
+					Email:  "test@example.com",
+					Groups: tt.userGroups,
+				}
+				ctx := context.WithValue(req.Context(), sessionContextKey, session)
+				req = req.WithContext(ctx)
+			}
+
+			w := httptest.NewRecorder()
+			server.getRenovateJobLogs(w, req)
+
+			if w.Code != tt.wantStatusCode {
+				t.Errorf("Expected status %d, got %d", tt.wantStatusCode, w.Code)
+			}
+		})
+	}
+}
+
+func TestAuthorizeJobAccess_DirectBypassAttempt(t *testing.T) {
+	// Test that users cannot bypass authorization by directly calling endpoints
+	// with correct namespace/job name but without proper group membership
+
+	job := &api.RenovateJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret-job", Namespace: "default"},
+		Spec:       api.RenovateJobSpec{AllowedGroups: []string{"admin"}},
+	}
+
+	mockManager := &mockRenovateJobManager{
+		getRenovateJobFunc: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+			return job, nil
+		},
+	}
+
+	server := &Server{
+		manager: mockManager,
+		logger:  logr.Discard(),
+		auth:    &OIDCAuth{}, // Auth enabled
+	}
+
+	// User with wrong group tries to access job by knowing its name
+	session := &sessionData{
+		Email:  "attacker@example.com",
+		Groups: []string{"regular-user"},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := context.WithValue(req.Context(), sessionContextKey, session)
+	req = req.WithContext(ctx)
+
+	authorized := server.authorizeJobAccess(req, "default", "secret-job")
+	if authorized {
+		t.Error("User should not be authorized to access job with different group")
+	}
+}
+
+// TestAuthorizeAndGetJobAvoidsDoubleFetch verifies we don't fetch jobs twice
+func TestAuthorizeAndGetJobAvoidsDoubleFetch(t *testing.T) {
+	fetchCount := 0
+	mockManager := &mockRenovateJobManager{
+		getRenovateJobFunc: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+			fetchCount++
+			return &api.RenovateJob{}, nil
+		},
+	}
+
+	server := &Server{
+		manager: mockManager,
+		logger:  logr.Discard(),
+		auth:    nil, // Auth disabled for simplicity
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// First call to authorizeAndGetJob
+	job, authorized := server.authorizeAndGetJob(req, "default", "job1")
+
+	if !authorized {
+		t.Error("Expected authorization to succeed")
+	}
+	if job == nil {
+		t.Error("Expected job to be returned")
+	}
+	if fetchCount != 1 {
+		t.Errorf("Expected GetRenovateJob to be called exactly once, got %d calls", fetchCount)
 	}
 }

--- a/src/ui/server.go
+++ b/src/ui/server.go
@@ -1,10 +1,10 @@
 package ui
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
-	"encoding/json"
 	"renovate-operator/assert"
 	"renovate-operator/config"
 	"renovate-operator/health"
@@ -17,25 +17,27 @@ import (
 )
 
 type Server struct {
-	manager   crdmanager.RenovateJobManager
-	discovery renovate.DiscoveryAgent
-	scheduler scheduler.Scheduler
-	logger    logr.Logger
-	server    *http.Server
-	health    health.HealthCheck
-	version   string
-	auth      AuthProvider
+	manager              crdmanager.RenovateJobManager
+	discovery            renovate.DiscoveryAgent
+	scheduler            scheduler.Scheduler
+	logger               logr.Logger
+	server               *http.Server
+	health               health.HealthCheck
+	version              string
+	auth                 AuthProvider
+	defaultAllowedGroups []string
 }
 
-func NewServer(manager crdmanager.RenovateJobManager, discovery renovate.DiscoveryAgent, scheduler scheduler.Scheduler, logger logr.Logger, health health.HealthCheck, version string, auth AuthProvider) *Server {
+func NewServer(manager crdmanager.RenovateJobManager, discovery renovate.DiscoveryAgent, scheduler scheduler.Scheduler, logger logr.Logger, health health.HealthCheck, version string, auth AuthProvider, defaultAllowedGroups []string) *Server {
 	return &Server{
-		manager:   manager,
-		logger:    logger,
-		health:    health,
-		discovery: discovery,
-		scheduler: scheduler,
-		version:   version,
-		auth:      auth,
+		manager:              manager,
+		logger:               logger,
+		health:               health,
+		discovery:            discovery,
+		scheduler:            scheduler,
+		version:              version,
+		auth:                 auth,
+		defaultAllowedGroups: defaultAllowedGroups,
 	}
 }
 


### PR DESCRIPTION
This PR adds authorization support to the OIDC authentication method. 

This enables administrators to define who can see which jobs based on:
* `defaultAllowedGroups`: groups which will be allowed to see and interact with all Renovate Jobs
* `allowedGroups` on the Renovatejob: group which will be allowed to see and interact with the Renovate Job

Additionally, given some (for example my job's) OIDC environments, we can easily have hundreds of groups, so I've added some filtering for the groups so only those relevant can be populated in Renovate Operator.

This change has not been implemented for GitHub for now, to keep the changes minimal. Let me know if this is something you would like though, and I'll be glad to add it.



