### PR TITLE
feat: add optional userinfo endpoint group fetching for OIDC

### DIFF
--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -148,6 +148,10 @@ spec:
             - name: OIDC_ADDITIONAL_SCOPES
               value: {{ .Values.auth.oidc.additionalScopes | join "," | quote }}
             {{- end }}
+            {{- if .Values.auth.oidc.fetchUserInfoGroups }}
+            - name: OIDC_FETCH_USERINFO_GROUPS
+              value: "true"
+            {{- end }}
             {{- else if .Values.auth.github.enabled }}
             - name: GITHUB_CLIENT_ID
               value: {{ .Values.auth.github.clientId | quote }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -171,6 +171,8 @@ auth:
     allowedGroupPattern: ""
     # -- optional: additional OIDC scopes to request (e.g., "groups" for Keycloak)
     additionalScopes: []
+    # -- optional: fetch groups from the OIDC userinfo endpoint and merge with ID token groups (for providers that only expose groups via userinfo)
+    fetchUserInfoGroups: false
   github:
     # -- whether to enable GitHub OAuth authentication for the UI (mutually exclusive with OIDC)
     enabled: false

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -27,6 +27,7 @@ auth:
     allowedGroupPrefix: ""                     # Optional: only accept groups with this prefix
     allowedGroupPattern: ""                    # Optional: only accept groups matching this regex
     additionalScopes: []                        # Optional: extra OIDC scopes (e.g., ["groups"])
+    fetchUserInfoGroups: false                   # Optional: fetch groups from userinfo endpoint
 ```
 
 ### Secret
@@ -64,6 +65,18 @@ auth:
 ```
 
 **Azure AD / Entra ID**: Do **not** add `groups` here. Azure AD does not support `groups` as an OIDC scope and will reject the request with `AADSTS650053`. Instead, configure the `groups` claim in **App Registration → Token Configuration → Add groups claim**. The operator will read groups from the ID token regardless of whether the scope is requested.
+
+#### Userinfo Group Fetching
+
+Some OIDC providers (Keycloak, Auth0, custom setups) expose groups exclusively via the userinfo endpoint rather than in the ID token. To fetch groups from the userinfo endpoint and merge them with any ID token groups:
+
+```yaml
+auth:
+  oidc:
+    fetchUserInfoGroups: true
+```
+
+When enabled, the operator makes an additional HTTP call to the provider's userinfo endpoint during login. Groups from both sources are deduplicated and merged before validation. Userinfo failures are treated as hard errors and will block login.
 
 ---
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -206,6 +206,11 @@ func main() {
 			Optional: true,
 			Default:  "",
 		},
+		{
+			Key:      "OIDC_FETCH_USERINFO_GROUPS",
+			Optional: true,
+			Default:  "false",
+		},
 	})
 	assert.NoError(err, "failed to initialize config module")
 
@@ -276,6 +281,7 @@ func main() {
 			AllowedGroupPrefix:  config.GetValue("OIDC_ALLOWED_GROUP_PREFIX"),
 			AllowedGroupPattern: config.GetValue("OIDC_ALLOWED_GROUP_PATTERN"),
 			AdditionalScopes:    splitAndTrim(config.GetValue("OIDC_ADDITIONAL_SCOPES"), ","),
+			FetchUserInfoGroups: config.GetValue("OIDC_FETCH_USERINFO_GROUPS") == "true",
 		}, ctrl.Log.WithName("oidc"))
 		assert.NoError(oidcErr, "failed to initialize OIDC provider")
 		authProvider = oidcAuth

--- a/src/ui/oidc.go
+++ b/src/ui/oidc.go
@@ -26,17 +26,19 @@ type OIDCConfig struct {
 	AllowedGroupPrefix  string
 	AllowedGroupPattern string
 	AdditionalScopes    []string
+	FetchUserInfoGroups bool
 }
 
 type OIDCAuth struct {
 	baseAuth
-	provider           *oidc.Provider
-	oauth2Config       oauth2.Config
-	verifier           *oidc.IDTokenVerifier
-	httpClient         *http.Client
-	endSessionURL      string
-	postLogoutRedirect string
-	groupFilterConfig  GroupFilterConfig
+	provider            *oidc.Provider
+	oauth2Config        oauth2.Config
+	verifier            *oidc.IDTokenVerifier
+	httpClient          *http.Client
+	endSessionURL       string
+	postLogoutRedirect  string
+	groupFilterConfig   GroupFilterConfig
+	fetchUserInfoGroups bool
 }
 
 func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, logger logr.Logger) (*OIDCAuth, error) {
@@ -121,15 +123,20 @@ func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, logger logr.Logger) (*OIDC
 		groupFilterConfig.AllowedPattern = pattern
 	}
 
+	if cfg.FetchUserInfoGroups {
+		logger.Info("OIDC userinfo group fetching enabled -- groups will be fetched from both ID token and userinfo endpoint; userinfo failures will block login")
+	}
+
 	return &OIDCAuth{
-		baseAuth:           baseAuth{encryptionKey: key, logger: logger},
-		provider:           provider,
-		oauth2Config:       oauth2Cfg,
-		verifier:           verifier,
-		httpClient:         httpClient,
-		endSessionURL:      endSessionURL,
-		postLogoutRedirect: postLogoutRedirect,
-		groupFilterConfig:  groupFilterConfig,
+		baseAuth:            baseAuth{encryptionKey: key, logger: logger},
+		provider:            provider,
+		oauth2Config:        oauth2Cfg,
+		verifier:            verifier,
+		httpClient:          httpClient,
+		endSessionURL:       endSessionURL,
+		postLogoutRedirect:  postLogoutRedirect,
+		groupFilterConfig:   groupFilterConfig,
+		fetchUserInfoGroups: cfg.FetchUserInfoGroups,
 	}, nil
 }
 
@@ -195,13 +202,41 @@ func (o *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		"name", claims.Name,
 		"groups", claims.Groups)
 
+	idTokenGroups := claims.Groups
+
+	if o.fetchUserInfoGroups {
+		o.logger.V(1).Info("fetching groups from userinfo endpoint", "user", claims.Email)
+		userInfoCtx, cancel := context.WithTimeout(exchangeCtx, 15*time.Second)
+		defer cancel()
+		userInfo, err := o.provider.UserInfo(userInfoCtx, oauth2.StaticTokenSource(oauth2Token))
+		if err != nil {
+			o.logger.Error(err, "failed to fetch userinfo")
+			http.Error(w, "failed to fetch userinfo", http.StatusInternalServerError)
+			return
+		}
+		var userInfoClaims struct {
+			Groups []string `json:"groups,omitempty"`
+		}
+		if err := userInfo.Claims(&userInfoClaims); err != nil {
+			o.logger.Error(err, "failed to parse userinfo claims")
+			http.Error(w, "failed to parse userinfo claims", http.StatusInternalServerError)
+			return
+		}
+		o.logger.V(1).Info("userinfo groups received",
+			"user", claims.Email,
+			"id_token_groups", claims.Groups,
+			"userinfo_groups", userInfoClaims.Groups)
+		claims.Groups = mergeGroups(claims.Groups, userInfoClaims.Groups)
+	}
+
 	// Apply 3-layer group validation
 	validatedGroups := ValidateAndNormalizeGroups(claims.Groups, o.groupFilterConfig, o.logger)
 
 	if len(claims.Groups) > 0 && len(validatedGroups) == 0 {
 		o.logger.Info("WARNING: User authenticated but all groups filtered out",
 			"user", claims.Email,
-			"original_groups", claims.Groups)
+			"id_token_groups", idTokenGroups,
+			"groups_before_validation", claims.Groups)
 	}
 
 	completeURL, err := o.buildCompleteURL(claims.Email, claims.Name, func(s *sessionData) {
@@ -241,6 +276,25 @@ func (o *OIDCAuth) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
 
 func (o *OIDCAuth) SupportsGroups() bool {
 	return true
+}
+
+// mergeGroups combines groups from the ID token and userinfo endpoint,
+// deduplicating entries so that the merged result doesn't inflate the
+// count before the downstream maxGroupsPerUser truncation.
+func mergeGroups(idTokenGroups, userInfoGroups []string) []string {
+	seen := make(map[string]struct{}, len(idTokenGroups))
+	merged := make([]string, 0, len(idTokenGroups)+len(userInfoGroups))
+	for _, g := range idTokenGroups {
+		seen[g] = struct{}{}
+		merged = append(merged, g)
+	}
+	for _, g := range userInfoGroups {
+		if _, ok := seen[g]; !ok {
+			seen[g] = struct{}{}
+			merged = append(merged, g)
+		}
+	}
+	return merged
 }
 
 // buildOIDCScopes returns the base OIDC scopes plus any additional scopes, deduplicated.

--- a/src/ui/oidc_test.go
+++ b/src/ui/oidc_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -69,6 +70,67 @@ func TestBuildOIDCScopes(t *testing.T) {
 				if result[i] != tt.want[i] {
 					t.Errorf("buildOIDCScopes()[%d] = %q, want %q", i, result[i], tt.want[i])
 				}
+			}
+		})
+	}
+}
+
+func TestMergeGroups(t *testing.T) {
+	tests := []struct {
+		name           string
+		idTokenGroups  []string
+		userInfoGroups []string
+		want           []string
+	}{
+		{
+			name:           "two non-empty slices",
+			idTokenGroups:  []string{"team-a", "team-b"},
+			userInfoGroups: []string{"team-c", "team-d"},
+			want:           []string{"team-a", "team-b", "team-c", "team-d"},
+		},
+		{
+			name:           "overlapping entries are deduplicated",
+			idTokenGroups:  []string{"team-a", "team-b"},
+			userInfoGroups: []string{"team-b", "team-c"},
+			want:           []string{"team-a", "team-b", "team-c"},
+		},
+		{
+			name:           "first empty",
+			idTokenGroups:  []string{},
+			userInfoGroups: []string{"team-a"},
+			want:           []string{"team-a"},
+		},
+		{
+			name:           "second empty",
+			idTokenGroups:  []string{"team-a"},
+			userInfoGroups: []string{},
+			want:           []string{"team-a"},
+		},
+		{
+			name:           "both empty",
+			idTokenGroups:  []string{},
+			userInfoGroups: []string{},
+			want:           []string{},
+		},
+		{
+			name:           "nil and non-empty",
+			idTokenGroups:  nil,
+			userInfoGroups: []string{"team-a"},
+			want:           []string{"team-a"},
+		},
+		{
+			name:           "both nil",
+			idTokenGroups:  nil,
+			userInfoGroups: nil,
+			want:           []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeGroups(tt.idTokenGroups, tt.userInfoGroups)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("mergeGroups() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Some OIDC providers (Keycloak, Auth0, custom setups) expose groups exclusively via the userinfo endpoint rather than in ID token claims. 

This PR adds an opt-in OIDC_FETCH_USERINFO_GROUPS env var that, when set to "true", fetches groups from the userinfo endpoint and merges them with ID token groups before validation.
