### PR TITLE
feat(chart): add priorityClassName support for operator deployment

### DIFF
--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -228,6 +228,8 @@ tolerations: []
 affinity: {}
 # -- topologySpreadConstraints for the operator pod
 topologySpreadConstraints: []
+# -- priorityClassName for the operator pod
+priorityClassName: ""
 
 serviceAccount:
   # -- name of the serviceaccount, if not set a name is generated using the fullname template


### PR DESCRIPTION
## Summary

- Add optional `priorityClassName` field to the operator Deployment pod spec
- Add corresponding `priorityClassName` value (default: `""`) in `values.yaml`

This allows users to set a [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) on the operator pod, which is commonly required by Kyverno/OPA policies enforcing pod scheduling standards.

## Usage

```yaml
priorityClassName: "high-priority"
```

## Changes

- `charts/renovate-operator/templates/deployment.yaml` — add `{{- with .Values.priorityClassName }}` block
- `charts/renovate-operator/values.yaml` — add `priorityClassName: ""` default