### PR TITLE
feat(operator): issue-303 enabling adding of extraManifests in the operator values

### DIFF
--- a/charts/renovate-operator/templates/extra-manifests.yaml
+++ b/charts/renovate-operator/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraManifests }}
+---
+{{ tpl . $ }}
+{{ end }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -306,3 +306,6 @@ metrics:
       instanceSelector:
         matchLabels:
           grafana.internal/instance: "grafana"
+
+# -- list of extra manifests
+extraManifests: []

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -309,3 +309,12 @@ metrics:
 
 # -- list of extra manifests
 extraManifests: []
+  #- | 
+  #  apiVersion: v1
+  #  data:
+  #    client-secret: XXXXXXXXXXXXXXXXXXX
+  #  kind: Secret
+  #  metadata:
+  #    name: oidc-secret
+  #    namespace: renovate-operator
+  #  type: Opaque


### PR DESCRIPTION
adding support for extraManifests generic mechanism in the Helm chart values.

This would allow users to define arbitrary Kubernetes manifests directly in values.yaml, which are then rendered and deployed as part of the same Helm release.