### PR TITLE
feat: add valkey configuration to RenovateJobs

### DIFF
--- a/docs/valkey.md
+++ b/docs/valkey.md
@@ -1,0 +1,7 @@
+# Valkey
+
+The operator ships with an optional Valkey datastore. This uses the [official Valkey Helm chart](https://github.com/valkey-io/valkey-helm). This deploys a single standalone Valkey instance.
+
+## High availability
+
+The upstream Helm chart currently [does not support](https://github.com/valkey-io/valkey-helm/issues/18) Valkey clustering. Once this is delivered, we will have to update the protocol from `redis://` to `redis+cluster://`.

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	gitProviderClientFactory "renovate-operator/gitProviderClients/factory"
 	"renovate-operator/health"
 	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/kvstore"
 	"renovate-operator/internal/logStore"
 	"renovate-operator/internal/renovate"
 	"renovate-operator/metricStore"
@@ -53,7 +54,7 @@ func splitAndTrim(s, sep string) []string {
 
 type authSetup struct {
 	provider             ui.AuthProvider
-	kvStore              ui.KVStore
+	kvStore              kvstore.KVStore
 	defaultAllowedGroups []string
 	cleanup              func()
 }
@@ -85,7 +86,7 @@ func initAuth() authSetup {
 	cookieKey, storeKey := ui.DeriveSubKeys(encryptionKey)
 
 	// Initialize KV store (Valkey if configured, otherwise nil)
-	kvStore, kvErr := ui.NewKVStore(ui.ValkeyConfig{
+	kvStore, kvErr := kvstore.NewKVStore(kvstore.ValkeyConfig{
 		URL:      config.GetValue("VALKEY_URL"),
 		Host:     config.GetValue("VALKEY_HOST"),
 		Port:     config.GetValue("VALKEY_PORT"),

--- a/src/controllers/renovatejob_controller_test.go
+++ b/src/controllers/renovatejob_controller_test.go
@@ -97,15 +97,6 @@ func (f *fakeDiscovery) WaitForDiscoveryJob(ctx context.Context, job *api.Renova
 	return []string{}, nil
 }
 
-// fakeGitProviderClient implements gitprovider.GitProviderClient for tests.
-type fakeGitProviderClient struct {
-	isForkFn func(ctx context.Context, project string) (bool, error)
-}
-
-func (f *fakeGitProviderClient) IsFork(ctx context.Context, project string) (bool, error) {
-	return f.isForkFn(ctx, project)
-}
-
 type fakeScheduler struct {
 	addedExpr    string
 	addedName    string

--- a/src/internal/kvstore/kvstore.go
+++ b/src/internal/kvstore/kvstore.go
@@ -1,4 +1,4 @@
-package ui
+package kvstore
 
 import (
 	"context"
@@ -40,7 +40,7 @@ type ValkeyConfig struct {
 func NewKVStore(cfg ValkeyConfig) (KVStore, error) {
 	valkeyURL := cfg.URL
 	if valkeyURL == "" {
-		valkeyURL = buildValkeyURL(cfg.Host, cfg.Port, cfg.Password)
+		valkeyURL = BuildValkeyURL(cfg.Host, cfg.Port, cfg.Password)
 	}
 
 	if valkeyURL != "" {
@@ -50,9 +50,9 @@ func NewKVStore(cfg ValkeyConfig) (KVStore, error) {
 	return nil, nil
 }
 
-// buildValkeyURL constructs a Valkey URL from host, port, and password.
+// BuildValkeyURL constructs a Valkey URL from host, port, and password.
 // Returns "" if host is empty. Uses the redis:// scheme (wire-compatible protocol).
-func buildValkeyURL(host, port, password string) string {
+func BuildValkeyURL(host, port, password string) string {
 	if host == "" {
 		return ""
 	}

--- a/src/internal/kvstore/valkey_store.go
+++ b/src/internal/kvstore/valkey_store.go
@@ -1,4 +1,4 @@
-package ui
+package kvstore
 
 import (
 	"context"

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -172,6 +172,10 @@ func (e *discoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api
 	lock.Lock()
 	defer lock.Unlock()
 
+	if err := ensureRedisURLSecret(ctx, e.client, renovateJob.Namespace); err != nil {
+		return "", fmt.Errorf("failed to ensure redis url secret: %w", err)
+	}
+
 	discoveryJob := newDiscoveryJob(&renovateJob)
 	if err := controllerutil.SetControllerReference(&renovateJob, discoveryJob, e.scheme); err != nil {
 		return "", fmt.Errorf("failed to set controller reference: %w", err)

--- a/src/internal/renovate/discoveryAgent_test.go
+++ b/src/internal/renovate/discoveryAgent_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -94,6 +95,9 @@ func TestCreateDiscoveryJobAndWait(t *testing.T) {
 	if err := batchv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("failed to add batch scheme: %v", err)
 	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
 
 	// initialize minimal config used by newDiscoveryJob
 	_ = config.InitializeConfigModule([]config.ConfigItemDescription{
@@ -127,5 +131,35 @@ func TestCreateDiscoveryJobAndWait(t *testing.T) {
 	}
 	if len(projects) != 2 {
 		t.Fatalf("expected 2 projects, got %d", len(projects))
+	}
+}
+
+func TestEnsureRedisURLSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := api.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add api scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+
+	_ = config.InitializeConfigModule([]config.ConfigItemDescription{
+		{Key: "VALKEY_URL", Optional: true, Default: "redis://redis.svc.cluster.local:6379/0"},
+		{Key: "VALKEY_HOST", Optional: true, Default: ""},
+		{Key: "VALKEY_PORT", Optional: true, Default: "6379"},
+		{Key: "VALKEY_PASSWORD", Optional: true, Default: ""},
+	})
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if err := ensureRedisURLSecret(context.Background(), cl, "ns"); err != nil {
+		t.Fatalf("ensureRedisURLSecret returned error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := cl.Get(context.Background(), client.ObjectKey{Name: redisURLSecretName, Namespace: "ns"}, secret); err != nil {
+		t.Fatalf("expected secret to be created: %v", err)
+	}
+	if got := string(secret.Data["redis-url"]); got != "redis://redis.svc.cluster.local:6379/1" {
+		t.Fatalf("expected redis-url secret data, got %q", got)
 	}
 }

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -277,6 +277,10 @@ func (e *renovateExecutor) dispatchScheduled(ctx context.Context, renovateJobs [
 			continue
 		}
 
+		if err := ensureRedisURLSecret(ctx, e.client, renovateJob.Namespace); err != nil {
+			return fmt.Errorf("failed to ensure redis url secret: %w", err)
+		}
+
 		k8sJob := newRenovateJob(renovateJob, project.Name)
 		if err := controllerutil.SetControllerReference(renovateJob, k8sJob, e.scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference: %w", err)

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -6,6 +6,7 @@ import (
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/config"
 	crdmanager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/kvstore"
 	"renovate-operator/internal/utils"
 	"strconv"
 	"strings"
@@ -207,6 +208,22 @@ func getDefaultEnvVars(job *api.RenovateJob) []v1.EnvVar {
 		predefinedEnvVars = append(predefinedEnvVars, v1.EnvVar{
 			Name:  "LOG_LEVEL",
 			Value: "debug",
+		})
+	}
+
+	valkeyURL := config.GetValue("VALKEY_URL")
+	if valkeyURL == "" {
+		valkeyURL = kvstore.BuildValkeyURL(
+			config.GetValue("VALKEY_HOST"),
+			config.GetValue("VALKEY_PORT"),
+			config.GetValue("VALKEY_PASSWORD"),
+		)
+	}
+
+	if valkeyURL != "" {
+		predefinedEnvVars = append(predefinedEnvVars, v1.EnvVar{
+			Name:  "RENOVATE_REDIS_URL",
+			Value: valkeyURL,
 		})
 	}
 	return predefinedEnvVars

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -6,13 +6,13 @@ import (
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/config"
 	crdmanager "renovate-operator/internal/crdManager"
-	"renovate-operator/internal/kvstore"
 	"renovate-operator/internal/utils"
 	"strconv"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+
 	"k8s.io/utils/ptr"
 )
 
@@ -211,19 +211,17 @@ func getDefaultEnvVars(job *api.RenovateJob) []v1.EnvVar {
 		})
 	}
 
-	valkeyURL := config.GetValue("VALKEY_URL")
-	if valkeyURL == "" {
-		valkeyURL = kvstore.BuildValkeyURL(
-			config.GetValue("VALKEY_HOST"),
-			config.GetValue("VALKEY_PORT"),
-			config.GetValue("VALKEY_PASSWORD"),
-		)
-	}
-
-	if valkeyURL != "" {
+	if getValkeyURL() != "" {
 		predefinedEnvVars = append(predefinedEnvVars, v1.EnvVar{
-			Name:  "RENOVATE_REDIS_URL",
-			Value: valkeyURL,
+			Name: "RENOVATE_REDIS_URL",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: redisURLSecretName,
+					},
+					Key: "redis-url",
+				},
+			},
 		})
 	}
 	return predefinedEnvVars

--- a/src/internal/renovate/jobDefinitions_test.go
+++ b/src/internal/renovate/jobDefinitions_test.go
@@ -182,7 +182,7 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	err := config.InitializeConfigModule([]config.ConfigItemDescription{
 		{Key: "JOB_TIMEOUT_SECONDS", Optional: true, Default: "10"},
 		{Key: "JOB_TTL_SECONDS_AFTER_FINISHED", Optional: true, Default: "360"},
-		{Key: "VALKEY_URL", Optional: true, Default: "redis://redis.svc.cluster.local:6379"},
+		{Key: "VALKEY_URL", Optional: true, Default: "redis://redis.svc.cluster.local:6379/0"},
 		{Key: "VALKEY_HOST", Optional: true, Default: ""},
 		{Key: "VALKEY_PORT", Optional: true, Default: "6379"},
 		{Key: "VALKEY_PASSWORD", Optional: true, Default: ""},
@@ -210,8 +210,9 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	expectEnvVar(t, djContainer, "RENOVATE_ENDPOINT", "gitlab.example.com")
 	expectEnvVar(t, djContainer, "RENOVATE_PLATFORM", "gitlab")
 	expectEnvVar(t, djContainer, "LOG_LEVEL", "debug")
-	expectEnvVar(t, djContainer, "RENOVATE_REDIS_URL", "redis://redis.svc.cluster.local:6379")
 	expectEnvFromSecret(t, djContainer, "sref")
+	expectEnvVarFromSecretKey(t, djContainer, "RENOVATE_REDIS_URL", "renovate-redis-url", "redis-url")
+
 	// volumes
 	expectVolumeMounts(t, djContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})
 	expectVolumes(t, dj, []v1.Volume{{Name: "tmp"}, {Name: "extra-vol"}})
@@ -239,7 +240,7 @@ func TestNewJobs_WithSettings(t *testing.T) {
 
 	// env vars
 	expectEnvVar(t, rjContainer, "LOG_FORMAT", "console")
-	expectEnvVar(t, rjContainer, "RENOVATE_REDIS_URL", "redis://redis.svc.cluster.local:6379")
+	expectEnvVarFromSecretKey(t, rjContainer, "RENOVATE_REDIS_URL", "renovate-redis-url", "redis-url")
 	expectEnvFromSecret(t, rjContainer, "sref")
 	// volumes
 	expectVolumeMounts(t, rjContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})
@@ -586,6 +587,22 @@ func expectEnvVar(t *testing.T, container *v1.Container, name, expectedValue str
 			}
 			return
 		}
+	}
+	t.Fatalf("expected env var %s not found", name)
+}
+
+func expectEnvVarFromSecretKey(t *testing.T, container *v1.Container, name, secretName, secretKey string) {
+	for _, env := range container.Env {
+		if env.Name != name {
+			continue
+		}
+		if env.ValueFrom == nil || env.ValueFrom.SecretKeyRef == nil {
+			t.Fatalf("expected env var %s to use secret key ref, got %+v", name, env)
+		}
+		if env.ValueFrom.SecretKeyRef.Name != secretName || env.ValueFrom.SecretKeyRef.Key != secretKey {
+			t.Fatalf("expected env var %s to use %s/%s, got %+v", name, secretName, secretKey, env.ValueFrom.SecretKeyRef)
+		}
+		return
 	}
 	t.Fatalf("expected env var %s not found", name)
 }

--- a/src/internal/renovate/jobDefinitions_test.go
+++ b/src/internal/renovate/jobDefinitions_test.go
@@ -182,6 +182,10 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	err := config.InitializeConfigModule([]config.ConfigItemDescription{
 		{Key: "JOB_TIMEOUT_SECONDS", Optional: true, Default: "10"},
 		{Key: "JOB_TTL_SECONDS_AFTER_FINISHED", Optional: true, Default: "360"},
+		{Key: "VALKEY_URL", Optional: true, Default: "redis://redis.svc.cluster.local:6379"},
+		{Key: "VALKEY_HOST", Optional: true, Default: ""},
+		{Key: "VALKEY_PORT", Optional: true, Default: "6379"},
+		{Key: "VALKEY_PASSWORD", Optional: true, Default: ""},
 	})
 	if err != nil {
 		t.Fatalf("expected to initialize config module without error, got %v", err)
@@ -206,6 +210,7 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	expectEnvVar(t, djContainer, "RENOVATE_ENDPOINT", "gitlab.example.com")
 	expectEnvVar(t, djContainer, "RENOVATE_PLATFORM", "gitlab")
 	expectEnvVar(t, djContainer, "LOG_LEVEL", "debug")
+	expectEnvVar(t, djContainer, "RENOVATE_REDIS_URL", "redis://redis.svc.cluster.local:6379")
 	expectEnvFromSecret(t, djContainer, "sref")
 	// volumes
 	expectVolumeMounts(t, djContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})
@@ -234,6 +239,7 @@ func TestNewJobs_WithSettings(t *testing.T) {
 
 	// env vars
 	expectEnvVar(t, rjContainer, "LOG_FORMAT", "console")
+	expectEnvVar(t, rjContainer, "RENOVATE_REDIS_URL", "redis://redis.svc.cluster.local:6379")
 	expectEnvFromSecret(t, rjContainer, "sref")
 	// volumes
 	expectVolumeMounts(t, rjContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})

--- a/src/internal/renovate/redisSecret.go
+++ b/src/internal/renovate/redisSecret.go
@@ -1,0 +1,81 @@
+package renovate
+
+import (
+	context "context"
+	"fmt"
+	"net/url"
+
+	"renovate-operator/config"
+	"renovate-operator/internal/kvstore"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const redisURLSecretName = "renovate-redis-url"
+
+func getValkeyURL() string {
+	valkeyURL := config.GetValue("VALKEY_URL")
+	if valkeyURL == "" {
+		valkeyURL = kvstore.BuildValkeyURL(
+			config.GetValue("VALKEY_HOST"),
+			config.GetValue("VALKEY_PORT"),
+			config.GetValue("VALKEY_PASSWORD"),
+		)
+	}
+	return valkeyURL
+}
+
+func getRenovateCacheURL() (string, error) {
+	baseURL := getValkeyURL()
+	if baseURL == "" {
+		return "", nil
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing valkey url: %w", err)
+	}
+	parsed.Path = "/1"
+	return parsed.String(), nil
+}
+
+func ensureRedisURLSecret(ctx context.Context, c client.Client, namespace string) error {
+	valkeyURL, err := getRenovateCacheURL()
+	if err != nil {
+		return err
+	}
+	if valkeyURL == "" {
+		return nil
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      redisURLSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"redis-url": []byte(valkeyURL),
+		},
+	}
+
+	existing := &corev1.Secret{}
+	err = c.Get(ctx, client.ObjectKey{Name: redisURLSecretName, Namespace: namespace}, existing)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			if err := c.Create(ctx, secret); err != nil {
+				return fmt.Errorf("creating redis url secret: %w", err)
+			}
+			return nil
+		}
+		return fmt.Errorf("reading redis url secret: %w", err)
+	}
+
+	secret.ResourceVersion = existing.ResourceVersion
+	if err := c.Update(ctx, secret); err != nil {
+		return fmt.Errorf("updating redis url secret: %w", err)
+	}
+	return nil
+}

--- a/src/ui/session_store.go
+++ b/src/ui/session_store.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"renovate-operator/internal/kvstore"
 )
 
 // Sentinel errors for session store operations.
@@ -29,7 +31,7 @@ type SessionStore interface {
 
 // NewSessionStore creates a SessionStore wrapping the provided KVStore.
 // If kvStore is nil, returns (nil, nil) — indicating cookie-only mode.
-func NewSessionStore(kvStore KVStore, encryptionKey [32]byte) (SessionStore, error) {
+func NewSessionStore(kvStore kvstore.KVStore, encryptionKey [32]byte) (SessionStore, error) {
 	if kvStore == nil {
 		return nil, nil
 	}
@@ -46,7 +48,7 @@ func NewSessionStore(kvStore KVStore, encryptionKey [32]byte) (SessionStore, err
 // It handles JSON marshaling and AES-GCM encryption, delegating
 // raw storage to the underlying KVStore with a "session:" key prefix.
 type valkeySessionStore struct {
-	store KVStore
+	store kvstore.KVStore
 	gcm   cipher.AEAD
 }
 
@@ -61,12 +63,12 @@ func (v *valkeySessionStore) Save(ctx context.Context, id string, data sessionDa
 		return fmt.Errorf("failed to encrypt session data: %w", err)
 	}
 
-	return v.store.Put(ctx, JoinKey("session", id), sealed, ttl)
+	return v.store.Put(ctx, kvstore.JoinKey("session", id), sealed, ttl)
 }
 
 func (v *valkeySessionStore) Load(ctx context.Context, id string) (*sessionData, error) {
-	raw, err := v.store.Get(ctx, JoinKey("session", id))
-	if errors.Is(err, ErrKeyNotFound) {
+	raw, err := v.store.Get(ctx, kvstore.JoinKey("session", id))
+	if errors.Is(err, kvstore.ErrKeyNotFound) {
 		return nil, ErrSessionNotFound
 	}
 	if err != nil {
@@ -87,7 +89,7 @@ func (v *valkeySessionStore) Load(ctx context.Context, id string) (*sessionData,
 }
 
 func (v *valkeySessionStore) Delete(ctx context.Context, id string) error {
-	return v.store.Del(ctx, JoinKey("session", id))
+	return v.store.Del(ctx, kvstore.JoinKey("session", id))
 }
 
 func (v *valkeySessionStore) Close() error {

--- a/src/ui/session_store_test.go
+++ b/src/ui/session_store_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"renovate-operator/internal/kvstore"
 	"strings"
 	"testing"
 	"time"
@@ -268,10 +269,10 @@ func TestCookieOnlySession_RoundTrip(t *testing.T) {
 
 // --- KVStore tests (using miniredis — wire-compatible) ---
 
-func newTestValkeyKVStore(t *testing.T) (KVStore, *miniredis.Miniredis) {
+func newTestValkeyKVStore(t *testing.T) (kvstore.KVStore, *miniredis.Miniredis) {
 	t.Helper()
 	mr := miniredis.RunT(t)
-	store, err := NewValkeyKVStore("redis://" + mr.Addr() + "/0")
+	store, err := kvstore.NewValkeyKVStore("redis://" + mr.Addr() + "/0")
 	if err != nil {
 		t.Fatalf("NewValkeyKVStore failed: %v", err)
 	}
@@ -302,7 +303,7 @@ func TestKVStore_GetNotFound(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := store.Get(ctx, "nonexistent")
-	if !errors.Is(err, ErrKeyNotFound) {
+	if !errors.Is(err, kvstore.ErrKeyNotFound) {
 		t.Errorf("Expected ErrKeyNotFound, got %v", err)
 	}
 }
@@ -319,7 +320,7 @@ func TestKVStore_Del(t *testing.T) {
 	}
 
 	_, err := store.Get(ctx, "key-del")
-	if !errors.Is(err, ErrKeyNotFound) {
+	if !errors.Is(err, kvstore.ErrKeyNotFound) {
 		t.Errorf("Expected ErrKeyNotFound after Del, got %v", err)
 	}
 }
@@ -341,7 +342,7 @@ func TestKVStore_Expiry(t *testing.T) {
 	mr.FastForward(11 * time.Second)
 
 	_, err := store.Get(ctx, "key-exp")
-	if !errors.Is(err, ErrKeyNotFound) {
+	if !errors.Is(err, kvstore.ErrKeyNotFound) {
 		t.Errorf("Expected ErrKeyNotFound after expiry, got %v", err)
 	}
 }
@@ -493,17 +494,17 @@ func TestValkeyStore_EncryptionAtRest(t *testing.T) {
 	keys := mr.Keys()
 	found := false
 	for _, k := range keys {
-		if k == JoinKey("session", "rs-enc") {
+		if k == kvstore.JoinKey("session", "rs-enc") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("Expected key %q in Valkey, got keys: %v", JoinKey("session", "rs-enc"), keys)
+		t.Errorf("Expected key %q in Valkey, got keys: %v", kvstore.JoinKey("session", "rs-enc"), keys)
 	}
 
 	// Read the raw value from miniredis — it should NOT be plaintext JSON
-	raw, err := mr.Get(JoinKey("session", "rs-enc"))
+	raw, err := mr.Get(kvstore.JoinKey("session", "rs-enc"))
 	if err != nil {
 		t.Fatalf("Failed to read raw value from miniredis: %v", err)
 	}
@@ -529,14 +530,14 @@ func TestValkeyStore_EncryptionAtRest(t *testing.T) {
 // --- Factory and URL builder tests ---
 
 func TestBuildValkeyURL_EmptyHost(t *testing.T) {
-	result := buildValkeyURL("", "6379", "")
+	result := kvstore.BuildValkeyURL("", "6379", "")
 	if result != "" {
 		t.Errorf("Expected empty string for empty host, got %q", result)
 	}
 }
 
 func TestBuildValkeyURL_HostAndPort(t *testing.T) {
-	result := buildValkeyURL("valkey.example.com", "6380", "")
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6380", "")
 	expected := "redis://valkey.example.com:6380/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -544,7 +545,7 @@ func TestBuildValkeyURL_HostAndPort(t *testing.T) {
 }
 
 func TestBuildValkeyURL_DefaultPort(t *testing.T) {
-	result := buildValkeyURL("valkey.example.com", "", "")
+	result := kvstore.BuildValkeyURL("valkey.example.com", "", "")
 	expected := "redis://valkey.example.com:6379/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -552,7 +553,7 @@ func TestBuildValkeyURL_DefaultPort(t *testing.T) {
 }
 
 func TestBuildValkeyURL_WithPassword(t *testing.T) {
-	result := buildValkeyURL("valkey.example.com", "6379", "s3cret")
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "s3cret")
 	expected := "redis://:s3cret@valkey.example.com:6379/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -560,7 +561,7 @@ func TestBuildValkeyURL_WithPassword(t *testing.T) {
 }
 
 func TestBuildValkeyURL_PasswordWithSpecialChars(t *testing.T) {
-	result := buildValkeyURL("valkey.example.com", "6379", "p@ss:word/123")
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "p@ss:word/123")
 	expected := "redis://:p%40ss%3Aword%2F123@valkey.example.com:6379/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -568,7 +569,7 @@ func TestBuildValkeyURL_PasswordWithSpecialChars(t *testing.T) {
 }
 
 func TestNewKVStore_EmptyConfig_ReturnsNil(t *testing.T) {
-	store, err := NewKVStore(ValkeyConfig{})
+	store, err := kvstore.NewKVStore(kvstore.ValkeyConfig{})
 	if err != nil {
 		t.Fatalf("NewKVStore failed: %v", err)
 	}
@@ -580,7 +581,7 @@ func TestNewKVStore_EmptyConfig_ReturnsNil(t *testing.T) {
 func TestNewKVStore_WithValkeyURL(t *testing.T) {
 	mr := miniredis.RunT(t)
 
-	store, err := NewKVStore(ValkeyConfig{
+	store, err := kvstore.NewKVStore(kvstore.ValkeyConfig{
 		URL: "redis://" + mr.Addr() + "/0",
 	})
 	if err != nil {
@@ -594,7 +595,7 @@ func TestNewKVStore_WithValkeyURL(t *testing.T) {
 func TestNewKVStore_WithHost(t *testing.T) {
 	mr := miniredis.RunT(t)
 
-	store, err := NewKVStore(ValkeyConfig{
+	store, err := kvstore.NewKVStore(kvstore.ValkeyConfig{
 		Host: mr.Host(),
 		Port: mr.Port(),
 	})
@@ -610,7 +611,7 @@ func TestNewKVStore_URLTakesPrecedenceOverHost(t *testing.T) {
 	mr := miniredis.RunT(t)
 
 	// URL points to miniredis, Host points to nowhere
-	store, err := NewKVStore(ValkeyConfig{
+	store, err := kvstore.NewKVStore(kvstore.ValkeyConfig{
 		URL:  "redis://" + mr.Addr() + "/0",
 		Host: "nonexistent.invalid",
 		Port: "9999",
@@ -645,7 +646,7 @@ func TestNewSessionStore_WithKVStore(t *testing.T) {
 		t.Fatalf("ComputeEncryptionKey failed: %v", err)
 	}
 
-	kvStore, kvErr := NewValkeyKVStore("redis://" + mr.Addr() + "/0")
+	kvStore, kvErr := kvstore.NewValkeyKVStore("redis://" + mr.Addr() + "/0")
 	if kvErr != nil {
 		t.Fatalf("NewValkeyKVStore failed: %v", kvErr)
 	}
@@ -670,7 +671,7 @@ func TestJoinKey(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := JoinKey(tt.parts...)
+		result := kvstore.JoinKey(tt.parts...)
 		if result != tt.expected {
 			t.Errorf("JoinKey(%v) = %q, want %q", tt.parts, result, tt.expected)
 		}


### PR DESCRIPTION
This PR Provisions the `RENOVATE_REDIS_URL` on all jobs, reusing the existing valkey configuration.