### PR TITLE
feat(executor): adding executor loop duration metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,13 @@ Health state is managed centrally in the `health/` package with thread-safe sett
 - **Global parallelism limit** — `GLOBAL_PARALLELISM_LIMIT` env var (Helm: `config.globalParallelismLimit`, default `0` = unlimited) caps total concurrent executor jobs across all RenovateJobs. Per-job `Spec.Parallelism` is still enforced as an additional gate.
 - **Anti-starvation via priority-then-oldest-wait sort** — in Pass 2, candidates are sorted first by `Priority` descending, then by the oldest `LastRun` time among Scheduled projects in their RenovateJob. Among equal-priority candidates, the job that has been waiting longest dispatches first, preventing starvation.
 
+# Verification
+
+Use the following commands to validate the code:
+- `just build`
+- `just test-unit`
+- `just generate`
+
 # Important
 
 Every change to the structure should be adapted here!

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -98,12 +98,18 @@ func (e *renovateExecutor) Start(ctx context.Context) error {
 
 func (e *renovateExecutor) execute(options executionOptions) error {
 	ctx := context.Background()
+	start := time.Now()
+	defer func() {
+		duration := time.Since(start)
+		metricStore.ObserveExecutorLoopDuration(duration)
+		e.logger.V(2).Info("Executed renovate executor loop", "duration", duration)
+	}()
 
 	renovateJobs, err := e.manager.ListRenovateJobsFull(ctx)
 	if err != nil {
 		return nil
 	}
-	e.logger.V(2).Info("Executing renovate loop for projects", "count", len(renovateJobs))
+	e.logger.V(2).Info("Executing renovate executor loop for projects", "count", len(renovateJobs))
 
 	// Pass 1: check all currently running projects across all jobs, update their statuses,
 	// and count how many are still running globally and per job.

--- a/src/metricStore/metrics.go
+++ b/src/metricStore/metrics.go
@@ -1,11 +1,21 @@
 package metricStore
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var (
+	executorLoopDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "renovate_operator_executor_loop_duration_seconds",
+			Help:    "Duration of a single executor loop tick in seconds",
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+	)
+
 	projectRuns = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "renovate_operator_project_executions_total",
@@ -29,9 +39,14 @@ var (
 )
 
 func Register(registry ctrlmetrics.RegistererGatherer) {
+	registry.MustRegister(executorLoopDuration)
 	registry.MustRegister(projectRuns)
 	registry.MustRegister(runFailed)
 	registry.MustRegister(dependencyIssues)
+}
+
+func ObserveExecutorLoopDuration(duration time.Duration) {
+	executorLoopDuration.Observe(duration.Seconds())
 }
 
 func CaptureRenovateProjectExecution(namespace, job, project, status string) {


### PR DESCRIPTION
References #274
References #35

To get some data, to be sure that our changes we plan in #274 actually work, we should add some metrics for the executor loop duration.