### PR TITLE
fix(crd): mark image as required field in RenovateJob spec

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -3885,6 +3885,7 @@ spec:
                 - enabled
                 type: object
             required:
+            - image
             - parallelism
             - provider
             - schedule

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -16,7 +16,7 @@ type RenovateJobSpec struct {
 	// Cron schedule in standard cron format
 	Schedule string `json:"schedule"`
 	// Renovate Docker image to use
-	Image string `json:"image,omitempty"`
+	Image string `json:"image"`
 	// Renovate Provider Information to fill "RENOVATE_ENDPOINT" and "RENOVATE_PLATFORM" environment variables in the renovate container
 	Provider *RenovateProvider `json:"provider"`
 	// Filter to select which projects to process


### PR DESCRIPTION
## Summary
- Mark `image` as a required field in the RenovateJob CRD spec, matching the behavior of `parallelism`, `provider`, and `schedule`
- Remove `omitempty` from the `Image` field in the Go struct and add `image` to the `required` list in the generated CRD YAML
- Users now get immediate API server validation errors instead of cryptic runtime failures when `image` is omitted

Closes #202

## Test plan
- [ ] Create a RenovateJob without the `image` field and verify the API server rejects it at admission time
- [ ] Create a RenovateJob with the `image` field and verify it is accepted and works as before