### PR TITLE
fix: add missing authorization checks to runRenovateForAllProjects and updateExecutionOptions

### DIFF
--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -424,6 +424,11 @@ func (s *Server) runRenovateForAllProjects(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if !s.authorizeJobAccess(r, params.namespace, params.name) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
 	jobIdentifier := crdmanager.RenovateJobIdentifier{
 		Name:      params.name,
 		Namespace: params.namespace,
@@ -519,6 +524,11 @@ func (s *Server) updateExecutionOptions(w http.ResponseWriter, r *http.Request) 
 	}
 	if params.RenovateJob == "" || params.Namespace == "" {
 		badRequestError(w, nil, "missing parameters")
+		return
+	}
+
+	if !s.authorizeJobAccess(r, params.Namespace, params.RenovateJob) {
+		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
 

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -944,3 +944,174 @@ func TestAuthorizeAndGetJobAvoidsDoubleFetch(t *testing.T) {
 		t.Errorf("Expected GetRenovateJob to be called exactly once, got %d calls", fetchCount)
 	}
 }
+
+func TestRunRenovateForAllProjects_Authorization(t *testing.T) {
+	tests := []struct {
+		name           string
+		job            *api.RenovateJob
+		userGroups     []string
+		authEnabled    bool
+		wantStatusCode int
+	}{
+		{
+			name: "authorized user can trigger all projects",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-a"},
+			authEnabled:    true,
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "unauthorized user gets 403",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-b"},
+			authEnabled:    true,
+			wantStatusCode: http.StatusForbidden,
+		},
+		{
+			name: "auth disabled - all users can trigger",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-b"},
+			authEnabled:    false,
+			wantStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := &mockRenovateJobManager{
+				getRenovateJobFunc: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+					return tt.job, nil
+				},
+			}
+
+			server := &Server{
+				manager: mockManager,
+				logger:  logr.Discard(),
+			}
+
+			if tt.authEnabled {
+				server.auth = &OIDCAuth{}
+			}
+
+			body := map[string]string{
+				"renovateJob": "job1",
+				"namespace":   "default",
+			}
+			jsonBody, _ := json.Marshal(body)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/renovate/all", bytes.NewReader(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			if tt.authEnabled {
+				session := &sessionData{
+					Email:  "test@example.com",
+					Groups: tt.userGroups,
+				}
+				ctx := context.WithValue(req.Context(), sessionContextKey, session)
+				req = req.WithContext(ctx)
+			}
+
+			w := httptest.NewRecorder()
+			server.runRenovateForAllProjects(w, req)
+
+			if w.Code != tt.wantStatusCode {
+				t.Errorf("Expected status %d, got %d", tt.wantStatusCode, w.Code)
+			}
+		})
+	}
+}
+
+func TestUpdateExecutionOptions_Authorization(t *testing.T) {
+	tests := []struct {
+		name           string
+		job            *api.RenovateJob
+		userGroups     []string
+		authEnabled    bool
+		wantStatusCode int
+	}{
+		{
+			name: "authorized user can update execution options",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-a"},
+			authEnabled:    true,
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "unauthorized user gets 403",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-b"},
+			authEnabled:    true,
+			wantStatusCode: http.StatusForbidden,
+		},
+		{
+			name: "auth disabled - all users can update",
+			job: &api.RenovateJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job1", Namespace: "default"},
+				Spec:       api.RenovateJobSpec{AllowedGroups: []string{"team-a"}},
+			},
+			userGroups:     []string{"team-b"},
+			authEnabled:    false,
+			wantStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockManager := &mockRenovateJobManager{
+				getRenovateJobFunc: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+					return tt.job, nil
+				},
+			}
+
+			server := &Server{
+				manager: mockManager,
+				logger:  logr.Discard(),
+			}
+
+			if tt.authEnabled {
+				server.auth = &OIDCAuth{}
+			}
+
+			body := map[string]interface{}{
+				"renovateJob": "job1",
+				"namespace":   "default",
+				"debug":       true,
+			}
+			jsonBody, _ := json.Marshal(body)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/executionOptions", bytes.NewReader(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			if tt.authEnabled {
+				session := &sessionData{
+					Email:  "test@example.com",
+					Groups: tt.userGroups,
+				}
+				ctx := context.WithValue(req.Context(), sessionContextKey, session)
+				req = req.WithContext(ctx)
+			}
+
+			w := httptest.NewRecorder()
+			server.updateExecutionOptions(w, req)
+
+			if w.Code != tt.wantStatusCode {
+				t.Errorf("Expected status %d, got %d", tt.wantStatusCode, w.Code)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Both endpoints were protected by global auth middleware but lacked job-level authorization, allowing any authenticated user to act on jobs their groups did not grant access to.