### PR TITLE
fix: if there are no groups provided the job counts as being authorized

### DIFF
--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -37,9 +37,9 @@ type ExecutionOptions struct {
 // - When auth is disabled (authEnabled == false): all jobs visible
 // - When auth is enabled (authEnabled == true):
 //   - Jobs without allowedGroups use defaultAllowedGroups (from operator config)
-//   - If defaultAllowedGroups is also empty, job is HIDDEN (secure by default)
+//   - If defaultAllowedGroups is also empty, job is visible to all authenticated users
 //   - Jobs with allowedGroups shown only if user has at least one matching group
-//   - Users without groups see no jobs
+//   - Users without groups see no jobs (unless the job has no group restrictions)
 //   - If session is nil (edge case/bug), return empty list for security
 func filterRenovateJobsByGroups(jobs []api.RenovateJob, authEnabled bool, session *sessionData, defaultAllowedGroups []string) []api.RenovateJob {
 	// If auth is disabled, return all jobs
@@ -66,8 +66,9 @@ func filterRenovateJobsByGroups(jobs []api.RenovateJob, authEnabled bool, sessio
 			effectiveAllowedGroups = defaultAllowedGroups
 		}
 
-		// If no effective groups (neither job-specific nor defaults), hide the job
+		// If no effective groups (neither job-specific nor defaults), job is visible to all authenticated users
 		if len(effectiveAllowedGroups) == 0 {
+			filtered = append(filtered, job)
 			continue
 		}
 
@@ -149,16 +150,15 @@ func (s *Server) authorizeAndGetJob(r *http.Request, namespace, jobName string) 
 		effectiveAllowedGroups = s.defaultAllowedGroups
 	}
 
-	// If no effective groups (neither job-specific nor defaults), deny access
+	// If no effective groups (neither job-specific nor defaults), job is visible to all authenticated users
 	if len(effectiveAllowedGroups) == 0 {
-		s.logger.Info("Authorization denied: job has no allowed groups",
+		s.logger.V(1).Info("Authorization granted: job has no group restrictions",
 			"user", session.Email,
-			"user_groups", session.Groups,
 			"resource", jobName,
 			"namespace", namespace,
 			"path", r.URL.Path,
 			"remote_addr", r.RemoteAddr)
-		return nil, false
+		return job, true
 	}
 
 	// Check if user has any matching group

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -522,15 +522,15 @@ func TestFilterRenovateJobsByGroups(t *testing.T) {
 			wantJobs:    []string{},
 		},
 		{
-			name: "job without allowedGroups hidden from all users",
+			name: "job without allowedGroups visible to all authenticated users",
 			jobs: []api.RenovateJob{
 				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: nil}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "job2"}, Spec: api.RenovateJobSpec{AllowedGroups: []string{}}},
 			},
 			authEnabled: true,
 			session:     &sessionData{Groups: []string{"team-a"}},
-			wantLen:     0,
-			wantJobs:    []string{},
+			wantLen:     2,
+			wantJobs:    []string{"job1", "job2"},
 		},
 		{
 			name: "user with multiple groups sees all matching jobs",
@@ -623,15 +623,15 @@ func TestFilterRenovateJobsByGroups_WithDefaults(t *testing.T) {
 			wantJobs:             []string{},
 		},
 		{
-			name: "job without allowedGroups and no defaults - hidden",
+			name: "job without allowedGroups and no defaults - visible to all authenticated users",
 			jobs: []api.RenovateJob{
 				{ObjectMeta: metav1.ObjectMeta{Name: "job1"}, Spec: api.RenovateJobSpec{AllowedGroups: nil}},
 			},
 			authEnabled:          true,
 			session:              &sessionData{Groups: []string{"team-a"}},
 			defaultAllowedGroups: nil,
-			wantLen:              0,
-			wantJobs:             []string{},
+			wantLen:              1,
+			wantJobs:             []string{"job1"},
 		},
 		{
 			name: "multiple defaults - user has one",


### PR DESCRIPTION
References: https://github.com/mogenius/renovate-operator/pull/178#issuecomment-4079978714 & https://github.com/mogenius/renovate-operator/pull/178#issuecomment-4080015777

Asking for Opinions here: What is the expected behaviour if the job does not provide groups? Is it authorized or not?