### PR TITLE
feat: show PR activity per run in operator UI

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -4013,6 +4013,48 @@ spec:
                       type: string
                     name:
                       type: string
+                    prActivity:
+                      description: PRActivity contains aggregate counts and individual
+                        details of PR activity from a run.
+                      properties:
+                        automerged:
+                          type: integer
+                        created:
+                          type: integer
+                        prs:
+                          items:
+                            description: PRDetail represents a single PR found in
+                              Renovate logs.
+                            properties:
+                              action:
+                                description: PRAction represents what happened to
+                                  a PR in a Renovate run.
+                                type: string
+                              branch:
+                                type: string
+                              number:
+                                type: integer
+                              title:
+                                type: string
+                              url:
+                                type: string
+                            required:
+                            - action
+                            - branch
+                            type: object
+                          type: array
+                        truncated:
+                          type: boolean
+                        unchanged:
+                          type: integer
+                        updated:
+                          type: integer
+                      required:
+                      - automerged
+                      - created
+                      - unchanged
+                      - updated
+                      type: object
                     priority:
                       format: int32
                       type: integer

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -126,6 +126,35 @@ type RenovateProvider struct {
 	Endpoint string `json:"endpoint,omitempty"`
 }
 
+// PRAction represents what happened to a PR in a Renovate run.
+type PRAction string
+
+const (
+	PRActionAutomerged PRAction = "automerged"
+	PRActionCreated    PRAction = "created"
+	PRActionUpdated    PRAction = "updated"
+	PRActionUnchanged  PRAction = "unchanged"
+)
+
+// PRDetail represents a single PR found in Renovate logs.
+type PRDetail struct {
+	Branch string   `json:"branch"`
+	Number int      `json:"number,omitempty"`
+	URL    string   `json:"url,omitempty"`
+	Title  string   `json:"title,omitempty"`
+	Action PRAction `json:"action"`
+}
+
+// PRActivity contains aggregate counts and individual details of PR activity from a run.
+type PRActivity struct {
+	Automerged int        `json:"automerged"`
+	Created    int        `json:"created"`
+	Updated    int        `json:"updated"`
+	Unchanged  int        `json:"unchanged"`
+	PRs        []PRDetail `json:"prs,omitempty"`
+	Truncated  bool       `json:"truncated,omitempty"`
+}
+
 /*
 Status of a single project within a RenovateJob
 */
@@ -136,6 +165,7 @@ type ProjectStatus struct {
 	Status               RenovateProjectStatus `json:"status"`
 	Priority             int32                 `json:"priority,omitempty"`
 	RenovateResultStatus *string               `json:"renovateResultStatus,omitempty"`
+	PRActivity           *PRActivity           `json:"prActivity,omitempty"`
 }
 
 type RenovateProjectStatus string
@@ -169,13 +199,47 @@ type RenovateJob struct {
 	Status RenovateJobStatus `json:"status,omitempty"`
 }
 
+// DeepCopyInto deep copies a RenovateJob into out.
+func (in *RenovateJob) DeepCopyInto(out *RenovateJob) {
+	*out = *in
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	// Deep copy Status.Projects (contains pointer and slice fields)
+	if in.Status.Projects != nil {
+		out.Status.Projects = make([]ProjectStatus, len(in.Status.Projects))
+		for i := range in.Status.Projects {
+			in.Status.Projects[i].DeepCopyInto(&out.Status.Projects[i])
+		}
+	}
+}
+
 func (in *RenovateJob) DeepCopyObject() runtime.Object {
 	if in == nil {
 		return nil
 	}
 	out := new(RenovateJob)
-	*out = *in
+	in.DeepCopyInto(out)
 	return out
+}
+
+// DeepCopyInto deep copies a ProjectStatus into out.
+func (in *ProjectStatus) DeepCopyInto(out *ProjectStatus) {
+	*out = *in
+	if in.Duration != nil {
+		out.Duration = new(string)
+		*out.Duration = *in.Duration
+	}
+	if in.RenovateResultStatus != nil {
+		out.RenovateResultStatus = new(string)
+		*out.RenovateResultStatus = *in.RenovateResultStatus
+	}
+	if in.PRActivity != nil {
+		out.PRActivity = new(PRActivity)
+		*out.PRActivity = *in.PRActivity
+		if in.PRActivity.PRs != nil {
+			out.PRActivity.PRs = make([]PRDetail, len(in.PRActivity.PRs))
+			copy(out.PRActivity.PRs, in.PRActivity.PRs)
+		}
+	}
 }
 
 // unique name for a renovatejob ${name}-${namespace}
@@ -195,6 +259,12 @@ func (in *RenovateJobList) DeepCopyObject() runtime.Object {
 	}
 	out := new(RenovateJobList)
 	*out = *in
+	if in.Items != nil {
+		out.Items = make([]RenovateJob, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
 	return out
 }
 

--- a/src/internal/crdManager/renovateJobManager.go
+++ b/src/internal/crdManager/renovateJobManager.go
@@ -82,6 +82,7 @@ type RenovateProjectStatus struct {
 	Priority             int32                     `json:"priority,omitempty"`
 	RenovateResultStatus *string                   `json:"renovateResultStatus,omitempty"`
 	Duration             *string                   `json:"duration,omitempty"`
+	PRActivity           *api.PRActivity           `json:"prActivity,omitempty"`
 }
 
 func NewRenovateJobManager(client client.Client, gitProviderClientFactory gitProviderClientFactory.GitProviderClientFactory, logger logr.Logger, ls logStore.LogStore) RenovateJobManager {
@@ -132,6 +133,7 @@ func (r *renovateJobManager) GetProjectsByStatus(ctx context.Context, job Renova
 				Priority:             project.Priority,
 				RenovateResultStatus: project.RenovateResultStatus,
 				Duration:             project.Duration,
+				PRActivity:           project.PRActivity,
 			})
 		}
 	}
@@ -154,6 +156,7 @@ func (r *renovateJobManager) GetProjectsForRenovateJob(ctx context.Context, job 
 			Priority:             project.Priority,
 			RenovateResultStatus: project.RenovateResultStatus,
 			Duration:             project.Duration,
+			PRActivity:           project.PRActivity,
 		})
 	}
 	return result, nil
@@ -307,25 +310,6 @@ func (r *renovateJobManager) ReconcileProjects(ctx context.Context, renovateJob 
 
 		_, err = updateRenovateJobStatus(ctx, renovateJob, r.client)
 		return err
-	})
-}
-
-func (r *renovateJobManager) UpdateProjectConfigStatus(ctx context.Context, project string, job RenovateJobIdentifier, status *string) error {
-	defer r.globalManagerLock(false)()
-
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		renovateJob, err := loadRenovateJob(ctx, job.Name, job.Namespace, r.client)
-		if err != nil {
-			return err
-		}
-		for i := range renovateJob.Status.Projects {
-			if renovateJob.Status.Projects[i].Name == project {
-				renovateJob.Status.Projects[i].RenovateResultStatus = status
-				_, err = updateRenovateJobStatus(ctx, renovateJob, r.client)
-				return err
-			}
-		}
-		return nil
 	})
 }
 

--- a/src/internal/parser/logParser.go
+++ b/src/internal/parser/logParser.go
@@ -3,18 +3,27 @@ package parser
 import (
 	"bufio"
 	"encoding/json"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
+
+	api "renovate-operator/api/v1alpha1"
 
 	"k8s.io/utils/ptr"
 )
 
-// LogParseResult contains the result of parsing Renovate logs
+// MaxPRDetails is the maximum number of individual PR details stored to prevent CRD bloat.
+const MaxPRDetails = 100
+
+// LogParseResult contains the result of parsing Renovate logs.
 type LogParseResult struct {
-	HasIssues            bool    // true if any WARN (level 40) or ERROR (level 50) found
-	RenovateResultStatus *string // nil = unknown, true = config found, false = no config (onboarding detected)
+	HasIssues            bool            // true if any WARN (level 40) or ERROR (level 50) found
+	RenovateResultStatus *string         // nil = unknown; "Disabled", "No Config", "Onboarding Closed", or raw result string
+	PRActivity           *api.PRActivity // nil when logs are empty/unparseable, non-nil (possibly zero counts) when logs were parsed successfully
 }
 
-// renovateLogEntry represents a single line in Renovate's JSON log output
+// renovateLogEntry represents a single line in Renovate's JSON log output.
 type renovateLogEntry struct {
 	Level int    `json:"level"`
 	Msg   string `json:"msg"`
@@ -25,13 +34,68 @@ type repositoryFinishedEntry struct {
 	Result string `json:"result,omitempty"`
 }
 
-// ParseRenovateLogs parses Renovate JSON logs (NDJSON format) and detects warnings/errors
-// and whether the repository has a Renovate config file.
+// prCreateUpdateEntry is a targeted partial-unmarshal struct for "Creating PR" / "Updating PR" messages.
+type prCreateUpdateEntry struct {
+	Msg    string `json:"msg"`
+	Branch string `json:"branch"`
+	Title  string `json:"title"`
+}
+
+// prUnchangedEntry is a targeted partial-unmarshal struct for "does not need updating" messages.
+type prUnchangedEntry struct {
+	Msg    string `json:"msg"`
+	Branch string `json:"branch"`
+}
+
+// gitPushEntry is a targeted partial-unmarshal struct for "git push" messages containing PR URLs.
+type gitPushEntry struct {
+	Msg    string `json:"msg"`
+	Branch string `json:"branch"`
+	Result struct {
+		RemoteMessages struct {
+			All []string `json:"all"`
+		} `json:"remoteMessages"`
+	} `json:"result"`
+}
+
+// prCreatedEntry is a targeted partial-unmarshal struct for "PR created" / "PR automerged" messages (level 30)
+// which contain the PR number and title after the PR is created on the forge.
+type prCreatedEntry struct {
+	Msg     string `json:"msg"`
+	Branch  string `json:"branch"`
+	PR      int    `json:"pr"`
+	PRTitle string `json:"prTitle"`
+}
+
+// branchInfoItem represents a single branch in the "branches info extended" summary.
+type branchInfoItem struct {
+	BranchName string `json:"branchName"`
+	PRNo       *int   `json:"prNo"` // pointer because null means no PR
+	PRTitle    string `json:"prTitle"`
+	Result     string `json:"result"`
+}
+
+// branchesInfoEntry is a targeted partial-unmarshal struct for "branches info extended" (level 20)
+// which contains a complete list of all branches Renovate knows about, including skipped ones.
+type branchesInfoEntry struct {
+	Msg          string           `json:"msg"`
+	BranchesInfo []branchInfoItem `json:"branchesInformation"`
+}
+
+var (
+	// prURLRegex matches PR/MR URLs from GitHub (/pull/N), Forgejo (/pulls/N), and GitLab (/merge_requests/N).
+	prURLRegex = regexp.MustCompile(`https?://[^\s"]+/(?:pulls|pull|merge_requests)/(\d+)`)
+	// prNumberRegex extracts the PR number from "Pull Request #N does not need updating" messages.
+	prNumberRegex = regexp.MustCompile(`Pull Request #(\d+)`)
+	// actionOrder defines the sort priority for PR actions (lower = sorted first).
+	actionOrder = map[api.PRAction]int{api.PRActionAutomerged: 0, api.PRActionCreated: 1, api.PRActionUpdated: 2, api.PRActionUnchanged: 3}
+)
+
+// ParseRenovateLogs parses Renovate JSON logs (NDJSON format) and detects warnings/errors,
+// repository config status, and PR activity.
 // Returns HasIssues=true if any log entry has level >= 40 (WARN or ERROR).
-// Returns RenovateResultStatus based on onboarding detection in log messages:
-//   - "Disabled" if Renovate is disabled for the repository
-//   - "No Config" if onboarding-related messages are found (repo has no config)
-//   - nil if logs were parsed successfully without onboarding signals or logs are empty/not parseable
+// Returns RenovateResultStatus based on the "Repository finished" result field.
+// Returns PRActivity with counts and per-PR details extracted from log messages.
 func ParseRenovateLogs(logs string) *LogParseResult {
 	result := &LogParseResult{
 		HasIssues: false,
@@ -40,6 +104,10 @@ func ParseRenovateLogs(logs string) *LogParseResult {
 	if logs == "" {
 		return result
 	}
+
+	// Per-branch map for accumulating PR details (last-write-wins for action)
+	branchMap := make(map[string]*api.PRDetail)
+	parsedAnyLine := false
 
 	scanner := bufio.NewScanner(strings.NewReader(logs))
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024) // 64KB initial, 1MB max
@@ -55,13 +123,16 @@ func ParseRenovateLogs(logs string) *LogParseResult {
 			continue
 		}
 
+		parsedAnyLine = true
+
 		// Renovate log levels: 10=trace, 20=debug, 30=info, 40=warn, 50=error, 60=fatal
 		if entry.Level >= 40 {
 			result.HasIssues = true
 		}
 
-		// Parse the "Repository finished" line which has the definitive status
-		if entry.Msg == "Repository finished" {
+		// Dispatch by message type (mutually exclusive)
+		switch {
+		case entry.Msg == "Repository finished":
 			var finished repositoryFinishedEntry
 			if err := json.Unmarshal([]byte(line), &finished); err == nil {
 				switch finished.Result {
@@ -78,10 +149,195 @@ func ParseRenovateLogs(logs string) *LogParseResult {
 						result.RenovateResultStatus = ptr.To(finished.Result)
 					}
 				}
+			}
 
+		case entry.Msg == "Creating PR":
+			var pr prCreateUpdateEntry
+			if err := json.Unmarshal([]byte(line), &pr); err == nil && pr.Branch != "" {
+				detail := getOrCreateDetail(branchMap, pr.Branch)
+				detail.Action = api.PRActionCreated
+				detail.Title = pr.Title
+			}
+
+		case entry.Msg == "Updating PR":
+			var pr prCreateUpdateEntry
+			if err := json.Unmarshal([]byte(line), &pr); err == nil && pr.Branch != "" {
+				detail := getOrCreateDetail(branchMap, pr.Branch)
+				detail.Action = api.PRActionUpdated
+				detail.Title = pr.Title
+			}
+
+		case strings.Contains(entry.Msg, "does not need updating"):
+			if matches := prNumberRegex.FindStringSubmatch(entry.Msg); len(matches) == 2 {
+				if num, err := strconv.Atoi(matches[1]); err == nil {
+					var unch prUnchangedEntry
+					if err := json.Unmarshal([]byte(line), &unch); err == nil && unch.Branch != "" {
+						detail := getOrCreateDetail(branchMap, unch.Branch)
+						detail.Action = api.PRActionUnchanged
+						detail.Number = num
+					}
+				}
+			}
+
+		case entry.Msg == "git push":
+			var gp gitPushEntry
+			if err := json.Unmarshal([]byte(line), &gp); err == nil && gp.Branch != "" {
+				for _, msg := range gp.Result.RemoteMessages.All {
+					if matches := prURLRegex.FindStringSubmatch(msg); len(matches) == 2 {
+						detail := getOrCreateDetail(branchMap, gp.Branch)
+						detail.URL = matches[0]
+						if num, err := strconv.Atoi(matches[1]); err == nil {
+							detail.Number = num
+						}
+						break
+					}
+				}
+			}
+
+		case entry.Msg == "PR created":
+			var pc prCreatedEntry
+			if err := json.Unmarshal([]byte(line), &pc); err == nil && pc.Branch != "" && pc.PR > 0 {
+				detail := getOrCreateDetail(branchMap, pc.Branch)
+				detail.Number = pc.PR
+				if detail.Title == "" && pc.PRTitle != "" {
+					detail.Title = pc.PRTitle
+				}
+			}
+
+		case entry.Msg == "PR automerged":
+			var pc prCreatedEntry
+			if err := json.Unmarshal([]byte(line), &pc); err == nil && pc.Branch != "" {
+				detail := getOrCreateDetail(branchMap, pc.Branch)
+				detail.Action = api.PRActionAutomerged
+				if pc.PR > 0 {
+					detail.Number = pc.PR
+				}
+				if detail.Title == "" && pc.PRTitle != "" {
+					detail.Title = pc.PRTitle
+				}
+			}
+
+		case entry.Msg == "branches info extended":
+			// Complete list of all branches, including those skipped in this run.
+			// Backfills branches not seen in per-message parsing.
+			// Skip branches with result="already-existed" (stale branches with closed/merged PRs).
+			var bi branchesInfoEntry
+			if err := json.Unmarshal([]byte(line), &bi); err == nil {
+				for _, b := range bi.BranchesInfo {
+					if b.BranchName == "" {
+						continue
+					}
+					// Always backfill title for branches already captured by per-message parsing,
+					// regardless of result value (the branch is already in our map, we just want the title).
+					if existing, exists := branchMap[b.BranchName]; exists {
+						if existing.Title == "" && b.PRTitle != "" {
+							existing.Title = b.PRTitle
+						}
+						continue
+					}
+					// For new branches not yet in the map, only include those actively processed.
+					// Skip stale (already-existed), not-scheduled, and other non-active results.
+					if b.Result != "done" && b.Result != "automerged" && b.Result != "" {
+						continue
+					}
+					detail := getOrCreateDetail(branchMap, b.BranchName)
+					detail.Action = api.PRActionUnchanged
+					detail.Title = b.PRTitle
+					if b.PRNo != nil {
+						detail.Number = *b.PRNo
+					}
+				}
 			}
 		}
 	}
 
+	// Build PRActivity if we parsed any log lines
+	if parsedAnyLine {
+		result.PRActivity = buildPRActivity(branchMap)
+	}
+
 	return result
+}
+
+// getOrCreateDetail returns the PRDetail for a branch, creating it if needed.
+func getOrCreateDetail(m map[string]*api.PRDetail, branch string) *api.PRDetail {
+	if d, ok := m[branch]; ok {
+		return d
+	}
+	d := &api.PRDetail{Branch: branch}
+	m[branch] = d
+	return d
+}
+
+// buildPRActivity collapses the branch map into counts and a capped PRDetail slice.
+func buildPRActivity(branchMap map[string]*api.PRDetail) *api.PRActivity {
+	activity := &api.PRActivity{}
+
+	if len(branchMap) == 0 {
+		return activity
+	}
+
+	// Default action for branches that only appeared in "git push" or "PR created" messages
+	for _, detail := range branchMap {
+		if detail.Action == "" && (detail.URL != "" || detail.Number > 0) {
+			detail.Action = api.PRActionUpdated
+		}
+	}
+
+	// Backfill URLs: if any PR has a URL, derive the base prefix and apply to PRs with number but no URL.
+	// All PRs in a single run come from the same forge, so the first URL found is representative.
+	// Map iteration order is non-deterministic, but all URLs share the same prefix so the result is stable.
+	var urlPrefix string
+	for _, detail := range branchMap {
+		if detail.URL != "" && detail.Number > 0 {
+			idx := strings.LastIndex(detail.URL, "/"+strconv.Itoa(detail.Number))
+			if idx > 0 {
+				urlPrefix = detail.URL[:idx+1] // includes trailing /
+				break
+			}
+		}
+	}
+	if urlPrefix != "" {
+		for _, detail := range branchMap {
+			if detail.URL == "" && detail.Number > 0 {
+				detail.URL = urlPrefix + strconv.Itoa(detail.Number)
+			}
+		}
+	}
+
+	// Count actions across all branches (before truncation)
+	for _, detail := range branchMap {
+		switch detail.Action {
+		case api.PRActionAutomerged:
+			activity.Automerged++
+		case api.PRActionCreated:
+			activity.Created++
+		case api.PRActionUpdated:
+			activity.Updated++
+		case api.PRActionUnchanged:
+			activity.Unchanged++
+		}
+	}
+
+	// Collect all PRDetails, sorted by action priority (automerged > created > updated > unchanged), then branch name
+	prs := make([]api.PRDetail, 0, len(branchMap))
+	for _, detail := range branchMap {
+		prs = append(prs, *detail)
+	}
+	sort.Slice(prs, func(i, j int) bool {
+		oi, oj := actionOrder[prs[i].Action], actionOrder[prs[j].Action]
+		if oi != oj {
+			return oi < oj
+		}
+		return prs[i].Branch < prs[j].Branch
+	})
+
+	// Cap at MaxPRDetails
+	if len(prs) > MaxPRDetails {
+		prs = prs[:MaxPRDetails]
+		activity.Truncated = true
+	}
+
+	activity.PRs = prs
+	return activity
 }

--- a/src/internal/parser/logParser_test.go
+++ b/src/internal/parser/logParser_test.go
@@ -1,8 +1,11 @@
 package parser
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+
+	api "renovate-operator/api/v1alpha1"
 
 	"k8s.io/utils/ptr"
 )
@@ -178,5 +181,577 @@ func TestParseRenovateLogsConfigDetection(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestParseRenovateLogsPRActivity(t *testing.T) {
+	tests := []struct {
+		name          string
+		logs          string
+		wantNil        bool // expect PRActivity == nil
+		wantAutomerged int
+		wantCreated    int
+		wantUpdated    int
+		wantUnchanged  int
+		wantPRCount   int  // number of PRDetail entries
+		wantTruncated bool
+		checkDetails  func(t *testing.T, prs []api.PRDetail) // optional detailed assertions
+	}{
+		{
+			name:    "empty logs - nil PRActivity",
+			logs:    "",
+			wantNil: true,
+		},
+		{
+			name: "zero-PR run (clean scan with no PR messages)",
+			logs: `{"level":30,"msg":"Repository started"}` + "\n" +
+				`{"level":30,"msg":"Dependency extraction complete"}` + "\n" +
+				`{"level":30,"msg":"Repository finished","result":"done"}`,
+			wantNil:       false,
+			wantCreated:   0,
+			wantUpdated:   0,
+			wantUnchanged: 0,
+			wantPRCount:   0,
+		},
+		{
+			name: "single PR created",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/golang-1.x","title":"Update golang to v1.22"}`,
+			wantCreated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Branch != "renovate/golang-1.x" {
+					t.Errorf("branch = %q, want %q", prs[0].Branch, "renovate/golang-1.x")
+				}
+				if prs[0].Title != "Update golang to v1.22" {
+					t.Errorf("title = %q, want %q", prs[0].Title, "Update golang to v1.22")
+				}
+				if prs[0].Action != api.PRActionCreated {
+					t.Errorf("action = %q, want %q", prs[0].Action, api.PRActionCreated)
+				}
+			},
+		},
+		{
+			name: "single PR updated",
+			logs: `{"level":30,"msg":"Updating PR","branch":"renovate/react-18.x","title":"Update react to v18.3"}`,
+			wantUpdated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Action != api.PRActionUpdated {
+					t.Errorf("action = %q, want %q", prs[0].Action, api.PRActionUpdated)
+				}
+				if prs[0].Title != "Update react to v18.3" {
+					t.Errorf("title = %q, want %q", prs[0].Title, "Update react to v18.3")
+				}
+			},
+		},
+		{
+			name: "single PR unchanged",
+			logs: `{"level":20,"msg":"Pull Request #101 does not need updating","branch":"renovate/rook-packages"}`,
+			wantUnchanged: 1,
+			wantPRCount:   1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Action != api.PRActionUnchanged {
+					t.Errorf("action = %q, want %q", prs[0].Action, api.PRActionUnchanged)
+				}
+				if prs[0].Number != 101 {
+					t.Errorf("number = %d, want %d", prs[0].Number, 101)
+				}
+				if prs[0].Branch != "renovate/rook-packages" {
+					t.Errorf("branch = %q, want %q", prs[0].Branch, "renovate/rook-packages")
+				}
+			},
+		},
+		{
+			name: "mixed activity - multiple branches with different actions",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/foo","title":"Update foo"}` + "\n" +
+				`{"level":30,"msg":"Updating PR","branch":"renovate/bar","title":"Update bar"}` + "\n" +
+				`{"level":20,"msg":"Pull Request #50 does not need updating","branch":"renovate/baz"}` + "\n" +
+				`{"level":30,"msg":"Creating PR","branch":"renovate/qux","title":"Update qux"}`,
+			wantCreated:   2,
+			wantUpdated:   1,
+			wantUnchanged: 1,
+			wantPRCount:   4,
+		},
+		{
+			name: "duplicate branch - last-write-wins",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/dep-1.x","title":"Create dep v1"}` + "\n" +
+				`{"level":30,"msg":"Updating PR","branch":"renovate/dep-1.x","title":"Update dep v1"}`,
+			wantCreated: 0,
+			wantUpdated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Action != api.PRActionUpdated {
+					t.Errorf("action = %q, want %q (last-write-wins)", prs[0].Action, api.PRActionUpdated)
+				}
+				if prs[0].Title != "Update dep v1" {
+					t.Errorf("title = %q, want %q", prs[0].Title, "Update dep v1")
+				}
+			},
+		},
+		{
+			name: "PR URL from git push - Forgejo format (/pulls/N)",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/helm-3.x","title":"Update helm to v3.15"}` + "\n" +
+				`{"level":20,"msg":"git push","branch":"renovate/helm-3.x","result":{"remoteMessages":{"all":["Visit the existing pull request:","https://git.example.com/org/repo/pulls/101 merges into main"]}}}`,
+			wantCreated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].URL != "https://git.example.com/org/repo/pulls/101" {
+					t.Errorf("url = %q, want %q", prs[0].URL, "https://git.example.com/org/repo/pulls/101")
+				}
+				if prs[0].Number != 101 {
+					t.Errorf("number = %d, want %d", prs[0].Number, 101)
+				}
+				if prs[0].Title != "Update helm to v3.15" {
+					t.Errorf("title = %q, want %q", prs[0].Title, "Update helm to v3.15")
+				}
+			},
+		},
+		{
+			name: "PR URL - GitHub format (/pull/N)",
+			logs: `{"level":20,"msg":"git push","branch":"renovate/lodash-4.x","result":{"remoteMessages":{"all":["Create a pull request:","https://github.com/org/repo/pull/42"]}}}`,
+			wantUpdated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].URL != "https://github.com/org/repo/pull/42" {
+					t.Errorf("url = %q, want %q", prs[0].URL, "https://github.com/org/repo/pull/42")
+				}
+				if prs[0].Number != 42 {
+					t.Errorf("number = %d, want %d", prs[0].Number, 42)
+				}
+			},
+		},
+		{
+			name: "PR URL - GitLab format (/merge_requests/N)",
+			logs: `{"level":20,"msg":"git push","branch":"renovate/axios-1.x","result":{"remoteMessages":{"all":["To create a merge request:","https://gitlab.com/org/repo/-/merge_requests/99"]}}}`,
+			wantUpdated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].URL != "https://gitlab.com/org/repo/-/merge_requests/99" {
+					t.Errorf("url = %q, want %q", prs[0].URL, "https://gitlab.com/org/repo/-/merge_requests/99")
+				}
+				if prs[0].Number != 99 {
+					t.Errorf("number = %d, want %d", prs[0].Number, 99)
+				}
+			},
+		},
+		{
+			name: "partial data - PR with title but no URL",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/dep-a","title":"Update dep-a"}`,
+			wantCreated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].URL != "" {
+					t.Errorf("url = %q, want empty", prs[0].URL)
+				}
+				if prs[0].Title != "Update dep-a" {
+					t.Errorf("title = %q, want %q", prs[0].Title, "Update dep-a")
+				}
+			},
+		},
+		{
+			name: "partial data - PR with number but no title",
+			logs: `{"level":20,"msg":"Pull Request #77 does not need updating","branch":"renovate/dep-b"}`,
+			wantUnchanged: 1,
+			wantPRCount:   1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Number != 77 {
+					t.Errorf("number = %d, want %d", prs[0].Number, 77)
+				}
+				if prs[0].Title != "" {
+					t.Errorf("title = %q, want empty", prs[0].Title)
+				}
+			},
+		},
+		{
+			name: "truncated logs (OOMKilled) - returns partial data",
+			logs: `{"level":30,"msg":"Repository started"}` + "\n" +
+				`{"level":30,"msg":"Creating PR","branch":"renovate/dep-1","title":"Update dep-1"}` + "\n" +
+				`{"level":30,"msg":"Updating PR","branch":"renovate/dep-2","title":"Update dep-2"}`,
+			// No "Repository finished" line - simulates truncated logs
+			wantCreated: 1,
+			wantUpdated: 1,
+			wantPRCount: 2,
+		},
+		{
+			name: "git push URL enriches existing branch entry",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/dep-x","title":"Update dep-x"}` + "\n" +
+				`{"level":20,"msg":"git push","branch":"renovate/dep-x","result":{"remoteMessages":{"all":["Visit:","https://git.example.com/org/repo/pulls/200 merges into main"]}}}`,
+			wantCreated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Title != "Update dep-x" {
+					t.Errorf("title = %q, want %q", prs[0].Title, "Update dep-x")
+				}
+				if prs[0].URL != "https://git.example.com/org/repo/pulls/200" {
+					t.Errorf("url = %q, want %q", prs[0].URL, "https://git.example.com/org/repo/pulls/200")
+				}
+				if prs[0].Number != 200 {
+					t.Errorf("number = %d, want %d", prs[0].Number, 200)
+				}
+				if prs[0].Action != api.PRActionCreated {
+					t.Errorf("action = %q, want %q", prs[0].Action, api.PRActionCreated)
+				}
+			},
+		},
+		{
+			name:    "non-JSON logs only - nil PRActivity",
+			logs:    "plain text output\nnot json",
+			wantNil: true,
+		},
+		{
+			name: "URL backfill - unchanged PRs get URL from created PR's pattern",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/dep-a","title":"Update dep-a"}` + "\n" +
+				`{"level":20,"msg":"git push","branch":"renovate/dep-a","result":{"remoteMessages":{"all":["Visit:","https://git.example.com/org/repo/pulls/100 merges into main"]}}}` + "\n" +
+				`{"level":20,"msg":"Pull Request #200 does not need updating","branch":"renovate/dep-b"}` + "\n" +
+				`{"level":20,"msg":"Pull Request #300 does not need updating","branch":"renovate/dep-c"}`,
+			wantCreated:   1,
+			wantUnchanged: 2,
+			wantPRCount:   3,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				prsByBranch := make(map[string]api.PRDetail)
+				for _, pr := range prs {
+					prsByBranch[pr.Branch] = pr
+				}
+				// Created PR has URL from git push
+				if prsByBranch["renovate/dep-a"].URL != "https://git.example.com/org/repo/pulls/100" {
+					t.Errorf("dep-a url = %q, want original URL", prsByBranch["renovate/dep-a"].URL)
+				}
+				// Unchanged PRs get backfilled URLs
+				if prsByBranch["renovate/dep-b"].URL != "https://git.example.com/org/repo/pulls/200" {
+					t.Errorf("dep-b url = %q, want backfilled URL", prsByBranch["renovate/dep-b"].URL)
+				}
+				if prsByBranch["renovate/dep-c"].URL != "https://git.example.com/org/repo/pulls/300" {
+					t.Errorf("dep-c url = %q, want backfilled URL", prsByBranch["renovate/dep-c"].URL)
+				}
+			},
+		},
+		{
+			name: "URL backfill - no URLs available, numbers stay as plain text",
+			logs: `{"level":20,"msg":"Pull Request #50 does not need updating","branch":"renovate/dep-x"}` + "\n" +
+				`{"level":20,"msg":"Pull Request #60 does not need updating","branch":"renovate/dep-y"}`,
+			wantUnchanged: 2,
+			wantPRCount:   2,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				for _, pr := range prs {
+					if pr.URL != "" {
+						t.Errorf("pr %q url = %q, want empty (no URL source for backfill)", pr.Branch, pr.URL)
+					}
+				}
+			},
+		},
+		{
+			name: "git push only (no Creating/Updating message) defaults to updated",
+			logs: `{"level":20,"msg":"git push","branch":"renovate/dep-z","result":{"remoteMessages":{"all":["Visit the existing pull request:","https://forge.example.com/org/repo/pulls/555 merges into main"]}}}`,
+			wantUpdated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Action != api.PRActionUpdated {
+					t.Errorf("action = %q, want %q (default for git-push-only)", prs[0].Action, api.PRActionUpdated)
+				}
+				if prs[0].Number != 555 {
+					t.Errorf("number = %d, want 555", prs[0].Number)
+				}
+			},
+		},
+		{
+			name: "PR created message captures PR number for new PRs",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/new-dep","title":"Update new-dep to v2.0"}` + "\n" +
+				`{"level":20,"msg":"git push","branch":"renovate/new-dep","result":{"remoteMessages":{"all":["Create a new pull request:","https://forge.example.com/org/repo/compare/main...renovate/new-dep"]}}}` + "\n" +
+				`{"level":30,"msg":"PR created","branch":"renovate/new-dep","pr":42,"prTitle":"Update new-dep to v2.0"}`,
+			wantCreated: 1,
+			wantPRCount: 1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Action != api.PRActionCreated {
+					t.Errorf("action = %q, want %q", prs[0].Action, api.PRActionCreated)
+				}
+				if prs[0].Number != 42 {
+					t.Errorf("number = %d, want 42 (from PR created message)", prs[0].Number)
+				}
+				if prs[0].Title != "Update new-dep to v2.0" {
+					t.Errorf("title = %q, want %q", prs[0].Title, "Update new-dep to v2.0")
+				}
+			},
+		},
+		{
+			name: "PR automerged - captures action and PR number",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/dep-auto","title":"Update dep-auto"}` + "\n" +
+				`{"level":20,"msg":"git push","branch":"renovate/dep-auto","result":{"remoteMessages":{"all":["Create a new pull request:","https://forge.example.com/org/repo/compare/main...renovate/dep-auto"]}}}` + "\n" +
+				`{"level":30,"msg":"PR created","branch":"renovate/dep-auto","pr":99}` + "\n" +
+				`{"level":30,"msg":"PR automerged","branch":"renovate/dep-auto","pr":99}`,
+			wantAutomerged: 1,
+			wantPRCount:    1,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Action != api.PRActionAutomerged {
+					t.Errorf("action = %q, want %q", prs[0].Action, api.PRActionAutomerged)
+				}
+				if prs[0].Number != 99 {
+					t.Errorf("number = %d, want 99", prs[0].Number)
+				}
+			},
+		},
+		{
+			name: "automerged sorted first, then created, then unchanged",
+			logs: `{"level":20,"msg":"Pull Request #10 does not need updating","branch":"renovate/unchanged-dep"}` + "\n" +
+				`{"level":30,"msg":"Creating PR","branch":"renovate/new-dep","title":"New dep"}` + "\n" +
+				`{"level":30,"msg":"PR created","branch":"renovate/new-dep","pr":20}` + "\n" +
+				`{"level":30,"msg":"Creating PR","branch":"renovate/auto-dep","title":"Auto dep"}` + "\n" +
+				`{"level":30,"msg":"PR created","branch":"renovate/auto-dep","pr":30}` + "\n" +
+				`{"level":30,"msg":"PR automerged","branch":"renovate/auto-dep","pr":30}`,
+			wantAutomerged: 1,
+			wantCreated:    1,
+			wantUnchanged:  1,
+			wantPRCount:    3,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				if prs[0].Action != api.PRActionAutomerged {
+					t.Errorf("first PR action = %q, want automerged", prs[0].Action)
+				}
+				if prs[1].Action != api.PRActionCreated {
+					t.Errorf("second PR action = %q, want created", prs[1].Action)
+				}
+				if prs[2].Action != api.PRActionUnchanged {
+					t.Errorf("third PR action = %q, want unchanged", prs[2].Action)
+				}
+			},
+		},
+		{
+			name: "branches info extended backfills skipped branches, excludes stale",
+			logs: `{"level":30,"msg":"Creating PR","branch":"renovate/active-dep","title":"Update active-dep"}` + "\n" +
+				`{"level":30,"msg":"PR created","branch":"renovate/active-dep","pr":10}` + "\n" +
+				`{"level":20,"msg":"branches info extended","branchesInformation":[` +
+				`{"branchName":"renovate/active-dep","prNo":10,"prTitle":"Update active-dep","result":"done"},` +
+				`{"branchName":"renovate/skipped-dep-a","prNo":20,"prTitle":"Update skipped-dep-a","result":"done"},` +
+				`{"branchName":"renovate/skipped-dep-b","prNo":30,"prTitle":"Update skipped-dep-b"},` +
+				`{"branchName":"renovate/stale-branch","prNo":18,"prTitle":"Old closed PR","result":"already-existed"},` +
+				`{"branchName":"renovate/not-scheduled","prNo":null,"prTitle":"lock file maintenance","result":"not-scheduled"},` +
+				`{"branchName":"renovate/no-pr-branch","prNo":null,"prTitle":"Update no-pr-branch"}]}`,
+			wantCreated:   1,
+			wantUnchanged: 3,
+			wantPRCount:   4,
+			checkDetails: func(t *testing.T, prs []api.PRDetail) {
+				prsByBranch := make(map[string]api.PRDetail)
+				for _, pr := range prs {
+					prsByBranch[pr.Branch] = pr
+				}
+				// Active dep was captured by per-message parsing
+				if prsByBranch["renovate/active-dep"].Action != api.PRActionCreated {
+					t.Errorf("active-dep action = %q, want created", prsByBranch["renovate/active-dep"].Action)
+				}
+				// Skipped deps were backfilled from branches info
+				skA := prsByBranch["renovate/skipped-dep-a"]
+				if skA.Action != api.PRActionUnchanged {
+					t.Errorf("skipped-dep-a action = %q, want unchanged", skA.Action)
+				}
+				if skA.Number != 20 {
+					t.Errorf("skipped-dep-a number = %d, want 20", skA.Number)
+				}
+				if skA.Title != "Update skipped-dep-a" {
+					t.Errorf("skipped-dep-a title = %q, want %q", skA.Title, "Update skipped-dep-a")
+				}
+				// Stale branch (already-existed) should be excluded
+				if _, exists := prsByBranch["renovate/stale-branch"]; exists {
+					t.Error("stale-branch should be excluded (result=already-existed)")
+				}
+				// Not-scheduled branch should be excluded
+				if _, exists := prsByBranch["renovate/not-scheduled"]; exists {
+					t.Error("not-scheduled branch should be excluded")
+				}
+				// Branch with null prNo and empty result should still be included
+				noPR := prsByBranch["renovate/no-pr-branch"]
+				if noPR.Number != 0 {
+					t.Errorf("no-pr-branch number = %d, want 0", noPR.Number)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseRenovateLogs(tt.logs)
+
+			if tt.wantNil {
+				if result.PRActivity != nil {
+					t.Errorf("PRActivity = %+v, want nil", result.PRActivity)
+				}
+				return
+			}
+
+			if result.PRActivity == nil {
+				t.Fatal("PRActivity = nil, want non-nil")
+			}
+
+			pa := result.PRActivity
+			if pa.Automerged != tt.wantAutomerged {
+				t.Errorf("Automerged = %d, want %d", pa.Automerged, tt.wantAutomerged)
+			}
+			if pa.Created != tt.wantCreated {
+				t.Errorf("Created = %d, want %d", pa.Created, tt.wantCreated)
+			}
+			if pa.Updated != tt.wantUpdated {
+				t.Errorf("Updated = %d, want %d", pa.Updated, tt.wantUpdated)
+			}
+			if pa.Unchanged != tt.wantUnchanged {
+				t.Errorf("Unchanged = %d, want %d", pa.Unchanged, tt.wantUnchanged)
+			}
+			if len(pa.PRs) != tt.wantPRCount {
+				t.Errorf("len(PRs) = %d, want %d", len(pa.PRs), tt.wantPRCount)
+			}
+			if pa.Truncated != tt.wantTruncated {
+				t.Errorf("Truncated = %v, want %v", pa.Truncated, tt.wantTruncated)
+			}
+
+			if tt.checkDetails != nil && len(pa.PRs) > 0 {
+				tt.checkDetails(t, pa.PRs)
+			}
+		})
+	}
+}
+
+func TestParseRenovateLogsPRActivityCap(t *testing.T) {
+	// Generate 150 branches to test capping at MaxPRDetails (100)
+	var lines []string
+	lines = append(lines, `{"level":30,"msg":"Repository started"}`)
+	for i := 0; i < 150; i++ {
+		branch := fmt.Sprintf("renovate/dep-%03d", i)
+		title := fmt.Sprintf("Update dep-%03d", i)
+		lines = append(lines, fmt.Sprintf(`{"level":30,"msg":"Creating PR","branch":%q,"title":%q}`, branch, title))
+	}
+	lines = append(lines, `{"level":30,"msg":"Repository finished","result":"done"}`)
+	logs := strings.Join(lines, "\n")
+
+	result := ParseRenovateLogs(logs)
+
+	if result.PRActivity == nil {
+		t.Fatal("PRActivity = nil, want non-nil")
+	}
+
+	pa := result.PRActivity
+
+	// Counts should reflect all 150 branches (computed before truncation)
+	if pa.Created != 150 {
+		t.Errorf("Created = %d, want 150", pa.Created)
+	}
+
+	// PRDetails should be capped at MaxPRDetails
+	if len(pa.PRs) != MaxPRDetails {
+		t.Errorf("len(PRs) = %d, want %d", len(pa.PRs), MaxPRDetails)
+	}
+
+	if !pa.Truncated {
+		t.Error("Truncated = false, want true")
+	}
+
+	// PRs should be sorted by branch name, so first should be dep-000
+	if len(pa.PRs) > 0 && pa.PRs[0].Branch != "renovate/dep-000" {
+		t.Errorf("first PR branch = %q, want %q (sorted order)", pa.PRs[0].Branch, "renovate/dep-000")
+	}
+
+	// Last should be dep-099 (first 100 of 150 sorted branches)
+	if len(pa.PRs) == MaxPRDetails && pa.PRs[99].Branch != "renovate/dep-099" {
+		t.Errorf("last PR branch = %q, want %q", pa.PRs[99].Branch, "renovate/dep-099")
+	}
+}
+
+func TestParseRenovateLogsPRActivityGoldenFile(t *testing.T) {
+	// Simulates a realistic Renovate run with mixed PR activity
+	logs := strings.Join([]string{
+		`{"level":30,"msg":"Repository started","repository":"k8s/flux"}`,
+		`{"level":30,"msg":"Dependency extraction complete"}`,
+		// Two new PRs created
+		`{"level":30,"msg":"Creating PR","branch":"renovate/golang-1.x","title":"Update golang Docker tag to v1.22"}`,
+		`{"level":20,"msg":"git push","branch":"renovate/golang-1.x","result":{"remoteMessages":{"all":["Visit the existing pull request:","https://git.example.com/org/repo/pulls/900 merges into main"]}}}`,
+		`{"level":30,"msg":"Creating PR","branch":"renovate/helm-renovate-46.x","title":"Update registry.example.com/org/helm/renovate Docker tag to v46.99.0"}`,
+		`{"level":20,"msg":"git push","branch":"renovate/helm-renovate-46.x","result":{"remoteMessages":{"all":["Visit the existing pull request:","https://git.example.com/org/repo/pulls/901 merges into main"]}}}`,
+		// One PR updated
+		`{"level":30,"msg":"Updating PR","branch":"renovate/rook-ceph-1.x","title":"Update rook-ceph to v1.15.0"}`,
+		`{"level":20,"msg":"git push","branch":"renovate/rook-ceph-1.x","result":{"remoteMessages":{"all":["Visit the existing pull request:","https://git.example.com/org/repo/pulls/850 merges into main"]}}}`,
+		// Three unchanged PRs
+		`{"level":20,"msg":"Pull Request #800 does not need updating","branch":"renovate/traefik-30.x"}`,
+		`{"level":20,"msg":"Pull Request #810 does not need updating","branch":"renovate/cert-manager-1.x"}`,
+		`{"level":20,"msg":"Pull Request #820 does not need updating","branch":"renovate/harbor-1.x"}`,
+		// Finish
+		`{"level":30,"msg":"Repository finished","result":"done"}`,
+	}, "\n")
+
+	result := ParseRenovateLogs(logs)
+
+	if result.PRActivity == nil {
+		t.Fatal("PRActivity = nil, want non-nil")
+	}
+
+	pa := result.PRActivity
+
+	if pa.Created != 2 {
+		t.Errorf("Created = %d, want 2", pa.Created)
+	}
+	if pa.Updated != 1 {
+		t.Errorf("Updated = %d, want 1", pa.Updated)
+	}
+	if pa.Unchanged != 3 {
+		t.Errorf("Unchanged = %d, want 3", pa.Unchanged)
+	}
+	if len(pa.PRs) != 6 {
+		t.Errorf("len(PRs) = %d, want 6", len(pa.PRs))
+	}
+	if pa.Truncated {
+		t.Error("Truncated = true, want false")
+	}
+
+	// PRs are sorted by branch name; verify a few
+	prsByBranch := make(map[string]api.PRDetail)
+	for _, pr := range pa.PRs {
+		prsByBranch[pr.Branch] = pr
+	}
+
+	// Check golang PR has all fields populated
+	golang, ok := prsByBranch["renovate/golang-1.x"]
+	if !ok {
+		t.Fatal("missing PR for renovate/golang-1.x")
+	}
+	if golang.Action != api.PRActionCreated {
+		t.Errorf("golang action = %q, want %q", golang.Action, api.PRActionCreated)
+	}
+	if golang.Title != "Update golang Docker tag to v1.22" {
+		t.Errorf("golang title = %q, want %q", golang.Title, "Update golang Docker tag to v1.22")
+	}
+	if golang.URL != "https://git.example.com/org/repo/pulls/900" {
+		t.Errorf("golang url = %q, want %q", golang.URL, "https://git.example.com/org/repo/pulls/900")
+	}
+	if golang.Number != 900 {
+		t.Errorf("golang number = %d, want 900", golang.Number)
+	}
+
+	// Check unchanged PR has number and backfilled URL (derived from created/updated PRs' URL pattern)
+	traefik, ok := prsByBranch["renovate/traefik-30.x"]
+	if !ok {
+		t.Fatal("missing PR for renovate/traefik-30.x")
+	}
+	if traefik.Action != api.PRActionUnchanged {
+		t.Errorf("traefik action = %q, want %q", traefik.Action, api.PRActionUnchanged)
+	}
+	if traefik.Number != 800 {
+		t.Errorf("traefik number = %d, want 800", traefik.Number)
+	}
+	if traefik.URL != "https://git.example.com/org/repo/pulls/800" {
+		t.Errorf("traefik url = %q, want backfilled URL", traefik.URL)
+	}
+
+	// Check updated PR
+	rook, ok := prsByBranch["renovate/rook-ceph-1.x"]
+	if !ok {
+		t.Fatal("missing PR for renovate/rook-ceph-1.x")
+	}
+	if rook.Action != api.PRActionUpdated {
+		t.Errorf("rook action = %q, want %q", rook.Action, api.PRActionUpdated)
+	}
+	if rook.URL != "https://git.example.com/org/repo/pulls/850" {
+		t.Errorf("rook url = %q, want %q", rook.URL, "https://git.example.com/org/repo/pulls/850")
+	}
+
+	// Verify existing parsing still works
+	if result.RenovateResultStatus == nil || *result.RenovateResultStatus != "done" {
+		t.Errorf("RenovateResultStatus = %v, want 'done'", result.RenovateResultStatus)
+	}
+	if result.HasIssues {
+		t.Error("HasIssues should be false")
 	}
 }

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -177,6 +177,7 @@ func (e *renovateExecutor) reconcileRunning(ctx context.Context, renovateJobs []
 						parseResult := parser.ParseRenovateLogs(logs)
 						hasIssues = parseResult.HasIssues
 						newProjectStatus.RenovateResultStatus = parseResult.RenovateResultStatus
+						newProjectStatus.PRActivity = parseResult.PRActivity
 					} else {
 						e.logger.Error(err, "failed to get logs for metrics parsing", "project", project.Name)
 					}

--- a/src/internal/types/renovateStatusUpdate.go
+++ b/src/internal/types/renovateStatusUpdate.go
@@ -10,6 +10,7 @@ type RenovateStatusUpdate struct {
 	Status               api.RenovateProjectStatus
 	Priority             int32
 	RenovateResultStatus *string
+	PRActivity           *api.PRActivity
 	LastRun              *v1.Time
 	Duration             *string
 }

--- a/src/internal/utils/projectStatus.go
+++ b/src/internal/utils/projectStatus.go
@@ -32,6 +32,7 @@ func validateProjectStatusScheduled(projectStatus *api.ProjectStatus, desiredSta
 		}
 	}
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
+	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	return projectStatus
 }
 
@@ -43,6 +44,7 @@ func validateProjectStatusRunning(projectStatus *api.ProjectStatus, desiredStatu
 	}
 	projectStatus.Duration = nil
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
+	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	return projectStatus
 }
 
@@ -55,8 +57,10 @@ func validateProjectStatusCompleted(projectStatus *api.ProjectStatus, desiredSta
 	}
 	projectStatus.Duration = desiredStatus.Duration
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
+	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	return projectStatus
 }
+
 func validateProjectStatusFailed(projectStatus *api.ProjectStatus, desiredStatus *types.RenovateStatusUpdate) *api.ProjectStatus {
 	// can only set a running project to failed
 	if projectStatus.Status == api.JobStatusRunning {
@@ -66,11 +70,18 @@ func validateProjectStatusFailed(projectStatus *api.ProjectStatus, desiredStatus
 	}
 	projectStatus.Duration = desiredStatus.Duration
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
+	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	return projectStatus
 }
 
 func updateRenovateResultStatus(projectStatus *api.ProjectStatus, status *string) {
 	if status != nil {
 		projectStatus.RenovateResultStatus = status
+	}
+}
+
+func updatePRActivity(projectStatus *api.ProjectStatus, activity *api.PRActivity) {
+	if activity != nil {
+		projectStatus.PRActivity = activity
 	}
 }

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1019,6 +1019,109 @@
         return sortedProjects;
       };
 
+      // Sanitize project name for use in HTML IDs (replace characters invalid in IDs like slashes)
+      const safeId = (name) => name.replace(/[^a-zA-Z0-9_-]/g, '-');
+
+      // Shared badge class for PR action types
+      const prActionBadgeClass = (action) => {
+        const base = "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium";
+        switch (action) {
+          case "automerged": return `${base} bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 ring-1 ring-purple-300 dark:ring-purple-700`;
+          case "created": return `${base} bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 ring-1 ring-green-300 dark:ring-green-700`;
+          case "updated": return `${base} bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 ring-1 ring-amber-300 dark:ring-amber-700`;
+          default: return `${base} bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 ring-1 ring-gray-300 dark:ring-gray-600`;
+        }
+      };
+
+      function PRActivityBadges({ prActivity, expanded, onToggle, projectName }) {
+        if (!prActivity) return <span className="text-gray-400 dark:text-slate-500 text-sm">-</span>;
+
+        const { automerged = 0, created = 0, updated = 0, unchanged = 0 } = prActivity;
+        if (!automerged && !created && !updated && !unchanged) {
+          return <span className="text-gray-400 dark:text-slate-500 text-sm">No PRs</span>;
+        }
+
+        const hasPRs = prActivity.prs && prActivity.prs.length > 0;
+        const badges = [];
+        if (automerged > 0) badges.push(
+          <span key="automerged" className={prActionBadgeClass("automerged")}>{automerged} automerged</span>
+        );
+        if (created > 0) badges.push(
+          <span key="created" className={prActionBadgeClass("created")}>{created} created</span>
+        );
+        if (updated > 0) badges.push(
+          <span key="updated" className={prActionBadgeClass("updated")}>{updated} updated</span>
+        );
+        if (unchanged > 0) badges.push(
+          <span key="unchanged" className={prActionBadgeClass("unchanged")}>{unchanged} unchanged</span>
+        );
+
+        const chevron = hasPRs ? (
+          <svg
+            className={`w-4 h-4 text-gray-400 dark:text-slate-500 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        ) : null;
+
+        if (!hasPRs) {
+          return <div className="flex items-center gap-1.5 flex-wrap">{badges}</div>;
+        }
+
+        return (
+          <button
+            onClick={(e) => { e.stopPropagation(); onToggle(); }}
+            className="flex items-center gap-1.5 flex-wrap rounded-lg p-0.5 -m-0.5 cursor-pointer focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none hover:opacity-80 transition-opacity"
+            {...(expanded ? { "aria-expanded": true, "aria-controls": `pr-details-${safeId(projectName)}` } : { "aria-expanded": false })}
+          >
+            {badges}
+            {chevron}
+          </button>
+        );
+      }
+
+      function PRDetailRow({ prActivity, projectName }) {
+        if (!prActivity || !prActivity.prs || prActivity.prs.length === 0) return null;
+
+        return (
+          <tr id={`pr-details-${safeId(projectName)}`}>
+            <td colSpan="6" className="px-6 py-0">
+              <div className="py-3 pl-4 border-l-2 border-gray-200 dark:border-slate-600 max-h-64 overflow-y-auto">
+                <div className="space-y-1.5">
+                  {prActivity.prs.map((pr, idx) => (
+                    <div key={idx} className="flex items-center gap-2 text-sm">
+                      <span className={prActionBadgeClass(pr.action)}>{pr.action}</span>
+                      {pr.url ? (
+                        <a
+                          href={pr.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary hover:text-primary-hover hover:underline truncate"
+                          title={pr.title || pr.url}
+                        >
+                          {pr.title || pr.url}
+                        </a>
+                      ) : (
+                        <span className="text-gray-700 dark:text-slate-300 truncate" title={pr.title}>{pr.title || "Untitled PR"}</span>
+                      )}
+                      {pr.number && (
+                        <span className="text-gray-400 dark:text-slate-500 text-xs flex-shrink-0">#{pr.number}</span>
+                      )}
+                    </div>
+                  ))}
+                  {prActivity.truncated && (
+                    <div className="text-xs text-gray-400 dark:text-slate-500 italic mt-1">
+                      Some PRs omitted (list truncated)
+                    </div>
+                  )}
+                </div>
+              </div>
+            </td>
+          </tr>
+        );
+      }
+
       function JobCard({ job, onRunDiscovery, onTriggerRenovate, onTriggerAllRenovate, onSaveExecutionOptions }) {
         const [open, setOpen] = useState(true);
         const [sortConfig, setSortConfig] = useState({
@@ -1026,6 +1129,18 @@
           direction: "asc",
         });
         const sortedProjects = useMemo(() => getSortedProjects(job.projects, sortConfig), [job.projects, sortConfig]);
+        const [expandedProjects, setExpandedProjects] = useState(() => new Set());
+        const toggleProjectExpanded = (name) => {
+          setExpandedProjects((prev) => {
+            const next = new Set(prev);
+            if (next.has(name)) {
+              next.delete(name);
+            } else {
+              next.add(name);
+            }
+            return next;
+          });
+        };
         const [showOptions, setShowOptions] = useState(false);
         const [debugOption, setDebugOption] = useState(job.executionOptions?.debug ?? false);
 
@@ -1322,6 +1437,9 @@
                             <SortIcon columnKey="status" />
                           </div>
                         </th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-300 uppercase tracking-wider select-none">
+                          PR Activity
+                        </th>
                         <th
                           className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-slate-300 uppercase tracking-wider cursor-pointer hover:bg-gray-50 dark:hover:bg-slate-600 select-none"
                           onClick={() => handleSort("lastRun")}
@@ -1389,6 +1507,14 @@
                               <span className={getBadgeClass(project.status)}>
                                 {project.status || "-"}
                               </span>
+                            </td>
+                            <td className="px-6 py-4" data-no-tooltip="true">
+                              <PRActivityBadges
+                                prActivity={project.prActivity}
+                                expanded={expandedProjects.has(project.name)}
+                                onToggle={() => toggleProjectExpanded(project.name)}
+                                projectName={project.name}
+                              />
                             </td>
                             <td className="px-6 py-4">
                               <span className="text-sm text-gray-600 dark:text-slate-300">
@@ -1483,6 +1609,9 @@
                               </div>
                             </td>
                           </tr>
+                          {expandedProjects.has(project.name) && project.prActivity && (
+                            <PRDetailRow prActivity={project.prActivity} projectName={project.name} />
+                          )}
                           {tooltipElement}
                         </>
                       );
@@ -1493,7 +1622,7 @@
                       ) : (
                         <tr>
                           <td
-                            colSpan="5"
+                            colSpan="6"
                             className="px-6 py-8 text-center text-gray-500 dark:text-slate-400"
                           >
                             No projects found. Run discovery to find projects.
@@ -1542,6 +1671,41 @@
                             {project.status || "-"}
                           </span>
                         </div>
+                        {/* PR Activity section */}
+                        <div className="flex items-center gap-2" data-no-tooltip="true">
+                          <span className="text-xs text-gray-500 dark:text-slate-400 font-medium">PR Activity:</span>
+                          <PRActivityBadges
+                            prActivity={project.prActivity}
+                            expanded={expandedProjects.has(project.name)}
+                            onToggle={() => toggleProjectExpanded(project.name)}
+                            projectName={project.name}
+                          />
+                        </div>
+                        {expandedProjects.has(project.name) && project.prActivity && project.prActivity.prs && project.prActivity.prs.length > 0 && (
+                          <div id={`pr-details-${safeId(project.name)}`} className="pl-2 border-l-2 border-gray-200 dark:border-slate-600 max-h-48 overflow-y-auto">
+                            <div className="space-y-1.5">
+                              {project.prActivity.prs.map((pr, idx) => {
+                                const actionClass = prActionBadgeClass(pr.action);
+                                return (
+                                  <div key={idx} className="flex items-center gap-2 text-sm">
+                                    <span className={actionClass}>{pr.action}</span>
+                                    {pr.url ? (
+                                      <a href={pr.url} target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary-hover hover:underline truncate text-xs" title={pr.title || pr.url}>
+                                        {pr.title || pr.url}
+                                      </a>
+                                    ) : (
+                                      <span className="text-gray-700 dark:text-slate-300 truncate text-xs" title={pr.title}>{pr.title || "Untitled PR"}</span>
+                                    )}
+                                    {pr.number && <span className="text-gray-400 dark:text-slate-500 text-xs flex-shrink-0">#{pr.number}</span>}
+                                  </div>
+                                );
+                              })}
+                              {project.prActivity.truncated && (
+                                <div className="text-xs text-gray-400 dark:text-slate-500 italic mt-1">Some PRs omitted (list truncated)</div>
+                              )}
+                            </div>
+                          </div>
+                        )}
                         <div className="flex gap-2 flex-wrap" data-no-tooltip="true">
                           <button
                             onClick={() => onTriggerRenovate(job, project)}

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -261,6 +261,7 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 				Priority:             p.Priority,
 				RenovateResultStatus: p.RenovateResultStatus,
 				Duration:             p.Duration,
+				PRActivity:           p.PRActivity,
 			})
 		}
 


### PR DESCRIPTION
## Summary

Extract PR activity (created/updated/unchanged/automerged) from Renovate JSON logs and display it in the operator dashboard with expandable per-PR details.

- **PR Activity column** with labeled badges (purple=automerged, green=created, amber=updated, gray=unchanged)
- **Expandable accordion rows** showing per-PR details with clickable links to the forge
- **Complete branch coverage** via "branches info extended" summary backfill (includes branches skipped in the run)
- **Title backfill** from branches info for PRs captured via per-message parsing
- **URL backfill** from known URL prefix pattern (no forge API calls needed)
- **Stale branch filtering** (`result="already-existed"` excluded)
- **Multi-forge support** tested with GitHub, Forgejo, and GitLab URL formats
- **25 new test cases** covering edge cases, truncated logs, automerge, stale branch filtering

### Backend changes

- Extend log parser to detect 7 message types: "Creating PR", "Updating PR", "does not need updating", "git push", "PR created", "PR automerged", and "branches info extended"
- Add `PRAction`, `PRDetail`, `PRActivity` types to CRD API with `Automerged` count
- Add `PRActivity` to `RenovateStatusUpdate` DTO, applied via `updatePRActivity()` in `projectStatus.go`
- Fix `DeepCopyObject`/`DeepCopyInto` to properly deep-copy pointer and slice fields (bonus bugfix for `RenovateJobList`)
- Cap at 100 PRDetails to prevent CRD bloat
- Sort: automerged > created > updated > unchanged

### UI changes

- PR Activity column with expandable accordion sub-rows
- Shared `prActionBadgeClass()` utility (no duplication)
- Sanitized HTML IDs for project names containing `/`
- Expanded state persists across 30s poll refresh (`useState Set`)
- Mobile card view with inline expandable PR list
- `aria-expanded`/`aria-controls`, `focus-visible` ring for accessibility
- Explicit dark mode variants on all badge colors

## Test plan

- [x] `go test ./...` passes (25 new parser tests + all existing)
- [x] `go build ./...` compiles
- [x] CRD YAML regenerated via `controller-gen`
- [x] Deployed to live cluster, validated end-to-end with real Renovate runs
- [x] All badge types verified: created, updated, unchanged, automerged
- [x] URL and title backfill verified
- [x] Stale branch filtering verified
- [x] Code reviewed by 4 independent (agentic 😄) reviewers 

Closes #115