### PR TITLE
feat(ui): add trigger all button

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -646,6 +646,52 @@
           }
         };
 
+        const triggerAllRenovate = async (job) => {
+          if (job.triggeringAll) return;
+
+          setJobs((prev) =>
+            prev.map((j) =>
+              j.name === job.name && j.namespace === job.namespace
+                ? { ...j, triggeringAll: true }
+                : j
+            )
+          );
+
+          try {
+            const response = await authFetch("/api/v1/renovate/all", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                renovateJob: job.name,
+                namespace: job.namespace,
+              }),
+            });
+
+            if (response.ok) {
+              addToast(
+                "success",
+                "All Triggered",
+                `All projects triggered for ${job.name}`
+              );
+            } else {
+              const errorText = await response.text();
+              throw new Error(errorText || "Failed to trigger all projects");
+            }
+          } catch (err) {
+            console.error("Error triggering all projects:", err);
+            addToast("error", "Trigger All Failed", err.message);
+          } finally {
+            setJobs((prev) =>
+              prev.map((j) =>
+                j.name === job.name && j.namespace === job.namespace
+                  ? { ...j, triggeringAll: false }
+                  : j
+              )
+            );
+            loadJobs();
+          }
+        };
+
         const saveExecutionOptions = async (job, options) => {
           try {
             const response = await authFetch("/api/v1/executionOptions", {
@@ -839,6 +885,7 @@
                       job={job}
                       onRunDiscovery={runDiscovery}
                       onTriggerRenovate={triggerRenovate}
+                      onTriggerAllRenovate={triggerAllRenovate}
                       onSaveExecutionOptions={saveExecutionOptions}
                     />
                   ))}
@@ -953,7 +1000,7 @@
         return sortedProjects;
       };
 
-      function JobCard({ job, onRunDiscovery, onTriggerRenovate, onSaveExecutionOptions }) {
+      function JobCard({ job, onRunDiscovery, onTriggerRenovate, onTriggerAllRenovate, onSaveExecutionOptions }) {
         const [open, setOpen] = useState(true);
         const [sortConfig, setSortConfig] = useState({
           key: "status",
@@ -1194,6 +1241,37 @@
                   </svg>
                   <span>
                     {job.discoveryRunning ? "Running..." : "Run Discovery"}
+                  </span>
+                </button>
+
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onTriggerAllRenovate(job);
+                  }}
+                  disabled={job.triggeringAll || !job.projects || job.projects.length === 0}
+                  className="bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-2 sm:px-4 sm:py-2 rounded-lg font-semibold text-xs sm:text-sm shadow-sm hover:shadow-md active:scale-98 transition-all flex items-center justify-center gap-2"
+                  aria-label={
+                    job.triggeringAll
+                      ? "Triggering all projects"
+                      : `Trigger all projects for ${job.name}`
+                  }
+                >
+                  <svg
+                    className={`w-3 h-3 sm:w-4 sm:h-4 ${
+                      job.triggeringAll ? "animate-spin" : ""
+                    }`}
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  <span>
+                    {job.triggeringAll ? "Triggering..." : "Trigger All"}
                   </span>
                 </button>
               </div>

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -35,6 +35,7 @@ func (s *Server) registerApiV1Routes(router *mux.Router) {
 	apiV1.HandleFunc("/version", s.getVersion).Methods("GET")
 	apiV1.HandleFunc("/renovatejobs", s.getRenovateJobs).Methods("GET")
 	apiV1.HandleFunc("/renovate", s.runRenovateForProject).Methods("POST")
+	apiV1.HandleFunc("/renovate/all", s.runRenovateForAllProjects).Methods("POST")
 	apiV1.HandleFunc("/logs", s.getRenovateJobLogs).Methods("GET")
 	apiV1.HandleFunc("/discovery/start", s.runDiscoveryForProject).Methods("POST")
 	apiV1.HandleFunc("/discovery/status", s.discoveryStatusForProject).Methods("GET")
@@ -196,6 +197,44 @@ func (s *Server) runRenovateForProject(w http.ResponseWriter, r *http.Request) {
 
 	writeSuccess(w, SuccessResult{Message: "Renovate job triggered for project"})
 	s.logger.V(2).Info("Successfully triggered Renovate for project", "project", params.project, "renovateJob", params.name, "namespace", params.namespace, "priority", 2)
+}
+
+func (s *Server) runRenovateForAllProjects(w http.ResponseWriter, r *http.Request) {
+	params, err := getRenovateJsonBody(r)
+	if err != nil {
+		badRequestError(w, err, "failed to parse request body")
+		return
+	}
+
+	if params.name == "" || params.namespace == "" {
+		badRequestError(w, err, "Missing parameters")
+		return
+	}
+
+	jobIdentifier := crdmanager.RenovateJobIdentifier{
+		Name:      params.name,
+		Namespace: params.namespace,
+	}
+
+	err = s.manager.UpdateProjectStatusBatched(
+		r.Context(),
+		func(p api.ProjectStatus) bool {
+			return p.Status != api.JobStatusRunning && p.Status != api.JobStatusScheduled
+		},
+		jobIdentifier,
+		&types.RenovateStatusUpdate{
+			Status:   api.JobStatusScheduled,
+			Priority: 2,
+		},
+	)
+	if err != nil {
+		s.logger.Error(err, "Failed to trigger all projects", "renovateJob", params.name, "namespace", params.namespace)
+		internalServerError(w, err, "failed to trigger all projects")
+		return
+	}
+
+	writeSuccess(w, SuccessResult{Message: "All projects triggered"})
+	s.logger.V(2).Info("Successfully triggered all projects", "renovateJob", params.name, "namespace", params.namespace)
 }
 
 func (s *Server) runDiscoveryForProject(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Adds a **Trigger All** button next to **Run Discovery** in the job card header
- New `POST /api/v1/renovate/all` backend endpoint uses existing `UpdateProjectStatusBatched` to schedule all non-running/non-scheduled projects at once
- Button shows loading spinner while triggering and is disabled when no projects exist

Closes #200

## Test plan
- [ ] Open the UI and verify the Trigger All button appears next to Run Discovery
- [ ] Click Trigger All and verify all idle projects get scheduled
- [ ] Verify already running/scheduled projects are not re-triggered
- [ ] Verify the button is disabled while triggering is in progress
- [ ] Verify the button is disabled when a job has no projects