### PR TITLE
fix: respect RENOVATE_BASE_DIR env var in job args

### DIFF
--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -129,6 +129,8 @@ func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
 		envFromSecrets = append(envFromSecrets, job.Spec.ExtraEnvFrom...)
 	}
 
+	baseDir := getBaseDir(job.Spec.ExtraEnv)
+
 	volumes := []v1.Volume{
 		{
 			Name: "tmp",
@@ -145,6 +147,19 @@ func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
 		},
 	}
 
+	if baseDir != "/tmp" {
+		volumes = append(volumes, v1.Volume{
+			Name: "base-dir",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		})
+		volumeMounts = append(volumeMounts, v1.VolumeMount{
+			Name:      "base-dir",
+			MountPath: baseDir,
+		})
+	}
+
 	batchJob := &batchv1.Job{
 		Spec: batchv1.JobSpec{
 			ActiveDeadlineSeconds:   getJobTimeoutSeconds(),
@@ -159,7 +174,7 @@ func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
 						{
 							Name:            "renovate",
 							Command:         []string{"renovate"},
-							Args:            []string{"--base-dir", "/tmp", project},
+							Args:            []string{"--base-dir", baseDir, project},
 							Image:           job.Spec.Image,
 							Env:             mergeEnvVars(job.Spec.ExtraEnv, predefinedEnvVars),
 							EnvFrom:         envFromSecrets,
@@ -339,6 +354,17 @@ func getDNSPolicy(spec api.RenovateJobSpec) v1.DNSPolicy {
 	}
 
 	return v1.DNSClusterFirst
+}
+
+// getBaseDir returns the value of RENOVATE_BASE_DIR from the extra env vars,
+// falling back to /tmp if not set.
+func getBaseDir(extraEnv []v1.EnvVar) string {
+	for _, env := range extraEnv {
+		if env.Name == "RENOVATE_BASE_DIR" && env.Value != "" {
+			return env.Value
+		}
+	}
+	return "/tmp"
 }
 
 // mergeEnvVars combines extraEnv and predefinedEnv, giving priority to extraEnv


### PR DESCRIPTION
## Bug
https://github.com/mogenius/renovate-operator/issues/226 — Setting `RENOVATE_BASE_DIR` in a RenovateJob has no effect because the `--base-dir` CLI argument is hardcoded to `/tmp`, which always takes precedence over the environment variable.

## Fix
- Added a `getBaseDir` helper that checks the job's `ExtraEnv` for a `RENOVATE_BASE_DIR` entry
- Uses that value for the `--base-dir` argument instead of the hardcoded `/tmp`
- When a custom base dir is set, provisions an additional emptyDir volume and mount at that path so Renovate can write to it
- Falls back to `/tmp` when no `RENOVATE_BASE_DIR` is specified, preserving existing behavior

## Testing
- Verified the build compiles cleanly with `go build ./...`
- With `RENOVATE_BASE_DIR` unset: job args remain `--base-dir /tmp` (no behavior change)
- With `RENOVATE_BASE_DIR=/renovate`: job args become `--base-dir /renovate` with a matching volume mount

Happy to address any feedback.

Greetings, saschabuehrle