### PR TITLE
fix(operator): persist dashboard stat-badge filter across reloads

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -490,8 +490,6 @@
         const [toasts, setToasts] = useState([]);
         const nextToastIdRef = useRef(0);
         const [authInfo, setAuthInfo] = useState(null);
-        const [selectedStatFilter, setSelectedStatFilter] = useState(null);
-
         const STAT_FILTER_LABELS = {
           failed: "Failed",
           scheduled: "Scheduled",
@@ -501,14 +499,36 @@
           withIssues: "With Issues",
         };
 
+        const [selectedStatFilter, setSelectedStatFilter] = useState(() => {
+          try {
+            const stored = localStorage.getItem('selectedStatFilter');
+            return stored && STAT_FILTER_LABELS[stored] ? stored : null;
+          } catch {
+            return null;
+          }
+        });
+
+        const persistStatFilter = (value) => {
+          try {
+            if (value === null) {
+              localStorage.removeItem('selectedStatFilter');
+            } else {
+              localStorage.setItem('selectedStatFilter', value);
+            }
+          } catch {}
+        };
+
         const toggleStatFilter = useCallback((filterKey) => {
-          setSelectedStatFilter((current) =>
-            current === filterKey ? null : filterKey
-          );
+          setSelectedStatFilter((current) => {
+            const next = current === filterKey ? null : filterKey;
+            persistStatFilter(next);
+            return next;
+          });
         }, []);
 
         const clearStatFilter = useCallback(() => {
           setSelectedStatFilter(null);
+          persistStatFilter(null);
         }, []);
 
         const filteredJobs = useMemo(() => {


### PR DESCRIPTION
## What

The six stat badges at the top of the dashboard (Failed, Scheduled, Running, Completed, Open PRs, With Issues) act as a filter toggle, but the selection lives in React state only and is lost on every reload. Three other filters in the same component already persist via localStorage per-job, so this is the only top-level filter that doesn't.

- Store the selected filter key in `localStorage.selectedStatFilter` using the same try/catch pattern as the existing persisted filters.
- Validate the stored value against `STAT_FILTER_LABELS` keys on load, so a future rename or removal of a filter key won't leave users with a silently-applied unknown filter.

## Validation

Deployed the built image to my own cluster and confirmed each of the six badges round-trips correctly across reloads (click, refresh, still active; re-click, refresh, cleared). `just test-unit` passes.

## Full disclosure

I don't have any programming skills so I asked Claude Code to implement this and did my best to test it and not create AI slop. I deployed the patched image to my own cluster and verified the filter persists across reloads end-to-end before opening this PR.
