### PR TITLE
feat: adding in memory log store

### DIFF
--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -184,6 +184,8 @@ spec:
             {{- end }}
             - name: GLOBAL_PARALLELISM_LIMIT
               value: {{ .Values.config.globalParallelismLimit | quote }}
+            - name: LOG_STORE_MODE
+              value: {{ .Values.config.logStorage.mode | quote }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -68,6 +68,9 @@ config:
   jobTTLSecondsAfterFinished: -1
   # -- global limit for concurrent renovate executor jobs across all RenovateJobs (0 = unlimited)
   globalParallelismLimit: 0
+  logStorage:
+    # -- log store mode: "disabled" (default, no-op) or "memory" (cache logs in-memory after job completion)
+    mode: disabled
 
 ingress:
   # -- whether to enable the ingress renovate-operator

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	gitProviderClientFactory "renovate-operator/gitProviderClients/factory"
 	"renovate-operator/health"
 	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/logStore"
 	"renovate-operator/internal/renovate"
 	"renovate-operator/metricStore"
 	"renovate-operator/scheduler"
@@ -213,6 +214,18 @@ func main() {
 			Default:  "false",
 		},
 		{
+			Key:      "LOG_STORE_MODE",
+			Optional: true,
+			Default:  "disabled",
+			Validate: func(value string) error {
+				switch value {
+				case "disabled", "memory":
+					return nil
+				}
+				return fmt.Errorf("'LOG_STORE_MODE' must be one of: disabled, memory")
+			},
+		},
+		{
 			Key:      "GLOBAL_PARALLELISM_LIMIT",
 			Optional: true,
 			Default:  "0",
@@ -267,7 +280,9 @@ func main() {
 
 	gitProviderClientFactory := gitProviderClientFactory.NewGitProviderClientFactory(mgr.GetClient())
 
-	jobMgr := crdManager.NewRenovateJobManager(mgr.GetClient(), gitProviderClientFactory, ctrl.Log.WithName("job-manager"))
+	ls := logStore.NewLogStore(config.GetValue("LOG_STORE_MODE"))
+
+	jobMgr := crdManager.NewRenovateJobManager(mgr.GetClient(), gitProviderClientFactory, ctrl.Log.WithName("job-manager"), ls)
 
 	discovery := renovate.NewDiscoveryAgent(
 		mgr.GetScheme(),
@@ -362,6 +377,7 @@ func main() {
 		mgr.GetClient(),
 		ctrl.Log.WithName("renovate-executor"),
 		health,
+		ls,
 	)
 
 	// Executor and scheduler must only run on the leader to prevent duplicate jobs.

--- a/src/internal/crdManager/renovateJobManager.go
+++ b/src/internal/crdManager/renovateJobManager.go
@@ -14,6 +14,7 @@ import (
 	"renovate-operator/clientProvider"
 	"renovate-operator/gitProviderClients"
 	gitProviderClientFactory "renovate-operator/gitProviderClients/factory"
+	"renovate-operator/internal/logStore"
 	"renovate-operator/internal/types"
 	"renovate-operator/internal/utils"
 	"renovate-operator/metricStore"
@@ -62,6 +63,7 @@ type renovateJobManager struct {
 	gitProviderClientFactory gitProviderClientFactory.GitProviderClientFactory
 	logger                   logr.Logger
 	lock                     *sync.RWMutex
+	logStore                 logStore.LogStore
 }
 
 type RenovateJobIdentifier struct {
@@ -82,12 +84,13 @@ type RenovateProjectStatus struct {
 	Duration             *string                   `json:"duration,omitempty"`
 }
 
-func NewRenovateJobManager(client client.Client, gitProviderClientFactory gitProviderClientFactory.GitProviderClientFactory, logger logr.Logger) RenovateJobManager {
+func NewRenovateJobManager(client client.Client, gitProviderClientFactory gitProviderClientFactory.GitProviderClientFactory, logger logr.Logger, ls logStore.LogStore) RenovateJobManager {
 	return &renovateJobManager{
 		client:                   client,
 		gitProviderClientFactory: gitProviderClientFactory,
 		logger:                   logger,
 		lock:                     &sync.RWMutex{},
+		logStore:                 ls,
 	}
 }
 
@@ -330,29 +333,50 @@ func (r *renovateJobManager) GetLogsForProject(ctx context.Context, job Renovate
 	defer r.globalManagerLock(true)()
 	renovateJob, err := loadRenovateJob(ctx, job.Name, job.Namespace, r.client)
 	if err != nil {
-		return "failed to load renovate job", err
+		return "", fmt.Errorf("failed to load renovate job: %w", err)
+	}
+
+	// Determine whether the project is currently running.
+	projectRunning := false
+	for _, p := range renovateJob.Status.Projects {
+		if p.Name == project && p.Status == api.JobStatusRunning {
+			projectRunning = true
+			break
+		}
 	}
 
 	executorJobName := utils.ExecutorJobName(renovateJob, project)
 
-	executorJob, err := GetJobByLabel(ctx, r.client, JobSelector{
+	executorJob, jobErr := GetJobByLabel(ctx, r.client, JobSelector{
 		JobName:   executorJobName,
 		JobType:   ExecutorJobType,
 		Namespace: job.Namespace,
 	})
-	if err != nil {
-		return "failed to get job", err
+
+	if jobErr == nil {
+		cp := clientProvider.StaticClientProvider()
+		clientset, err := cp.K8sClientSet()
+		if err != nil {
+			return "", fmt.Errorf("failed to create client: %w", err)
+		}
+		logs, err := GetLastJobLog(ctx, clientset, executorJob)
+		if err == nil {
+			return logs, nil
+		}
+		// Pod is gone — fall through to store only if job is not running.
+		if projectRunning {
+			return "", fmt.Errorf("failed to get pod logs for running project: %w", err)
+		}
+	} else if projectRunning {
+		return "", fmt.Errorf("failed to get job for running project: %w", jobErr)
 	}
 
-	cp := clientProvider.StaticClientProvider()
-	client, err := cp.K8sClientSet()
-	if err != nil {
-		return "failed to create client", err
+	// Job or pod not available and project is not running — try the log store.
+	if logs, ok := r.logStore.Get(job.Namespace, job.Name, project); ok {
+		return logs, nil
 	}
 
-	logs, err := GetLastJobLog(ctx, client, executorJob)
-
-	return logs, err
+	return "", fmt.Errorf("logs not available: pod has been cleaned up and no cached logs found")
 }
 
 func (r *renovateJobManager) getRenovateJobTokens(ctx context.Context, job *api.RenovateJob) ([]string, error) {

--- a/src/internal/crdManager/renovateJobManager_test.go
+++ b/src/internal/crdManager/renovateJobManager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	api "renovate-operator/api/v1alpha1"
+	"renovate-operator/internal/logStore"
 	"renovate-operator/internal/types"
 
 	"github.com/go-logr/logr"
@@ -37,7 +38,7 @@ func TestListRenovateJobs(t *testing.T) {
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(j1, j2).Build()
 
-	mgr := NewRenovateJobManager(cl, nil, logr.Logger{})
+	mgr := NewRenovateJobManager(cl, nil, logr.Logger{}, logStore.NewLogStore("memory"))
 	ctx := context.Background()
 	list, err := mgr.ListRenovateJobs(ctx)
 	if err != nil {
@@ -59,7 +60,7 @@ func TestListRenovateJobsFull(t *testing.T) {
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(j1, j2).Build()
 
-	mgr := NewRenovateJobManager(cl, nil, logr.Logger{})
+	mgr := NewRenovateJobManager(cl, nil, logr.Logger{}, logStore.NewLogStore("memory"))
 	ctx := context.Background()
 	list, err := mgr.ListRenovateJobsFull(ctx)
 	if err != nil {
@@ -89,7 +90,7 @@ func TestUpdateProjectStatus_AddAndUpdate(t *testing.T) {
 	inner := fake.NewClientBuilder().WithScheme(scheme).WithObjects(j).Build()
 	cl := inner
 
-	mgr := NewRenovateJobManager(cl, nil, logr.Logger{})
+	mgr := NewRenovateJobManager(cl, nil, logr.Logger{}, logStore.NewLogStore("memory"))
 	ctx := context.Background()
 
 	// shorten retries for tests
@@ -163,7 +164,7 @@ func TestUpdateProjectStatusBatched(t *testing.T) {
 	inner := fake.NewClientBuilder().WithScheme(scheme).WithObjects(j).Build()
 	cl := inner
 
-	mgr := NewRenovateJobManager(cl, nil, logr.Logger{})
+	mgr := NewRenovateJobManager(cl, nil, logr.Logger{}, logStore.NewLogStore("memory"))
 	ctx := context.Background()
 
 	// override status update implementation to avoid fake client Status() issues
@@ -225,7 +226,7 @@ func TestReconcileProjects_AddsAndKeepsExisting(t *testing.T) {
 	inner := fake.NewClientBuilder().WithScheme(scheme).WithObjects(j).Build()
 	cl := inner
 
-	mgr := NewRenovateJobManager(cl, nil, logr.Logger{})
+	mgr := NewRenovateJobManager(cl, nil, logr.Logger{}, logStore.NewLogStore("memory"))
 	ctx := context.Background()
 
 	// override status update implementation to avoid fake client Status() issues
@@ -287,7 +288,7 @@ func TestGetProjectsFilters(t *testing.T) {
 	j := makeJob("job1", "default", projects)
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(j).Build()
 
-	mgr := NewRenovateJobManager(cl, nil, logr.Logger{})
+	mgr := NewRenovateJobManager(cl, nil, logr.Logger{}, logStore.NewLogStore("memory"))
 	ctx := context.Background()
 
 	list, err := mgr.GetProjectsByStatus(ctx, RenovateJobIdentifier{Name: "job1", Namespace: "default"}, api.JobStatusCompleted)

--- a/src/internal/logStore/logStore.go
+++ b/src/internal/logStore/logStore.go
@@ -1,0 +1,58 @@
+package logStore
+
+import (
+	"fmt"
+	"sync"
+)
+
+// LogStore holds the most-recent log output for completed Renovate executor jobs,
+// keyed by (namespace, renovateJob, project). Entries are overwritten on every new
+// run, so memory growth is bounded by the number of distinct projects.
+type LogStore interface {
+	// Save stores logs for the given project, overwriting any previously saved value.
+	Save(namespace, renovateJob, project, logs string)
+	// Get retrieves the most-recently saved logs for the given project.
+	// Returns (logs, true) if found, ("", false) otherwise.
+	Get(namespace, renovateJob, project string) (string, bool)
+}
+
+// noopLogStore is the default implementation when LOG_STORE_MODE=disabled.
+// All operations are no-ops so there is zero overhead.
+type noopLogStore struct{}
+
+func (noopLogStore) Save(_, _, _, _ string)         {}
+func (noopLogStore) Get(_, _, _ string) (string, bool) { return "", false }
+
+// memoryLogStore is the in-memory implementation when LOG_STORE_MODE=memory.
+type memoryLogStore struct {
+	mu   sync.RWMutex
+	data map[string]string
+}
+
+func key(namespace, renovateJob, project string) string {
+	return fmt.Sprintf("RENOVATE_LOGS:%s:%s:%s", namespace, renovateJob, project)
+}
+
+func (s *memoryLogStore) Save(namespace, renovateJob, project, logs string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key(namespace, renovateJob, project)] = logs
+}
+
+func (s *memoryLogStore) Get(namespace, renovateJob, project string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	logs, ok := s.data[key(namespace, renovateJob, project)]
+	return logs, ok
+}
+
+// NewLogStore creates a LogStore based on the provided mode.
+// Supported modes: "disabled" (default, no-op), "memory" (in-memory store).
+func NewLogStore(mode string) LogStore {
+	switch mode {
+	case "memory":
+		return &memoryLogStore{data: make(map[string]string)}
+	default:
+		return noopLogStore{}
+	}
+}

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -14,6 +14,7 @@ import (
 	"renovate-operator/metricStore"
 
 	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/logStore"
 	"renovate-operator/internal/parser"
 	"renovate-operator/internal/types"
 	"renovate-operator/internal/utils"
@@ -35,24 +36,26 @@ type RenovateExecutor interface {
 }
 
 type renovateExecutor struct {
-	scheme  *runtime.Scheme
-	client  client.Client
-	logger  logr.Logger
-	health  health.HealthCheck
-	manager crdManager.RenovateJobManager
+	scheme   *runtime.Scheme
+	client   client.Client
+	logger   logr.Logger
+	health   health.HealthCheck
+	manager  crdManager.RenovateJobManager
+	logStore logStore.LogStore
 }
 
 type executionOptions struct {
 	globalParallelism int
 }
 
-func NewRenovateExecutor(scheme *runtime.Scheme, manager crdManager.RenovateJobManager, client client.Client, logger logr.Logger, health health.HealthCheck) RenovateExecutor {
+func NewRenovateExecutor(scheme *runtime.Scheme, manager crdManager.RenovateJobManager, client client.Client, logger logr.Logger, health health.HealthCheck, ls logStore.LogStore) RenovateExecutor {
 	return &renovateExecutor{
-		client:  client,
-		scheme:  scheme,
-		manager: manager,
-		logger:  logger,
-		health:  health,
+		client:   client,
+		scheme:   scheme,
+		manager:  manager,
+		logger:   logger,
+		health:   health,
+		logStore: ls,
 	}
 }
 
@@ -170,6 +173,7 @@ func (e *renovateExecutor) reconcileRunning(ctx context.Context, renovateJobs []
 				cp := clientProvider.StaticClientProvider()
 				if clientset, err := cp.K8sClientSet(); err == nil {
 					if logs, err := crdManager.GetLastJobLog(ctx, clientset, k8sJob); err == nil {
+						e.logStore.Save(renovateJob.Namespace, renovateJob.Name, project.Name, logs)
 						parseResult := parser.ParseRenovateLogs(logs)
 						hasIssues = parseResult.HasIssues
 						newProjectStatus.RenovateResultStatus = parseResult.RenovateResultStatus


### PR DESCRIPTION
references #181

Adding in memory log store that can be activated via elm-values. This provides the ground-work to add other stores that would also work for ha deployments