### PR TITLE
feat(ui): make Open PRs header badge a clickable filter toggle

### DIFF
--- a/src/static/components/StatBadge.js
+++ b/src/static/components/StatBadge.js
@@ -5,7 +5,8 @@ export function StatBadge({
   borderClass = "border-gray-200 dark:border-slate-600",
   onClick,
   active = false,
-  activeBorderClass = "ring-2 ring-blue-500 border-blue-500 dark:ring-blue-400 dark:border-blue-400",
+  activeClass = "bg-blue-50 border-blue-500 dark:bg-blue-900/30 dark:border-blue-400",
+  title,
 }) {
   const clickable = typeof onClick === "function";
   const handleKeyDown = clickable
@@ -23,14 +24,16 @@ export function StatBadge({
         onClick,
         onKeyDown: handleKeyDown,
         "aria-pressed": active,
+        title,
       }
     : {};
-  const effectiveBorder = active ? activeBorderClass : borderClass;
+  const bgClass = active ? "" : "bg-white dark:bg-slate-700";
+  const effectiveBorder = active ? activeClass : borderClass;
   const cursorClass = clickable ? "cursor-pointer select-none" : "";
   return (
     <div
       {...interactiveProps}
-      className={`flex items-center justify-between gap-1.5 min-w-[7rem] bg-white dark:bg-slate-700 rounded-lg border ${effectiveBorder} px-3 py-1.5 shadow-sm hover:shadow-md transition-all ${cursorClass}`}
+      className={`flex items-center justify-between gap-1.5 min-w-[7rem] ${bgClass} rounded-lg border ${effectiveBorder} px-3 py-1.5 shadow-sm hover:shadow-md transition-all ${cursorClass}`}
     >
       <span className="text-[0.625rem] text-gray-500 dark:text-slate-400 uppercase tracking-wider whitespace-nowrap">{label}</span>
       <span className={`text-sm font-bold ${valueClass} tabular-nums`}>{value}</span>

--- a/src/static/components/StatBadge.js
+++ b/src/static/components/StatBadge.js
@@ -1,6 +1,37 @@
-export function StatBadge({ label, value, valueClass = "text-gray-900 dark:text-slate-100", borderClass = "border-gray-200 dark:border-slate-600" }) {
+export function StatBadge({
+  label,
+  value,
+  valueClass = "text-gray-900 dark:text-slate-100",
+  borderClass = "border-gray-200 dark:border-slate-600",
+  onClick,
+  active = false,
+  activeBorderClass = "ring-2 ring-blue-500 border-blue-500 dark:ring-blue-400 dark:border-blue-400",
+}) {
+  const clickable = typeof onClick === "function";
+  const handleKeyDown = clickable
+    ? (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick(e);
+        }
+      }
+    : undefined;
+  const interactiveProps = clickable
+    ? {
+        role: "button",
+        tabIndex: 0,
+        onClick,
+        onKeyDown: handleKeyDown,
+        "aria-pressed": active,
+      }
+    : {};
+  const effectiveBorder = active ? activeBorderClass : borderClass;
+  const cursorClass = clickable ? "cursor-pointer select-none" : "";
   return (
-    <div className={`flex items-center justify-between gap-1.5 min-w-[7rem] bg-white dark:bg-slate-700 rounded-lg border ${borderClass} px-3 py-1.5 shadow-sm hover:shadow-md transition-all`}>
+    <div
+      {...interactiveProps}
+      className={`flex items-center justify-between gap-1.5 min-w-[7rem] bg-white dark:bg-slate-700 rounded-lg border ${effectiveBorder} px-3 py-1.5 shadow-sm hover:shadow-md transition-all ${cursorClass}`}
+    >
       <span className="text-[0.625rem] text-gray-500 dark:text-slate-400 uppercase tracking-wider whitespace-nowrap">{label}</span>
       <span className={`text-sm font-bold ${valueClass} tabular-nums`}>{value}</span>
     </div>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -515,6 +515,26 @@
         const [toasts, setToasts] = useState([]);
         const nextToastIdRef = useRef(0);
         const [authInfo, setAuthInfo] = useState(null);
+        const [headerFilter, setHeaderFilter] = useState(() => {
+          try {
+            return localStorage.getItem('headerFilter') || null;
+          } catch {
+            return null;
+          }
+        });
+        const toggleHeaderFilter = useCallback((key) => {
+          setHeaderFilter((prev) => {
+            const next = prev === key ? null : key;
+            try {
+              if (next) {
+                localStorage.setItem('headerFilter', next);
+              } else {
+                localStorage.removeItem('headerFilter');
+              }
+            } catch {}
+            return next;
+          });
+        }, []);
 
         const addToast = useCallback(
           (type, title, message = "", duration = 5000) => {
@@ -796,7 +816,15 @@
               <StatBadge label="Running"   value={loading ? "—" : stats.running}    valueClass="text-primary" />
               <StatBadge label="Completed" value={loading ? "—" : stats.completed}  valueClass="text-success" />
               <div className="hidden lg:block basis-full h-0" />
-              <StatBadge label="Open PRs"    value={loading ? "—" : stats.openPRs}    valueClass="text-blue-500"  borderClass="border-blue-200 dark:border-blue-700" />
+              <StatBadge
+                label="Open PRs"
+                value={loading ? "—" : stats.openPRs}
+                valueClass="text-blue-500"
+                borderClass="border-blue-200 dark:border-blue-700"
+                onClick={() => toggleHeaderFilter('openPRs')}
+                active={headerFilter === 'openPRs'}
+                activeBorderClass="ring-2 ring-blue-500 border-blue-500 dark:ring-blue-400 dark:border-blue-400"
+              />
               <StatBadge label="With Issues" value={loading ? "—" : stats.withIssues} valueClass="text-amber-500" borderClass="border-amber-300 dark:border-amber-600" />
             </SiteHeader>
 
@@ -859,6 +887,7 @@
                       onTriggerRenovate={triggerRenovate}
                       onTriggerAllRenovate={triggerAllRenovate}
                       onSaveExecutionOptions={saveExecutionOptions}
+                      headerFilter={headerFilter}
                     />
                   ))}
 
@@ -1153,7 +1182,7 @@
         );
       }
 
-      function JobCard({ job, onRunDiscovery, onTriggerRenovate, onTriggerAllRenovate, onSaveExecutionOptions }) {
+      function JobCard({ job, onRunDiscovery, onTriggerRenovate, onTriggerAllRenovate, onSaveExecutionOptions, headerFilter }) {
         const [open, setOpen] = useState(true);
         const [sortConfig, setSortConfig] = useState({
           key: "status",
@@ -1206,8 +1235,14 @@
           if (hideNoIssues) {
             sorted = sorted.filter((p) => p.logIssues && (p.logIssues.warnCount > 0 || p.logIssues.errorCount > 0));
           }
+          if (headerFilter === 'openPRs') {
+            sorted = sorted.filter((p) => {
+              const pa = p.prActivity;
+              return !!pa && ((pa.created || 0) + (pa.updated || 0) + (pa.unchanged || 0)) > 0;
+            });
+          }
           return sorted;
-        }, [job.projects, sortConfig, hiddenStatuses, hideNoPRs, hideNoIssues]);
+        }, [job.projects, sortConfig, hiddenStatuses, hideNoPRs, hideNoIssues, headerFilter]);
         const statusCounts = useMemo(() => {
           const counts = {};
           for (const s of STATUS_FILTERS) counts[s] = 0;

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -929,7 +929,7 @@
                   {visibleJobs.length === 0 && jobs.length > 0 && !loading && headerFilter === 'openPRs' && (
                     <div className="text-center py-12">
                       <p className="text-gray-500 dark:text-slate-400">
-                        No jobs have projects with open PRs. Click the <span className="font-semibold text-blue-500">Open PRs</span> badge to clear the filter.
+                        No jobs have projects with open PRs. Click the <span className="font-semibold text-blue-500 dark:text-blue-400">Open PRs</span> badge to clear the filter.
                       </p>
                     </div>
                   )}

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -823,7 +823,7 @@
                 borderClass="border-blue-200 dark:border-blue-700"
                 onClick={() => toggleHeaderFilter('openPRs')}
                 active={headerFilter === 'openPRs'}
-                activeBorderClass="ring-2 ring-blue-500 border-blue-500 dark:ring-blue-400 dark:border-blue-400"
+                title={headerFilter === 'openPRs' ? 'Click to clear filter' : 'Click to show only projects with open PRs'}
               />
               <StatBadge label="With Issues" value={loading ? "—" : stats.withIssues} valueClass="text-amber-500" borderClass="border-amber-300 dark:border-amber-600" />
             </SiteHeader>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -535,6 +535,16 @@
             return next;
           });
         }, []);
+        const visibleJobs = useMemo(() => {
+          if (headerFilter !== 'openPRs') return jobs;
+          return jobs.filter((job) => {
+            if (!Array.isArray(job.projects)) return false;
+            return job.projects.some((p) => {
+              const pa = p.prActivity;
+              return !!pa && ((pa.created || 0) + (pa.updated || 0) + (pa.unchanged || 0)) > 0;
+            });
+          });
+        }, [jobs, headerFilter]);
 
         const addToast = useCallback(
           (type, title, message = "", duration = 5000) => {
@@ -879,7 +889,7 @@
 
               {(!loading || jobs.length > 0) && (
                 <div className="space-y-6">
-                  {jobs.map((job) => (
+                  {visibleJobs.map((job) => (
                     <JobCard
                       key={`${job.name}-${job.namespace}`}
                       job={job}
@@ -912,6 +922,14 @@
                       </h3>
                       <p className="text-gray-500 dark:text-slate-400">
                         Create a RenovateJob resource to get started.
+                      </p>
+                    </div>
+                  )}
+
+                  {visibleJobs.length === 0 && jobs.length > 0 && !loading && headerFilter === 'openPRs' && (
+                    <div className="text-center py-12">
+                      <p className="text-gray-500 dark:text-slate-400">
+                        No jobs have projects with open PRs. Click the <span className="font-semibold text-blue-500">Open PRs</span> badge to clear the filter.
                       </p>
                     </div>
                   )}


### PR DESCRIPTION
## Summary

Makes the "Open PRs" header badge clickable as a toggle filter, hiding projects (and entire JobCards) that don't have any currently-open PRs. This implements the Open PRs portion of #275 and is ready to merge as-is. Follow-up work for the other 5 header badges is intentionally out of scope — see "Follow-ups" below.

Related: #259 / #270 (v4.2.0 badges + filter).

## Problem

The v4.2.0 Web UI shows PR-count badges in the header and a per-card "Without PRs" dropdown filter. The dropdown is awkward for the common case of "just show me the repos with open PRs" — users who spot the badge want to click it directly. #275 proposes clickable badges as filters.

## Changes

- **`StatBadge.js`**: gains optional `onClick`, `active`, `activeClass`, `title` props. When `onClick` is provided, the badge renders as a keyboard-accessible button (`role=button`, `tabIndex=0`, Enter/Space handlers, `aria-pressed`). Fully backward-compatible — the 5 non-clickable callers render identically.
- **`index.html`**:
  - New top-level `headerFilter` state in `App`, persisted to `localStorage`.
  - "Open PRs" header badge wired with `onClick={() => toggleHeaderFilter('openPRs')}`.
  - Active visual is a background fill + border (`bg-blue-50 dark:bg-blue-900/30 border-blue-500 dark:border-blue-400`) so it doesn't stack with the browser focus ring and is obvious in both light and dark mode.
  - `JobCard` accepts a `headerFilter` prop and applies the matching predicate in its `sortedProjects` useMemo. Predicate matches `stats.openPRs` exactly (`created + updated + unchanged`, excluding automerged).
  - New `visibleJobs` useMemo at the `App` level hides entire JobCards whose projects all fail the predicate, so the user doesn't see empty card headers when the filter is on.
  - Small inline hint when the filter is active but no jobs match, explaining how to clear it.
  - Stateful `title` tooltip on the clickable badge (`Click to show only projects with open PRs` / `Click to clear filter`).

## Follow-ups (separate issues/PRs, not blocking this one)

- **Other 5 header badges** (Failed / Scheduled / Running / Completed / With Issues): the interaction model established here extends trivially to the rest via the same `StatBadge` props. Happy to open follow-up issues/PRs for each once this one lands — keeping them separate makes review easier and lets us iterate on the pattern per-badge if needed.
- **Per-card `hideNoPRs` formula alignment**: the existing per-card `hideNoPRs` filter (around `src/static/index.html:1201`) includes `automerged` in its predicate, while `stats.openPRs` and this PR's new filter do not. The new filter matches `stats.openPRs` exactly for UI consistency. Aligning the per-card filter is out of scope here; happy to open a separate PR if you'd like.

## Pre-existing `just check` failure on `main`

Heads up, unrelated to this PR: `just check` is currently failing on `main` due to pre-existing dead code in `src/controllers/renovatejob_controller_test.go:101,105` (`fakeGitProviderClient` + its `IsFork` method, orphaned by commit `26bc839 refactor: dedicated clients for provider`). This PR doesn't touch any Go code; all 440 unit tests still pass via `just test-unit`. Happy to open a separate cleanup PR if you'd like.

## Test plan

No frontend test suite exists, so validation was manual. I deployed the patched image to my own Kubernetes cluster and walked through a 15-item checklist covering: click toggle + persistence, active state in light/dark mode, keyboard navigation, tooltip content, backward compat on the other badges, per-card filter composition, hide-empty-jobs behavior, "no matches" inline hint, no console errors, clean operator startup logs.

Go unit tests: `just test-unit` → **440 pass, 0 fail, 2 skip**.

## Full disclosure

I don't have any programming skills so I asked Claude Code to implement this and did my best to test it and not create AI slop. I deployed the patched image to my own cluster and verified the fix end-to-end (including the hide-empty-jobs behavior) before opening this PR.
