### PR TITLE
feat(operator)!: convert discoveryFilter and discoverTopics to lists

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -958,11 +958,17 @@ spec:
                   type: string
                 type: array
               discoverTopics:
-                description: Topics to discover projects from
-                type: string
-              discoveryFilter:
-                description: Filter to select which projects to process
-                type: string
+                description: Topics to discover projects from, will be concatenated
+                  using , separator
+                items:
+                  type: string
+                type: array
+              discoveryFilters:
+                description: Filter to select which projects to process, will be concatenated
+                  using , separator
+                items:
+                  type: string
+                type: array
               dnsPolicy:
                 description: DNS Policy for the renovate pods
                 type: string

--- a/docs/autodiscovery.md
+++ b/docs/autodiscovery.md
@@ -27,7 +27,8 @@ metadata:
   namespace: renovate-operator
 spec:
   schedule: "0 * * * *"
-  discoveryFilter: "Group1/*"
+  discoveryFilters: 
+    - "Group1/*"
   ...
 ```
 

--- a/docs/platforms/generic.md
+++ b/docs/platforms/generic.md
@@ -14,7 +14,8 @@ metadata:
   namespace: renovate-operator
 spec:
   schedule: "0 * * * *" # Hourly
-  discoveryFilter: "MyOrg/*" # Optional: filter discovered repositories
+  discoveryFilters: 
+    - "MyOrg/*" # Optional: filter discovered repositories
   image: renovate/renovate:latest # renovate
   secretRef: "renovate-secret"
   provider:

--- a/docs/platforms/github-app-eso.md
+++ b/docs/platforms/github-app-eso.md
@@ -9,7 +9,8 @@ metadata:
   name: renovate-github
   namespace: renovate-operator
 spec:
-  discoveryFilter: ###GITHUB_USERNAME###/*
+  discoveryFilters: 
+    - ###GITHUB_USERNAME###/*
   provider:
     name: github
     endpoint: ""  # optional, defaults to https://api.github.com

--- a/docs/platforms/github-pat.md
+++ b/docs/platforms/github-pat.md
@@ -9,7 +9,8 @@ metadata:
   name: renovate-github
   namespace: renovate-operator
 spec:
-  discoveryFilter: ###GITHUB_USERNAME###/*
+  discoveryFilters: 
+    - ###GITHUB_USERNAME###/*
   provider:
     name: github
     endpoint: ""  # optional, defaults to https://api.github.com

--- a/docs/platforms/gitlab.md
+++ b/docs/platforms/gitlab.md
@@ -8,7 +8,8 @@ metadata:
   namespace: renovate-operator
 spec:
   schedule: "0 * * * *"
-  discoveryFilter: "Group1/*"
+  discoveryFilters: 
+    - "Group1/*"
   image: renovate/renovate:41.43.3 # renovate
   secretRef: "renovate-secret"
   provider:

--- a/docs/webhooks/webhook.md
+++ b/docs/webhooks/webhook.md
@@ -34,7 +34,8 @@ metadata:
   namespace: renovate-operator
 spec:
   schedule: "0 * * * *"
-  discoveryFilter: "Group1/*"
+  discoveryFilters: 
+    - "Group1/*"
   image: renovate/renovate:41.43.3
   secretRef: "renovate-secret"
   parallelism: 1
@@ -73,7 +74,8 @@ metadata:
   namespace: renovate-operator
 spec:
   schedule: "0 * * * *"
-  discoveryFilter: "Group1/*"
+  discoveryFilters: 
+    - "Group1/*"
   image: renovate/renovate:41.43.3
   secretRef: "renovate-secret"
   parallelism: 1

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -19,10 +19,10 @@ type RenovateJobSpec struct {
 	Image string `json:"image"`
 	// Renovate Provider Information to fill "RENOVATE_ENDPOINT" and "RENOVATE_PLATFORM" environment variables in the renovate container
 	Provider *RenovateProvider `json:"provider"`
-	// Filter to select which projects to process
-	DiscoveryFilter string `json:"discoveryFilter,omitempty"`
-	// Topics to discover projects from
-	DiscoverTopics string `json:"discoverTopics,omitempty"`
+	// Filter to select which projects to process, will be concatenated using , separator
+	DiscoveryFilters []string `json:"discoveryFilters,omitempty"`
+	// Topics to discover projects from, will be concatenated using , separator
+	DiscoverTopics []string `json:"discoverTopics,omitempty"`
 	// If true, forked repositories discovered during autodiscovery will be excluded by querying the platform API
 	SkipForks bool `json:"skipForks,omitempty"`
 	// Reference to the secret containing the renovate config
@@ -79,8 +79,8 @@ type RenovateJobSecurityContext struct {
 
 // configuration for webhooks that can be used to trigger renovate runs
 type RenovateWebhook struct {
-	Enabled        bool                 `json:"enabled"`
-	Authentication *RenovateWebhookAuth `json:"authentication,omitempty"`
+	Enabled        bool                    `json:"enabled"`
+	Authentication *RenovateWebhookAuth    `json:"authentication,omitempty"`
 	Forgejo        *RenovateWebhookForgejo `json:"forgejo,omitempty"`
 }
 

--- a/src/controllers/renovatejob_controller.go
+++ b/src/controllers/renovatejob_controller.go
@@ -177,8 +177,8 @@ func (r *RenovateJobReconciler) ensureWebhookSyncer(ctx context.Context, logger 
 	}
 
 	topic := syncCfg.Topic
-	if topic == "" {
-		topic = renovateJob.Spec.DiscoverTopics
+	if topic == "" && len(renovateJob.Spec.DiscoverTopics) > 0 {
+		topic = renovateJob.Spec.DiscoverTopics[0]
 	}
 
 	webhookURL := syncCfg.WebhookURL
@@ -224,10 +224,10 @@ func (r *RenovateJobReconciler) ensureWebhookSyncer(ctx context.Context, logger 
 }
 
 // syncFingerprint produces a string that changes when any sync-relevant config changes.
-func syncFingerprint(cfg *api.RenovateWebhookForgejoSync, endpoint, defaultTopic, namespace, jobName string) string {
+func syncFingerprint(cfg *api.RenovateWebhookForgejoSync, endpoint string, defaultTopic []string, namespace, jobName string) string {
 	topic := cfg.Topic
-	if topic == "" {
-		topic = defaultTopic
+	if topic == "" && len(defaultTopic) > 0 {
+		topic = defaultTopic[0]
 	}
 	tokenRef := ""
 	if cfg.TokenSecretRef != nil {

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -8,6 +8,7 @@ import (
 	crdmanager "renovate-operator/internal/crdManager"
 	"renovate-operator/internal/utils"
 	"strconv"
+	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -18,16 +19,18 @@ import (
 func newDiscoveryJob(job *api.RenovateJob) *batchv1.Job {
 	predefinedEnvVars := getDefaultEnvVars(job)
 
-	if job.Spec.DiscoveryFilter != "" {
+	if len(job.Spec.DiscoveryFilters) > 0 {
+		filter := strings.Join(job.Spec.DiscoveryFilters, ",")
 		predefinedEnvVars = append(predefinedEnvVars, v1.EnvVar{
 			Name:  "RENOVATE_AUTODISCOVER_FILTER",
-			Value: job.Spec.DiscoveryFilter,
+			Value: filter,
 		})
 	}
-	if job.Spec.DiscoverTopics != "" {
+	if len(job.Spec.DiscoverTopics) > 0 {
+		filter := strings.Join(job.Spec.DiscoverTopics, ",")
 		predefinedEnvVars = append(predefinedEnvVars, v1.EnvVar{
 			Name:  "RENOVATE_AUTODISCOVER_TOPICS",
-			Value: job.Spec.DiscoverTopics,
+			Value: filter,
 		})
 	}
 

--- a/src/internal/renovate/jobDefinitions_test.go
+++ b/src/internal/renovate/jobDefinitions_test.go
@@ -91,8 +91,8 @@ func TestNewJobs_WithSettings(t *testing.T) {
 				Name:     "gitlab",
 				Endpoint: "gitlab.example.com",
 			},
-			DiscoveryFilter: "org/*",
-			DiscoverTopics:  "renovate",
+			DiscoveryFilters: []string{"org1/*", "org2/repo1"},
+			DiscoverTopics:   []string{"renovate", "!skipRenovate"},
 			Metadata: &api.RenovateJobMetadata{
 				Labels: map[string]string{"a": "b"},
 			},
@@ -201,8 +201,8 @@ func TestNewJobs_WithSettings(t *testing.T) {
 
 	// env vars
 	expectEnvVar(t, djContainer, "LOG_FORMAT", "console")
-	expectEnvVar(t, djContainer, "RENOVATE_AUTODISCOVER_FILTER", "org/*")
-	expectEnvVar(t, djContainer, "RENOVATE_AUTODISCOVER_TOPICS", "renovate")
+	expectEnvVar(t, djContainer, "RENOVATE_AUTODISCOVER_FILTER", "org1/*,org2/repo1")
+	expectEnvVar(t, djContainer, "RENOVATE_AUTODISCOVER_TOPICS", "renovate,!skipRenovate")
 	expectEnvVar(t, djContainer, "RENOVATE_ENDPOINT", "gitlab.example.com")
 	expectEnvVar(t, djContainer, "RENOVATE_PLATFORM", "gitlab")
 	expectEnvVar(t, djContainer, "LOG_LEVEL", "debug")


### PR DESCRIPTION
BREAKING CHANGE: discoveryFilter is renamed to discoveryFilters and is now a []string. discoverTopics becomes a []string as well. Both are joined with , before being passed to RENOVATE_AUTODISCOVER_FILTER and RENOVATE_AUTODISCOVER_TOPICS respectively.