### PR TITLE
fix(operator): honor OS theme changes and allow returning to system theme

### DIFF
--- a/src/static/components/ThemeToggle.js
+++ b/src/static/components/ThemeToggle.js
@@ -1,0 +1,53 @@
+export function ThemeToggle() {
+  const [theme, setTheme] = React.useState(() => window.ThemeUtils.getTheme());
+
+  const cycleTheme = () => {
+    const newTheme = window.ThemeUtils.nextTheme(theme);
+    setTheme(newTheme);
+    window.ThemeUtils.setTheme(newTheme);
+    window.ThemeUtils.apply(newTheme);
+  };
+
+  React.useEffect(() => {
+    window.ThemeUtils.apply(theme);
+  }, [theme]);
+
+  React.useEffect(() => {
+    const onOSChange = () => {
+      if (window.ThemeUtils.getTheme() === 'system') {
+        setTheme('system');
+      }
+    };
+    window.addEventListener('themechange', onOSChange);
+    return () => window.removeEventListener('themechange', onOSChange);
+  }, []);
+
+  const labels = {
+    system: 'Theme: system (click for light)',
+    light: 'Theme: light (click for dark)',
+    dark: 'Theme: dark (click for system)'
+  };
+  const label = labels[theme] || labels.system;
+
+  return (
+    <button
+      onClick={cycleTheme}
+      className="p-2 rounded-lg border border-gray-300 dark:border-slate-600 hover:bg-gray-100 dark:hover:bg-slate-700 transition-all text-gray-700 dark:text-slate-200"
+      aria-label={label}
+    >
+      {theme === 'light' ? (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+        </svg>
+      ) : theme === 'dark' ? (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+        </svg>
+      ) : (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -56,11 +56,32 @@
         },
         apply: (theme) => {
           document.documentElement.classList.toggle('dark', window.ThemeUtils.isDark(theme));
+        },
+        nextTheme: (theme) => {
+          return theme === 'system' ? 'light' : theme === 'light' ? 'dark' : 'system';
         }
       };
 
       // Initialize theme
       window.ThemeUtils.apply(window.ThemeUtils.getTheme());
+
+      // Keep the UI in sync with OS theme changes while 'system' is selected.
+      try {
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+        const onOSThemeChange = () => {
+          if (window.ThemeUtils.getTheme() === 'system') {
+            window.ThemeUtils.apply('system');
+            window.dispatchEvent(new Event('themechange'));
+          }
+        };
+        if (prefersDark.addEventListener) {
+          prefersDark.addEventListener('change', onOSThemeChange);
+        } else if (prefersDark.addListener) {
+          prefersDark.addListener(onOSThemeChange);
+        }
+      } catch (e) {
+        console.warn('Failed to bind OS theme listener:', e);
+      }
     </script>
     <script src="/js/react.production.min.js"></script>
     <script src="/js/react-dom.production.min.js"></script>
@@ -227,10 +248,9 @@
 
       function ThemeToggle() {
         const [theme, setTheme] = useState(() => window.ThemeUtils.getTheme());
-        const isDark = useMemo(() => window.ThemeUtils.isDark(theme), [theme]);
 
-        const toggleTheme = () => {
-          const newTheme = isDark ? 'light' : 'dark';
+        const cycleTheme = () => {
+          const newTheme = window.ThemeUtils.nextTheme(theme);
           setTheme(newTheme);
           window.ThemeUtils.setTheme(newTheme);
           window.ThemeUtils.apply(newTheme);
@@ -238,22 +258,40 @@
 
         useEffect(() => {
           window.ThemeUtils.apply(theme);
+          const onOSChange = () => {
+            if (window.ThemeUtils.getTheme() === 'system') {
+              setTheme('system');
+            }
+          };
+          window.addEventListener('themechange', onOSChange);
+          return () => window.removeEventListener('themechange', onOSChange);
         }, [theme]);
+
+        const labels = {
+          system: 'Theme: system (click for light)',
+          light: 'Theme: light (click for dark)',
+          dark: 'Theme: dark (click for system)'
+        };
+        const label = labels[theme] || labels.system;
 
         return (
           <button
-            onClick={toggleTheme}
+            onClick={cycleTheme}
             className="p-2 rounded-lg border border-gray-300 dark:border-slate-600 hover:bg-gray-100 dark:hover:bg-slate-700 transition-all text-gray-700 dark:text-slate-200"
-            aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-            title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+            aria-label={label}
+            title={label}
           >
-            {isDark ? (
+            {theme === 'light' ? (
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
               </svg>
-            ) : (
+            ) : theme === 'dark' ? (
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+              </svg>
+            ) : (
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
               </svg>
             )}
           </button>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -34,58 +34,11 @@
         },
       };
     </script>
-    <script>
-      // Shared theme utilities
-      window.ThemeUtils = {
-        getTheme: () => {
-          try {
-            return localStorage.getItem('theme') || 'system';
-          } catch {
-            return 'system';
-          }
-        },
-        setTheme: (theme) => {
-          try {
-            localStorage.setItem('theme', theme);
-          } catch (e) {
-            console.warn('Failed to save theme:', e);
-          }
-        },
-        isDark: (theme) => {
-          return theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-        },
-        apply: (theme) => {
-          document.documentElement.classList.toggle('dark', window.ThemeUtils.isDark(theme));
-        },
-        nextTheme: (theme) => {
-          return theme === 'system' ? 'light' : theme === 'light' ? 'dark' : 'system';
-        }
-      };
-
-      // Initialize theme
-      window.ThemeUtils.apply(window.ThemeUtils.getTheme());
-
-      // Keep the UI in sync with OS theme changes while 'system' is selected.
-      try {
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
-        const onOSThemeChange = () => {
-          if (window.ThemeUtils.getTheme() === 'system') {
-            window.ThemeUtils.apply('system');
-            window.dispatchEvent(new Event('themechange'));
-          }
-        };
-        if (prefersDark.addEventListener) {
-          prefersDark.addEventListener('change', onOSThemeChange);
-        } else if (prefersDark.addListener) {
-          prefersDark.addListener(onOSThemeChange);
-        }
-      } catch (e) {
-        console.warn('Failed to bind OS theme listener:', e);
-      }
-    </script>
+    <script src="/js/theme-utils.js"></script>
     <script src="/js/react.production.min.js"></script>
     <script src="/js/react-dom.production.min.js"></script>
     <script src="/js/babel.min.js"></script>
+    <script type="text/babel" src="/components/ThemeToggle.js"></script>
     <script type="text/babel" src="/components/SiteHeader.js"></script>
     <script type="text/babel" src="/components/StatBadge.js"></script>
     <script type="text/babel" src="/components/Footer.js"></script>
@@ -245,58 +198,6 @@
         if (platform === 'gitea' || platform === 'forgejo') return `${base}/${projectName}/pulls/${prNumber}`;
         return null;
       };
-
-      function ThemeToggle() {
-        const [theme, setTheme] = useState(() => window.ThemeUtils.getTheme());
-
-        const cycleTheme = () => {
-          const newTheme = window.ThemeUtils.nextTheme(theme);
-          setTheme(newTheme);
-          window.ThemeUtils.setTheme(newTheme);
-          window.ThemeUtils.apply(newTheme);
-        };
-
-        useEffect(() => {
-          window.ThemeUtils.apply(theme);
-          const onOSChange = () => {
-            if (window.ThemeUtils.getTheme() === 'system') {
-              setTheme('system');
-            }
-          };
-          window.addEventListener('themechange', onOSChange);
-          return () => window.removeEventListener('themechange', onOSChange);
-        }, [theme]);
-
-        const labels = {
-          system: 'Theme: system (click for light)',
-          light: 'Theme: light (click for dark)',
-          dark: 'Theme: dark (click for system)'
-        };
-        const label = labels[theme] || labels.system;
-
-        return (
-          <button
-            onClick={cycleTheme}
-            className="p-2 rounded-lg border border-gray-300 dark:border-slate-600 hover:bg-gray-100 dark:hover:bg-slate-700 transition-all text-gray-700 dark:text-slate-200"
-            aria-label={label}
-            title={label}
-          >
-            {theme === 'light' ? (
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-              </svg>
-            ) : theme === 'dark' ? (
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-              </svg>
-            ) : (
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-              </svg>
-            )}
-          </button>
-        );
-      }
 
       function useTooltip(project) {
         const [isVisible, setIsVisible] = useState(false);

--- a/src/static/js/theme-utils.js
+++ b/src/static/js/theme-utils.js
@@ -1,0 +1,49 @@
+(function () {
+  'use strict';
+
+  window.ThemeUtils = {
+    getTheme: () => {
+      try {
+        return localStorage.getItem('theme') || 'system';
+      } catch {
+        return 'system';
+      }
+    },
+    setTheme: (theme) => {
+      try {
+        localStorage.setItem('theme', theme);
+      } catch (e) {
+        console.warn('Failed to save theme:', e);
+      }
+    },
+    isDark: (theme) => {
+      return theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    },
+    apply: (theme) => {
+      document.documentElement.classList.toggle('dark', window.ThemeUtils.isDark(theme));
+    },
+    nextTheme: (theme) => {
+      return theme === 'system' ? 'light' : theme === 'light' ? 'dark' : 'system';
+    }
+  };
+
+  window.ThemeUtils.apply(window.ThemeUtils.getTheme());
+
+  // Keep the UI in sync with OS theme changes while 'system' is selected.
+  try {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+    const onOSThemeChange = () => {
+      if (window.ThemeUtils.getTheme() === 'system') {
+        window.ThemeUtils.apply('system');
+        window.dispatchEvent(new Event('themechange'));
+      }
+    };
+    if (prefersDark.addEventListener) {
+      prefersDark.addEventListener('change', onOSThemeChange);
+    } else if (prefersDark.addListener) {
+      prefersDark.addListener(onOSThemeChange);
+    }
+  } catch (e) {
+    console.warn('Failed to bind OS theme listener:', e);
+  }
+})();

--- a/src/static/pages/logs.html
+++ b/src/static/pages/logs.html
@@ -25,37 +25,11 @@
       },
     };
   </script>
-  <script>
-    // Shared theme utilities
-    window.ThemeUtils = {
-      getTheme: () => {
-        try {
-          return localStorage.getItem('theme') || 'system';
-        } catch {
-          return 'system';
-        }
-      },
-      setTheme: (theme) => {
-        try {
-          localStorage.setItem('theme', theme);
-        } catch (e) {
-          console.warn('Failed to save theme:', e);
-        }
-      },
-      isDark: (theme) => {
-        return theme === 'dark' || (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-      },
-      apply: (theme) => {
-        document.documentElement.classList.toggle('dark', window.ThemeUtils.isDark(theme));
-      }
-    };
-
-    // Initialize theme
-    window.ThemeUtils.apply(window.ThemeUtils.getTheme());
-  </script>
+  <script src="/js/theme-utils.js"></script>
   <script src="/js/react.production.min.js"></script>
   <script src="/js/react-dom.production.min.js"></script>
   <script src="/js/babel.min.js"></script>
+  <script type="text/babel" src="/components/ThemeToggle.js"></script>
   <script type="text/babel" src="/components/SiteHeader.js"></script>
   <script type="text/babel" src="/components/StatBadge.js"></script>
   <script type="text/babel" src="/components/Footer.js"></script>
@@ -68,41 +42,6 @@
 
   <script type="text/babel">
     const { useState, useEffect, useCallback, useRef, useMemo } = React;
-
-    function ThemeToggle() {
-      const [theme, setTheme] = useState(() => window.ThemeUtils.getTheme());
-      const isDark = useMemo(() => window.ThemeUtils.isDark(theme), [theme]);
-
-      const toggleTheme = () => {
-        const newTheme = isDark ? 'light' : 'dark';
-        setTheme(newTheme);
-        window.ThemeUtils.setTheme(newTheme);
-        window.ThemeUtils.apply(newTheme);
-      };
-
-      useEffect(() => {
-        window.ThemeUtils.apply(theme);
-      }, [theme]);
-
-      return (
-        <button
-          onClick={toggleTheme}
-          className="p-2 rounded-lg border border-gray-300 dark:border-slate-600 hover:bg-gray-100 dark:hover:bg-slate-700 transition-all text-gray-700 dark:text-slate-200"
-          aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-          title={isDark ? "Switch to light mode" : "Switch to dark mode"}
-        >
-          {isDark ? (
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-            </svg>
-          ) : (
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-            </svg>
-          )}
-        </button>
-      );
-    }
 
     function levelInfo(level) {
       if (level >= 60) return { label: "FATAL", color: "error" };


### PR DESCRIPTION
## What

The `system` theme only applied `prefers-color-scheme` on initial page load. Flipping the OS theme with the page open did nothing until reload, and the toggle button switched `light ↔ dark` only, so once clicked there was no way back to `system`.

This PR:
- Adds a `matchMedia` `change` listener that re-applies the theme when the stored value is `system`.
- Makes the header button cycle `system → light → dark → system`. Icon and `aria-label` reflect the current state (sun / moon / monitor).
- Moves `ThemeUtils` and `ThemeToggle` into shared files (`src/static/js/theme-utils.js`, `src/static/components/ThemeToggle.js`) so both `index.html` and `pages/logs.html` use the same code. Claude Code suggested this as best practice after noticing `logs.html` had its own duplicated copy that would otherwise need to be kept in sync.

## Validation

Deployed the built image to my own cluster. OS light↔dark flip propagates live on both `/` and `/logs`, 3-way cycle works, state persists. `just test-unit` passes.

## Full disclosure

I don't have any programming skills so I asked Claude Code to implement this and did my best to test it and not create AI slop. I deployed the patched image to my own cluster and verified both the OS live-update and the 3-way cycle end-to-end before opening this PR.
