### PR TITLE
fix: add mutex to healthcheck to prevent concurrent map writes

### DIFF
--- a/src/health/health.go
+++ b/src/health/health.go
@@ -1,6 +1,10 @@
 package health
 
-import "time"
+import (
+	"maps"
+	"sync"
+	"time"
+)
 
 type SchedulerHealth struct {
 	Running   bool                             `json:"running"`
@@ -34,6 +38,7 @@ type HealthCheck interface {
 	SetSchedulerHealth(func(health *SchedulerHealth) *SchedulerHealth)
 }
 type healthcheck struct {
+	mu     sync.RWMutex
 	health *ApplicationHealth
 }
 
@@ -54,27 +59,36 @@ func NewHealthCheck() HealthCheck {
 }
 
 func (h *healthcheck) GetHealth() *ApplicationHealth {
-	return h.health
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	cp := *h.health
+	cp.Scheduler.Scheduler = maps.Clone(h.health.Scheduler.Scheduler)
+	cp.Executor.Executor = maps.Clone(h.health.Executor.Executor)
+	return &cp
 }
 
 func (h *healthcheck) SetExecutorHealth(fn func(health *ExecutorHealth) *ExecutorHealth) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	e := *fn(&h.health.Executor)
 	lastUpdate := time.Now()
 	for key := range e.Executor {
-		s := e.Executor[key]
-		s.LastUpdate = lastUpdate
-		e.Executor[key] = s
+		entry := e.Executor[key]
+		entry.LastUpdate = lastUpdate
+		e.Executor[key] = entry
 	}
 	h.health.Executor = e
 }
 
 func (h *healthcheck) SetSchedulerHealth(fn func(health *SchedulerHealth) *SchedulerHealth) {
-	e := *fn(&h.health.Scheduler)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	s := *fn(&h.health.Scheduler)
 	lastUpdate := time.Now()
-	for key := range e.Scheduler {
-		s := e.Scheduler[key]
-		s.LastUpdate = lastUpdate
-		e.Scheduler[key] = s
+	for key := range s.Scheduler {
+		entry := s.Scheduler[key]
+		entry.LastUpdate = lastUpdate
+		s.Scheduler[key] = entry
 	}
-	h.health.Scheduler = e
+	h.health.Scheduler = s
 }

--- a/src/health/health_test.go
+++ b/src/health/health_test.go
@@ -1,6 +1,8 @@
 package health
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 )
 
@@ -24,4 +26,102 @@ func TestSetSchedulerHealth(t *testing.T) {
 	if !h.GetHealth().Scheduler.Running {
 		t.Error("Scheduler health not set to running")
 	}
+}
+
+func TestConcurrentSchedulerHealthWrites(t *testing.T) {
+	h := NewHealthCheck()
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	for i := range n {
+		go func(id int) {
+			defer wg.Done()
+			h.SetSchedulerHealth(func(s *SchedulerHealth) *SchedulerHealth {
+				s.Scheduler[fmt.Sprintf("repo-%d", id)] = SingleSchedulerHealth{
+					Name:      fmt.Sprintf("repo-%d", id),
+					Schedule:  "* * * * *",
+					IsRunning: true,
+				}
+				return s
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	health := h.GetHealth()
+	if len(health.Scheduler.Scheduler) != n {
+		t.Errorf("expected %d scheduler entries, got %d", n, len(health.Scheduler.Scheduler))
+	}
+}
+
+func TestConcurrentExecutorHealthWrites(t *testing.T) {
+	h := NewHealthCheck()
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	for i := range n {
+		go func(id int) {
+			defer wg.Done()
+			h.SetExecutorHealth(func(e *ExecutorHealth) *ExecutorHealth {
+				e.Executor[fmt.Sprintf("exec-%d", id)] = SingleExecutorHealth{
+					IsRunning: true,
+				}
+				return e
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	health := h.GetHealth()
+	if len(health.Executor.Executor) != n {
+		t.Errorf("expected %d executor entries, got %d", n, len(health.Executor.Executor))
+	}
+}
+
+func TestConcurrentReadWrite(t *testing.T) {
+	h := NewHealthCheck()
+
+	var wg sync.WaitGroup
+	wg.Add(300)
+
+	for i := range 100 {
+		go func(id int) {
+			defer wg.Done()
+			h.SetSchedulerHealth(func(s *SchedulerHealth) *SchedulerHealth {
+				s.Scheduler[fmt.Sprintf("repo-%d", id)] = SingleSchedulerHealth{
+					Name:      fmt.Sprintf("repo-%d", id),
+					IsRunning: true,
+				}
+				return s
+			})
+		}(i)
+
+		go func(id int) {
+			defer wg.Done()
+			h.SetExecutorHealth(func(e *ExecutorHealth) *ExecutorHealth {
+				e.Executor[fmt.Sprintf("exec-%d", id)] = SingleExecutorHealth{
+					IsRunning: true,
+				}
+				return e
+			})
+		}(i)
+
+		go func() {
+			defer wg.Done()
+			health := h.GetHealth()
+			// Iterate both maps like json.Encode would
+			for range health.Scheduler.Scheduler {
+			}
+			for range health.Executor.Executor {
+			}
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
The operator panics at runtime with:

```
fatal error: concurrent map writes

goroutine 234 [running]:
internal/runtime/maps.fatal({0x1dc4e81?, 0x104e5e5ddee0?})
        runtime/panic.go:1181 +0x18
renovate-operator/health.(*healthcheck).SetSchedulerHealth(0x104e5e4e0348, 0x425b2c?)
        renovate-operator/health/health.go:77 +0x1a5
renovate-operator/scheduler.(*scheduler).execute.func1()
        renovate-operator/scheduler/scheduler.go:141 +0xe2
github.com/netresearch/go-cron.FuncJob.Run(0x2f9b280?)
        github.com/netresearch/go-cron@v0.13.1/cron.go:528 +0x12
github.com/netresearch/go-cron.(*Cron).startJobWithExecution.func1.1(0x428513?, {0x1f39320?, 0x104e60d482c0?}, {0x1f4f3b0?, 0x104e60d0ec30?})
        github.com/netresearch/go-cron@v0.13.1/cron.go:1306 +0x8d
github.com/netresearch/go-cron.(*Cron).startJobWithExecution.func1()
        github.com/netresearch/go-cron@v0.13.1/cron.go:1308 +0x18b
created by github.com/netresearch/go-cron.(*Cron).startJobWithExecution in goroutine 136
        github.com/netresearch/go-cron@v0.13.1/cron.go:1290 +0x20c
```

  The healthcheck struct in health/health.go holds an *ApplicationHealth containing map[string]SingleSchedulerHealth and map[string]SingleExecutorHealth. 

Multiple cron goroutines call SetSchedulerHealth concurrently (via scheduler.execute()), all writing to the same underlying map with no synchronization.

The same race exists between SetExecutorHealth calls and between GetHealth reads (HTTP handler) and any concurrent write.

In this PR we: 
  - Add a sync.RWMutex to the healthcheck struct
  - SetSchedulerHealth / SetExecutorHealth: acquire exclusive Lock around the entire method body
  - GetHealth: acquire RLock and return a deep copy of ApplicationHealth using maps.Clone, so no map reference escapes the lock — preventing races when the HTTP handler iterates the maps via json.Encode
