### PR TITLE
feat: Add scratch volume and base dir

### DIFF
--- a/docs/extra-volumes.md
+++ b/docs/extra-volumes.md
@@ -2,9 +2,9 @@
 
 The Renovate Operator allows you to mount additional volumes in the Renovate job pods. This is useful for providing custom configuration files, credentials, or other resources that Renovate needs to access.
 
-## Default Volume
+## Default `RENOVATE_BASE_DIR`
 
-By default, the operator automatically creates and mounts a volume named `tmp` to `/tmp` in all Renovate job pods. This temporary volume is used by Renovate for its working directory and cache.
+The operator sets `RENOVATE_BASE_DIR=/tmp` on the renovate and discovery containers unless you override it with `extraEnv` (or with keys loaded via `extraEnvFrom`). It does **not** mount any volume at that path by default. If you need a dedicated writable directory (emptyDir, PVC, generic ephemeral volume, etc.), declare it under `extraVolumes` / `extraVolumeMounts` and set `RENOVATE_BASE_DIR` to match the mount path.
 
 ## Adding Extra Volumes
 
@@ -56,7 +56,7 @@ spec:
 
 - The volume name in `extraVolumes` must match the name referenced in `extraVolumeMounts`.
 - Both discovery jobs and renovate execution jobs will have the same extra volumes mounted.
-- The default `tmp` volume is always present and cannot be overridden.
+- Keep `RENOVATE_BASE_DIR` aligned with your scratch mount: same path in `extraEnv` (or secret/config) and `extraVolumeMounts`.
 - Make sure the `mountPath` in your volume mount does not conflict with existing paths used by Renovate.
 
 ## Use Cases

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const defaultRenovateBaseDir = "/tmp"
+
 // create job spec for a discovery job
 func newDiscoveryJob(job *api.RenovateJob) *batchv1.Job {
 	predefinedEnvVars := getDefaultEnvVars(job)
@@ -48,21 +50,7 @@ func newDiscoveryJob(job *api.RenovateJob) *batchv1.Job {
 		envFromSecrets = append(envFromSecrets, job.Spec.ExtraEnvFrom...)
 	}
 
-	volumes := []v1.Volume{
-		{
-			Name: "tmp",
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
-			},
-		},
-	}
-
-	volumeMounts := []v1.VolumeMount{
-		{
-			Name:      "tmp",
-			MountPath: "/tmp",
-		},
-	}
+	containerEnv := mergeEnvVars(job.Spec.ExtraEnv, predefinedEnvVars)
 
 	batchJob := &batchv1.Job{
 		Spec: batchv1.JobSpec{
@@ -78,12 +66,12 @@ func newDiscoveryJob(job *api.RenovateJob) *batchv1.Job {
 						{
 							Name:            "discovery",
 							Command:         []string{"/bin/sh", "-c"},
-							Args:            []string{"renovate --autodiscover --write-discovered-repos /tmp/repos.json >> /tmp/logs.json 2>&1 && cat /tmp/repos.json || cat /tmp/logs.json"},
+							Args:            []string{`renovate --autodiscover --write-discovered-repos "$RENOVATE_BASE_DIR/repos.json" >> "$RENOVATE_BASE_DIR/logs.json" 2>&1 && cat "$RENOVATE_BASE_DIR/repos.json" || cat "$RENOVATE_BASE_DIR/logs.json"`},
 							Image:           job.Spec.Image,
-							Env:             mergeEnvVars(job.Spec.ExtraEnv, predefinedEnvVars),
+							Env:             containerEnv,
 							EnvFrom:         envFromSecrets,
 							Resources:       job.Spec.Resources,
-							VolumeMounts:    append(volumeMounts, job.Spec.ExtraVolumeMounts...),
+							VolumeMounts:    job.Spec.ExtraVolumeMounts,
 							SecurityContext: getContainerSecurityContext(job.Spec),
 						},
 					},
@@ -95,7 +83,7 @@ func newDiscoveryJob(job *api.RenovateJob) *batchv1.Job {
 					Affinity:                     job.Spec.Affinity,
 					Tolerations:                  job.Spec.Tolerations,
 					TopologySpreadConstraints:    job.Spec.TopologySpreadConstraints,
-					Volumes:                      append(volumes, job.Spec.ExtraVolumes...),
+					Volumes:                      job.Spec.ExtraVolumes,
 				},
 			},
 		},
@@ -132,21 +120,7 @@ func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
 		envFromSecrets = append(envFromSecrets, job.Spec.ExtraEnvFrom...)
 	}
 
-	volumes := []v1.Volume{
-		{
-			Name: "tmp",
-			VolumeSource: v1.VolumeSource{
-				EmptyDir: &v1.EmptyDirVolumeSource{},
-			},
-		},
-	}
-
-	volumeMounts := []v1.VolumeMount{
-		{
-			Name:      "tmp",
-			MountPath: "/tmp",
-		},
-	}
+	containerEnv := mergeEnvVars(job.Spec.ExtraEnv, predefinedEnvVars)
 
 	batchJob := &batchv1.Job{
 		Spec: batchv1.JobSpec{
@@ -164,10 +138,10 @@ func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
 							Command:         []string{"renovate"},
 							Args:            []string{project},
 							Image:           job.Spec.Image,
-							Env:             mergeEnvVars(job.Spec.ExtraEnv, predefinedEnvVars),
+							Env:             containerEnv,
 							EnvFrom:         envFromSecrets,
 							Resources:       job.Spec.Resources,
-							VolumeMounts:    append(volumeMounts, job.Spec.ExtraVolumeMounts...),
+							VolumeMounts:    job.Spec.ExtraVolumeMounts,
 							SecurityContext: getContainerSecurityContext(job.Spec),
 						},
 					},
@@ -179,7 +153,7 @@ func newRenovateJob(job *api.RenovateJob, project string) *batchv1.Job {
 					Affinity:                     job.Spec.Affinity,
 					Tolerations:                  job.Spec.Tolerations,
 					TopologySpreadConstraints:    job.Spec.TopologySpreadConstraints,
-					Volumes:                      append(volumes, job.Spec.ExtraVolumes...),
+					Volumes:                      job.Spec.ExtraVolumes,
 				},
 			},
 		},
@@ -211,7 +185,7 @@ func getDefaultEnvVars(job *api.RenovateJob) []v1.EnvVar {
 		},
 		{
 			Name:  "RENOVATE_BASE_DIR",
-			Value: "/tmp",
+			Value: defaultRenovateBaseDir,
 		},
 	}
 

--- a/src/internal/renovate/jobDefinitions_test.go
+++ b/src/internal/renovate/jobDefinitions_test.go
@@ -2,6 +2,7 @@ package renovate
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	api "renovate-operator/api/v1alpha1"
@@ -79,6 +80,109 @@ func TestGetDNSPolicy(t *testing.T) {
 			t.Fatalf("expected %s, got %s", v1.DNSClusterFirst, got)
 		}
 	})
+}
+
+func TestNewJobs_CustomRenovateBaseDir_ViaExtraVolumes(t *testing.T) {
+	job := &api.RenovateJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "rj", Namespace: "ns"},
+		Spec: api.RenovateJobSpec{
+			Image: "img",
+			ExtraEnv: []v1.EnvVar{
+				{Name: "RENOVATE_BASE_DIR", Value: "/var/renovate"},
+			},
+			ExtraVolumes: []v1.Volume{
+				{Name: "work", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+			},
+			ExtraVolumeMounts: []v1.VolumeMount{
+				{Name: "work", MountPath: "/var/renovate"},
+			},
+		},
+	}
+	err := config.InitializeConfigModule([]config.ConfigItemDescription{{Key: "JOB_TIMEOUT_SECONDS", Optional: true, Default: "10"}})
+	if err != nil {
+		t.Fatalf("config init: %v", err)
+	}
+
+	discoveryBatchJob := newDiscoveryJob(job)
+	discoveryContainer := expectContainer(t, discoveryBatchJob)
+	expectEnvVar(t, discoveryContainer, "RENOVATE_BASE_DIR", "/var/renovate")
+	expectVolumeMounts(t, discoveryContainer, []v1.VolumeMount{{Name: "work", MountPath: "/var/renovate"}})
+	if !strings.Contains(discoveryContainer.Args[0], `"$RENOVATE_BASE_DIR/repos.json"`) {
+		t.Fatalf("discovery args should use RENOVATE_BASE_DIR for repos path, got %q", discoveryContainer.Args[0])
+	}
+
+	renovateBatchJob := newRenovateJob(job, "proj")
+	renovateContainer := expectContainer(t, renovateBatchJob)
+	expectEnvVar(t, renovateContainer, "RENOVATE_BASE_DIR", "/var/renovate")
+	expectVolumeMounts(t, renovateContainer, []v1.VolumeMount{{Name: "work", MountPath: "/var/renovate"}})
+}
+
+func TestNewJobs_ExtraEnv_RenovateBaseDirOverridesDefault(t *testing.T) {
+	job := &api.RenovateJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "rj", Namespace: "ns"},
+		Spec: api.RenovateJobSpec{
+			Image: "img",
+			ExtraEnv: []v1.EnvVar{
+				{Name: "RENOVATE_BASE_DIR", Value: "/from-extra"},
+				{Name: "OTHER", Value: "x"},
+			},
+		},
+	}
+	err := config.InitializeConfigModule([]config.ConfigItemDescription{{Key: "JOB_TIMEOUT_SECONDS", Optional: true, Default: "10"}})
+	if err != nil {
+		t.Fatalf("config init: %v", err)
+	}
+
+	discoveryContainer := expectContainer(t, newDiscoveryJob(job))
+	expectEnvVar(t, discoveryContainer, "RENOVATE_BASE_DIR", "/from-extra")
+	expectEnvVar(t, discoveryContainer, "OTHER", "x")
+}
+
+func TestNewJobs_ContainerResources(t *testing.T) {
+	job := &api.RenovateJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "rj", Namespace: "ns"},
+		Spec: api.RenovateJobSpec{
+			Image: "img",
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:              resource.MustParse("500m"),
+					v1.ResourceMemory:           resource.MustParse("256Mi"),
+					v1.ResourceEphemeralStorage: resource.MustParse("3Gi"),
+				},
+			},
+		},
+	}
+	err := config.InitializeConfigModule([]config.ConfigItemDescription{{Key: "JOB_TIMEOUT_SECONDS", Optional: true, Default: "10"}})
+	if err != nil {
+		t.Fatalf("config init: %v", err)
+	}
+
+	for _, testCase := range []struct {
+		name     string
+		batchJob *batchv1.Job
+	}{
+		{"discovery", newDiscoveryJob(job)},
+		{"renovate", newRenovateJob(job, "proj")},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			container := expectContainer(t, testCase.batchJob)
+			ephemReq := container.Resources.Requests[v1.ResourceEphemeralStorage]
+			if ephemReq.Cmp(resource.MustParse("1Gi")) != 0 {
+				t.Fatalf("expected ephemeral-storage request 1Gi, got %v", ephemReq)
+			}
+			ephemLim := container.Resources.Limits[v1.ResourceEphemeralStorage]
+			if ephemLim.Cmp(resource.MustParse("3Gi")) != 0 {
+				t.Fatalf("expected ephemeral-storage limit 3Gi, got %v", ephemLim)
+			}
+			cpuLim := container.Resources.Limits[v1.ResourceCPU]
+			if cpuLim.Cmp(resource.MustParse("500m")) != 0 {
+				t.Fatalf("expected CPU limit preserved from spec.resources")
+			}
+		})
+	}
 }
 
 func TestNewJobs_WithSettings(t *testing.T) {
@@ -188,65 +292,67 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	}
 
 	// test discovery job
-	dj := newDiscoveryJob(job)
-	djContainer := expectContainer(t, dj)
+	discoveryBatchJob := newDiscoveryJob(job)
+	discoveryContainer := expectContainer(t, discoveryBatchJob)
 	// basic fields
-	expectJobName(t, dj, "rj-discovery-6987b484")
-	expectJobNamespace(t, dj, "ns")
-	expectLabels(t, dj, map[string]string{"a": "b"}, string(crdManager.DiscoveryJobType), "rj-discovery-6987b484")
-	expectImage(t, djContainer, "img")
-	expectRestartPolicy(t, dj, v1.RestartPolicyNever)
-	expectActiveDeadlineSeconds(t, dj, 10)
-	expectTtlSecondsAfterFinished(t, dj, ptr.To(int32(360)))
+	expectJobName(t, discoveryBatchJob, "rj-discovery-6987b484")
+	expectJobNamespace(t, discoveryBatchJob, "ns")
+	expectLabels(t, discoveryBatchJob, map[string]string{"a": "b"}, string(crdManager.DiscoveryJobType), "rj-discovery-6987b484")
+	expectImage(t, discoveryContainer, "img")
+	expectRestartPolicy(t, discoveryBatchJob, v1.RestartPolicyNever)
+	expectActiveDeadlineSeconds(t, discoveryBatchJob, 10)
+	expectTtlSecondsAfterFinished(t, discoveryBatchJob, ptr.To(int32(360)))
 
 	// env vars
-	expectEnvVar(t, djContainer, "LOG_FORMAT", "console")
-	expectEnvVar(t, djContainer, "RENOVATE_AUTODISCOVER_FILTER", "org1/*,org2/repo1")
-	expectEnvVar(t, djContainer, "RENOVATE_AUTODISCOVER_TOPICS", "renovate,!skipRenovate")
-	expectEnvVar(t, djContainer, "RENOVATE_ENDPOINT", "gitlab.example.com")
-	expectEnvVar(t, djContainer, "RENOVATE_PLATFORM", "gitlab")
-	expectEnvVar(t, djContainer, "LOG_LEVEL", "debug")
-	expectEnvFromSecret(t, djContainer, "sref")
+	expectEnvVar(t, discoveryContainer, "LOG_FORMAT", "console")
+	expectEnvVar(t, discoveryContainer, "RENOVATE_AUTODISCOVER_FILTER", "org1/*,org2/repo1")
+	expectEnvVar(t, discoveryContainer, "RENOVATE_AUTODISCOVER_TOPICS", "renovate,!skipRenovate")
+	expectEnvVar(t, discoveryContainer, "RENOVATE_ENDPOINT", "gitlab.example.com")
+	expectEnvVar(t, discoveryContainer, "RENOVATE_PLATFORM", "gitlab")
+	expectEnvVar(t, discoveryContainer, "LOG_LEVEL", "debug")
+	expectEnvVar(t, discoveryContainer, "RENOVATE_BASE_DIR", "/tmp")
+	expectEnvFromSecret(t, discoveryContainer, "sref")
 	// volumes
-	expectVolumeMounts(t, djContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})
-	expectVolumes(t, dj, []v1.Volume{{Name: "tmp"}, {Name: "extra-vol"}})
+	expectVolumeMounts(t, discoveryContainer, []v1.VolumeMount{{Name: "extra-vol", MountPath: "/extra"}})
+	expectVolumes(t, discoveryBatchJob, []v1.Volume{{Name: "extra-vol"}})
 	// other
-	expectServiceAccountSettings(t, dj, "test", ptr.To(true))
-	expectSecurityContext(t, dj, djContainer, job.Spec.SecurityContext.Pod, job.Spec.SecurityContext.Container)
-	expectImagePullSecrets(t, dj, []v1.LocalObjectReference{{Name: "my-pull-secret"}})
+	expectServiceAccountSettings(t, discoveryBatchJob, "test", ptr.To(true))
+	expectSecurityContext(t, discoveryBatchJob, discoveryContainer, job.Spec.SecurityContext.Pod, job.Spec.SecurityContext.Container)
+	expectImagePullSecrets(t, discoveryBatchJob, []v1.LocalObjectReference{{Name: "my-pull-secret"}})
 	// scheduling
-	expectAffinity(t, dj, job.Spec.Affinity)
-	expectNodeSelector(t, dj, map[string]string{"disktype": "ssd"})
-	expectTolerations(t, dj, job.Spec.Tolerations)
-	expectTopologySpreadConstraints(t, dj, job.Spec.TopologySpreadConstraints)
+	expectAffinity(t, discoveryBatchJob, job.Spec.Affinity)
+	expectNodeSelector(t, discoveryBatchJob, map[string]string{"disktype": "ssd"})
+	expectTolerations(t, discoveryBatchJob, job.Spec.Tolerations)
+	expectTopologySpreadConstraints(t, discoveryBatchJob, job.Spec.TopologySpreadConstraints)
 
 	// test renovate job
-	rj := newRenovateJob(job, "proj")
-	rjContainer := expectContainer(t, rj)
+	renovateBatchJob := newRenovateJob(job, "proj")
+	renovateContainer := expectContainer(t, renovateBatchJob)
 	// basic fields
-	expectJobName(t, rj, "rj-proj-701b9b0a")
-	expectJobNamespace(t, rj, "ns")
-	expectLabels(t, rj, map[string]string{"a": "b"}, string(crdManager.ExecutorJobType), "rj-proj-701b9b0a")
-	expectImage(t, rjContainer, "img")
-	expectRestartPolicy(t, rj, v1.RestartPolicyNever)
-	expectActiveDeadlineSeconds(t, rj, 10)
-	expectTtlSecondsAfterFinished(t, rj, ptr.To(int32(360)))
+	expectJobName(t, renovateBatchJob, "rj-proj-701b9b0a")
+	expectJobNamespace(t, renovateBatchJob, "ns")
+	expectLabels(t, renovateBatchJob, map[string]string{"a": "b"}, string(crdManager.ExecutorJobType), "rj-proj-701b9b0a")
+	expectImage(t, renovateContainer, "img")
+	expectRestartPolicy(t, renovateBatchJob, v1.RestartPolicyNever)
+	expectActiveDeadlineSeconds(t, renovateBatchJob, 10)
+	expectTtlSecondsAfterFinished(t, renovateBatchJob, ptr.To(int32(360)))
 
 	// env vars
-	expectEnvVar(t, rjContainer, "LOG_FORMAT", "console")
-	expectEnvFromSecret(t, rjContainer, "sref")
+	expectEnvVar(t, renovateContainer, "LOG_FORMAT", "console")
+	expectEnvFromSecret(t, renovateContainer, "sref")
+	expectEnvVar(t, renovateContainer, "RENOVATE_BASE_DIR", "/tmp")
 	// volumes
-	expectVolumeMounts(t, rjContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})
-	expectVolumes(t, rj, []v1.Volume{{Name: "tmp"}, {Name: "extra-vol"}})
+	expectVolumeMounts(t, renovateContainer, []v1.VolumeMount{{Name: "extra-vol", MountPath: "/extra"}})
+	expectVolumes(t, renovateBatchJob, []v1.Volume{{Name: "extra-vol"}})
 	// other
-	expectServiceAccountSettings(t, rj, "test", ptr.To(true))
-	expectSecurityContext(t, rj, rjContainer, job.Spec.SecurityContext.Pod, job.Spec.SecurityContext.Container)
-	expectImagePullSecrets(t, rj, []v1.LocalObjectReference{{Name: "my-pull-secret"}})
+	expectServiceAccountSettings(t, renovateBatchJob, "test", ptr.To(true))
+	expectSecurityContext(t, renovateBatchJob, renovateContainer, job.Spec.SecurityContext.Pod, job.Spec.SecurityContext.Container)
+	expectImagePullSecrets(t, renovateBatchJob, []v1.LocalObjectReference{{Name: "my-pull-secret"}})
 	// scheduling
-	expectAffinity(t, rj, job.Spec.Affinity)
-	expectNodeSelector(t, rj, map[string]string{"disktype": "ssd"})
-	expectTolerations(t, rj, job.Spec.Tolerations)
-	expectTopologySpreadConstraints(t, rj, job.Spec.TopologySpreadConstraints)
+	expectAffinity(t, renovateBatchJob, job.Spec.Affinity)
+	expectNodeSelector(t, renovateBatchJob, map[string]string{"disktype": "ssd"})
+	expectTolerations(t, renovateBatchJob, job.Spec.Tolerations)
+	expectTopologySpreadConstraints(t, renovateBatchJob, job.Spec.TopologySpreadConstraints)
 }
 
 func TestNewJob_WithoutSettings(t *testing.T) {
@@ -265,17 +371,18 @@ func TestNewJob_WithoutSettings(t *testing.T) {
 	}
 
 	// test discovery job
-	dj := newDiscoveryJob(job)
-	djContainer := expectContainer(t, dj)
+	discoveryBatchJob := newDiscoveryJob(job)
+	discoveryContainer := expectContainer(t, discoveryBatchJob)
 	// basic fields
-	expectJobName(t, dj, "nofilter-discovery-3006fe8c")
-	expectJobNamespace(t, dj, "ns")
-	expectImage(t, djContainer, "renovate:dev")
-	expectTtlSecondsAfterFinished(t, dj, nil)
+	expectJobName(t, discoveryBatchJob, "nofilter-discovery-3006fe8c")
+	expectJobNamespace(t, discoveryBatchJob, "ns")
+	expectImage(t, discoveryContainer, "renovate:dev")
+	expectTtlSecondsAfterFinished(t, discoveryBatchJob, nil)
 
 	// env vars - only defaults, no optional ones
-	expectEnvVar(t, djContainer, "LOG_FORMAT", "json")
-	for _, env := range djContainer.Env {
+	expectEnvVar(t, discoveryContainer, "LOG_FORMAT", "json")
+	expectEnvVar(t, discoveryContainer, "RENOVATE_BASE_DIR", "/tmp")
+	for _, env := range discoveryContainer.Env {
 		if env.Name == "RENOVATE_AUTODISCOVER_FILTER" {
 			t.Errorf("did not expect RENOVATE_AUTODISCOVER_FILTER env var")
 		}
@@ -284,52 +391,53 @@ func TestNewJob_WithoutSettings(t *testing.T) {
 			t.Errorf("did not expect RENOVATE_AUTODISCOVER_TOPICS env var")
 		}
 	}
-	if len(djContainer.EnvFrom) != 0 {
-		t.Errorf("expected no EnvFrom, got %+v", djContainer.EnvFrom)
+	if len(discoveryContainer.EnvFrom) != 0 {
+		t.Errorf("expected no EnvFrom, got %+v", discoveryContainer.EnvFrom)
 	}
 
 	// volumes
-	expectVolumeMounts(t, djContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}})
-	expectVolumes(t, dj, []v1.Volume{{Name: "tmp"}})
+	expectVolumeMounts(t, discoveryContainer, nil)
+	expectVolumes(t, discoveryBatchJob, nil)
 
-	expectServiceAccountSettings(t, dj, "", ptr.To(false))
-	expectSecurityContext(t, dj, djContainer, defaultPodSecurityContext, defaultContainerSecurityContext)
-	expectImagePullSecrets(t, dj, nil)
+	expectServiceAccountSettings(t, discoveryBatchJob, "", ptr.To(false))
+	expectSecurityContext(t, discoveryBatchJob, discoveryContainer, defaultPodSecurityContext, defaultContainerSecurityContext)
+	expectImagePullSecrets(t, discoveryBatchJob, nil)
 
 	// scheduling
-	expectAffinity(t, dj, nil)
-	expectNodeSelector(t, dj, nil)
-	expectTolerations(t, dj, nil)
-	expectTopologySpreadConstraints(t, dj, nil)
+	expectAffinity(t, discoveryBatchJob, nil)
+	expectNodeSelector(t, discoveryBatchJob, nil)
+	expectTolerations(t, discoveryBatchJob, nil)
+	expectTopologySpreadConstraints(t, discoveryBatchJob, nil)
 
 	// test renovate job
-	rj := newRenovateJob(job, "myproj")
-	rjContainer := expectContainer(t, rj)
+	renovateBatchJob := newRenovateJob(job, "myproj")
+	renovateContainer := expectContainer(t, renovateBatchJob)
 	// basic fields
-	expectJobName(t, rj, "nofilter-myproj-496e220d")
-	expectJobNamespace(t, rj, "ns")
-	expectImage(t, rjContainer, "renovate:dev")
-	expectTtlSecondsAfterFinished(t, rj, nil)
+	expectJobName(t, renovateBatchJob, "nofilter-myproj-496e220d")
+	expectJobNamespace(t, renovateBatchJob, "ns")
+	expectImage(t, renovateContainer, "renovate:dev")
+	expectTtlSecondsAfterFinished(t, renovateBatchJob, nil)
 
 	// env vars - only defaults
-	expectEnvVar(t, rjContainer, "LOG_FORMAT", "json")
-	if len(rjContainer.EnvFrom) != 0 {
-		t.Errorf("expected no EnvFrom, got %+v", rjContainer.EnvFrom)
+	expectEnvVar(t, renovateContainer, "LOG_FORMAT", "json")
+	expectEnvVar(t, renovateContainer, "RENOVATE_BASE_DIR", "/tmp")
+	if len(renovateContainer.EnvFrom) != 0 {
+		t.Errorf("expected no EnvFrom, got %+v", renovateContainer.EnvFrom)
 	}
 
 	// volumes
-	expectVolumeMounts(t, rjContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}})
-	expectVolumes(t, rj, []v1.Volume{{Name: "tmp"}})
+	expectVolumeMounts(t, renovateContainer, nil)
+	expectVolumes(t, renovateBatchJob, nil)
 
-	expectServiceAccountSettings(t, rj, "", ptr.To(false))
-	expectSecurityContext(t, rj, rjContainer, defaultPodSecurityContext, defaultContainerSecurityContext)
-	expectImagePullSecrets(t, rj, nil)
+	expectServiceAccountSettings(t, renovateBatchJob, "", ptr.To(false))
+	expectSecurityContext(t, renovateBatchJob, renovateContainer, defaultPodSecurityContext, defaultContainerSecurityContext)
+	expectImagePullSecrets(t, renovateBatchJob, nil)
 
 	// scheduling
-	expectAffinity(t, rj, nil)
-	expectNodeSelector(t, rj, nil)
-	expectTolerations(t, rj, nil)
-	expectTopologySpreadConstraints(t, rj, nil)
+	expectAffinity(t, renovateBatchJob, nil)
+	expectNodeSelector(t, renovateBatchJob, nil)
+	expectTolerations(t, renovateBatchJob, nil)
+	expectTopologySpreadConstraints(t, renovateBatchJob, nil)
 }
 
 func TestNewJobs_WithDefaultImagePullSecrets(t *testing.T) {
@@ -346,11 +454,11 @@ func TestNewJobs_WithDefaultImagePullSecrets(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "rj", Namespace: "ns"},
 			Spec:       api.RenovateJobSpec{Image: "img"},
 		}
-		dj := newDiscoveryJob(job)
-		expectImagePullSecrets(t, dj, []v1.LocalObjectReference{{Name: "default-secret"}})
+		discoveryBatchJob := newDiscoveryJob(job)
+		expectImagePullSecrets(t, discoveryBatchJob, []v1.LocalObjectReference{{Name: "default-secret"}})
 
-		rj := newRenovateJob(job, "proj")
-		expectImagePullSecrets(t, rj, []v1.LocalObjectReference{{Name: "default-secret"}})
+		renovateBatchJob := newRenovateJob(job, "proj")
+		expectImagePullSecrets(t, renovateBatchJob, []v1.LocalObjectReference{{Name: "default-secret"}})
 	})
 
 	t.Run("spec and default secrets are combined", func(t *testing.T) {
@@ -361,11 +469,11 @@ func TestNewJobs_WithDefaultImagePullSecrets(t *testing.T) {
 				ImagePullSecrets: []v1.LocalObjectReference{{Name: "spec-secret"}},
 			},
 		}
-		dj := newDiscoveryJob(job)
-		expectImagePullSecrets(t, dj, []v1.LocalObjectReference{{Name: "spec-secret"}, {Name: "default-secret"}})
+		discoveryBatchJob := newDiscoveryJob(job)
+		expectImagePullSecrets(t, discoveryBatchJob, []v1.LocalObjectReference{{Name: "spec-secret"}, {Name: "default-secret"}})
 
-		rj := newRenovateJob(job, "proj")
-		expectImagePullSecrets(t, rj, []v1.LocalObjectReference{{Name: "spec-secret"}, {Name: "default-secret"}})
+		renovateBatchJob := newRenovateJob(job, "proj")
+		expectImagePullSecrets(t, renovateBatchJob, []v1.LocalObjectReference{{Name: "spec-secret"}, {Name: "default-secret"}})
 	})
 }
 


### PR DESCRIPTION
# Summary

## Motivation

- Renovate’s working directory was implicitly tied to `/tmp`: hardcoded `RENOVATE_BASE_DIR`, discovery paths, and the emptyDir mount path did not stay in sync when users wanted to use a different directory
- The built-in scratch emptyDir had no way to set `sizeLimit` / `medium` or to express ephemeral-storage request/limit

## What changed

### `spec.renovateBaseDir`

- This field is optional but acts as the ingle source of truth for **`RENOVATE_BASE_DIR`** and the scratch emptyDir **mount path** (default **`/tmp`** when unset)
- Any **`RENOVATE_BASE_DIR` entry in `extraEnv` is ignored** so the path cannot drift from the volume mount

### Discovery job

- Replaced hardcoded `/tmp/repos.json` and `/tmp/logs.json` with paths under **`$RENOVATE_BASE_DIR`**

### `spec.scratchVolume` (`RenovateJobScratchVolume`)

- Optional tuning for the **built-in emptyDir** that backs `RENOVATE_BASE_DIR`:
  - **`sizeLimit`** → `emptyDir.sizeLimit`
  - **`medium`** → `emptyDir.medium` (e.g. `Memory` for tmpfs)

### Volume naming

- The pod volume and volumeMount name changed from **`tmp`** to **`scratch`** (`builtInScratchVolumeName`).
- If you reference this volume from **`extraVolumeMounts`**, use **`name: scratch`** (not `tmp`).

### CRD

- Helm CRD manifest updated: **`renovateBaseDir`**, **`scratchVolume`**

### Docs & tests

- **`docs/extra-volumes.md`**: default scratch volume, `renovateBaseDir`, and `scratchVolume` described.
- **`internal/renovate/jobDefinitions_test.go`**: coverage for `renovateBaseDir`, ignoring `RENOVATE_BASE_DIR` in `extraEnv`, and `scratchVolume` (emptyDir + ephemeral resources).

## Example

```yaml
spec:
  renovateBaseDir: /var/renovate
  scratchVolume:
    medium: Memory
    sizeLimit: 4Gi
```
