### PR TITLE
feat: Add ugprade hooks

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -3187,6 +3187,708 @@ spec:
                 description: Maximum number of projects to process in parallel
                 format: int32
                 type: integer
+              postUpgrade:
+                description: Hook to run after renovate execution
+                properties:
+                  args:
+                    description: Arguments for the command
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: Command to execute (e.g., ["/bin/sh", "-c"])
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: Environment variables for the hook
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: Environment from secrets/configmaps
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  failOnError:
+                    description: 'Whether hook failure should block execution (default:
+                      true)'
+                    type: boolean
+                  image:
+                    description: Container image to use for the hook
+                    type: string
+                  resources:
+                    description: Resource requirements for the hook container
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  volumeMounts:
+                    description: Volume mounts for the hook container
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                            (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                            recursively.
+
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                            recursively read-only, if it is supported by the container runtime.  If this
+                            field is set to Enabled, the mount is made recursively read-only if it is
+                            supported by the container runtime, otherwise the pod will not be started and
+                            an error will be generated to indicate the reason.
+
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                            None (or be unspecified, which defaults to None).
+
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              preUpgrade:
+                description: Hook to run before renovate execution
+                properties:
+                  args:
+                    description: Arguments for the command
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: Command to execute (e.g., ["/bin/sh", "-c"])
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: Environment variables for the hook
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: Environment from secrets/configmaps
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  failOnError:
+                    description: 'Whether hook failure should block execution (default:
+                      true)'
+                    type: boolean
+                  image:
+                    description: Container image to use for the hook
+                    type: string
+                  resources:
+                    description: Resource requirements for the hook container
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  volumeMounts:
+                    description: Volume mounts for the hook container
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                            (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                            recursively.
+
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                            recursively read-only, if it is supported by the container runtime.  If this
+                            field is set to Enabled, the mount is made recursively read-only if it is
+                            supported by the container runtime, otherwise the pod will not be started and
+                            an error will be generated to indicate the reason.
+
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                            None (or be unspecified, which defaults to None).
+
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
               provider:
                 description: Renovate Provider Information to fill "RENOVATE_ENDPOINT"
                   and "RENOVATE_PLATFORM" environment variables in the renovate container
@@ -4357,6 +5059,10 @@ spec:
                     renovateResultStatus:
                       type: string
                     status:
+                      type: string
+                    subStatus:
+                      description: Current execution phase (preUpgrade, postUpgrade,
+                        or empty for renovate)
                       type: string
                   required:
                   - lastRun

--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -3205,6 +3205,708 @@ spec:
                 description: Maximum number of projects to process in parallel
                 format: int32
                 type: integer
+              postUpgrade:
+                description: Hook to run after renovate execution
+                properties:
+                  args:
+                    description: Arguments for the command
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: Command to execute (e.g., ["/bin/sh", "-c"])
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: Environment variables for the hook
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: Environment from secrets/configmaps
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  failOnError:
+                    description: 'Whether hook failure should block execution (default:
+                      true)'
+                    type: boolean
+                  image:
+                    description: Container image to use for the hook
+                    type: string
+                  resources:
+                    description: Resource requirements for the hook container
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  volumeMounts:
+                    description: Volume mounts for the hook container
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                            (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                            recursively.
+
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                            recursively read-only, if it is supported by the container runtime.  If this
+                            field is set to Enabled, the mount is made recursively read-only if it is
+                            supported by the container runtime, otherwise the pod will not be started and
+                            an error will be generated to indicate the reason.
+
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                            None (or be unspecified, which defaults to None).
+
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              preUpgrade:
+                description: Hook to run before renovate execution
+                properties:
+                  args:
+                    description: Arguments for the command
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    description: Command to execute (e.g., ["/bin/sh", "-c"])
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: Environment variables for the hook
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: Environment from secrets/configmaps
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  failOnError:
+                    description: 'Whether hook failure should block execution (default:
+                      true)'
+                    type: boolean
+                  image:
+                    description: Container image to use for the hook
+                    type: string
+                  resources:
+                    description: Resource requirements for the hook container
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  volumeMounts:
+                    description: Volume mounts for the hook container
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                            (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                            recursively.
+
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                            recursively read-only, if it is supported by the container runtime.  If this
+                            field is set to Enabled, the mount is made recursively read-only if it is
+                            supported by the container runtime, otherwise the pod will not be started and
+                            an error will be generated to indicate the reason.
+
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                            None (or be unspecified, which defaults to None).
+
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
               provider:
                 description: Renovate Provider Information to fill "RENOVATE_ENDPOINT"
                   and "RENOVATE_PLATFORM" environment variables in the renovate container
@@ -4371,6 +5073,10 @@ spec:
                     renovateResultStatus:
                       type: string
                     status:
+                      type: string
+                    subStatus:
+                      description: Current execution phase (preUpgrade, postUpgrade,
+                        or empty for renovate)
                       type: string
                   required:
                   - lastRun

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,506 @@
+# PreUpgrade and PostUpgrade Hooks
+
+The Renovate Operator supports optional `preUpgrade` and `postUpgrade` hooks that allow you to run custom logic before and after Renovate executions.
+
+## Overview
+
+Hooks are implemented as separate Kubernetes Jobs that run:
+- **preUpgrade**: Before the Renovate job starts
+- **postUpgrade**: After the Renovate job completes successfully
+
+Each hook runs as an independent container with its own configuration, allowing you to use any Docker image and run any commands.
+
+## Use Cases
+
+### PreUpgrade Hooks
+- **Environment validation**: Check that required credentials, tokens, or services are available
+- **Backup operations**: Create backups of configurations before updates
+- **Pre-checks**: Validate repository state, branch protection rules, or CI status
+- **Setup tasks**: Download additional config files, prepare working directories
+- **Notifications**: Send "starting update" notifications to Slack, email, etc.
+
+### PostUpgrade Hooks
+- **Notifications**: Send completion status to webhooks, Slack, email, or monitoring systems
+- **Log aggregation**: Upload Renovate logs to external storage or logging services
+- **Cleanup operations**: Remove temporary files, clear caches
+- **Verification**: Run additional checks on the results of the Renovate run
+- **Trigger downstream workflows**: Start CI/CD pipelines, run tests, or update dashboards
+
+## Configuration
+
+Hooks are configured in the `RenovateJob` spec using the `preUpgrade` and `postUpgrade` fields.
+
+### Basic Example
+
+```yaml
+apiVersion: renovate-operator.mogenius.com/v1alpha1
+kind: RenovateJob
+metadata:
+  name: example-with-hooks
+spec:
+  schedule: "0 2 * * *"
+  image: ghcr.io/renovatebot/renovate:latest
+  parallelism: 2
+  secretRef: renovate-secret
+
+  # Run validation before renovate
+  preUpgrade:
+    image: alpine:3
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        echo "Running pre-upgrade validation..."
+        if [ -z "$RENOVATE_TOKEN" ]; then
+          echo "Error: RENOVATE_TOKEN not set"
+          exit 1
+        fi
+        echo "Validation passed"
+    envFrom:
+      - secretRef:
+          name: renovate-secret
+
+  # Send notification after renovate
+  postUpgrade:
+    image: curlimages/curl:latest
+    command: ["/bin/sh", "-c"]
+    args:
+      - |
+        echo "Sending completion notification..."
+        curl -X POST https://hooks.slack.com/services/YOUR/WEBHOOK/URL \
+          -H 'Content-Type: application/json' \
+          -d '{"text": "Renovate completed for project"}'
+    failOnError: false  # Don't fail the job if notification fails
+```
+
+## Hook Configuration Options
+
+### Required Fields
+
+- **`image`** (string): The Docker image to use for the hook container
+
+### Optional Fields
+
+- **`command`** ([]string): The command to execute (e.g., `["/bin/sh", "-c"]`)
+- **`args`** ([]string): Arguments for the command
+- **`env`** ([]EnvVar): Environment variables for the hook
+- **`envFrom`** ([]EnvFromSource): Environment variables from secrets or configmaps
+- **`failOnError`** (*bool): Whether hook failure should block execution (default: `true`)
+- **`resources`** (ResourceRequirements): CPU and memory requests/limits for the hook
+- **`volumeMounts`** ([]VolumeMount): Volume mounts for the hook container
+
+## Failure Handling
+
+The `failOnError` flag controls what happens when a hook fails:
+
+### PreUpgrade Hooks
+
+**`failOnError: true`** (default)
+```yaml
+preUpgrade:
+  image: alpine:3
+  command: ["/bin/sh", "-c"]
+  args: ["exit 1"]  # This will fail
+  failOnError: true
+```
+- Hook failure → Project status = `failed`
+- Renovate job **does not run**
+- Use this when the hook is critical (e.g., credential validation)
+
+**`failOnError: false`**
+```yaml
+preUpgrade:
+  image: alpine:3
+  command: ["/bin/sh", "-c"]
+  args: ["exit 1"]  # This will fail
+  failOnError: false
+```
+- Hook failure → Warning logged
+- Renovate job **continues normally**
+- Use this for non-critical tasks (e.g., optional notifications)
+
+### PostUpgrade Hooks
+
+**`failOnError: true`** (default)
+```yaml
+postUpgrade:
+  image: curlimages/curl:latest
+  command: ["/bin/sh", "-c"]
+  args: ["curl https://invalid-url"]  # This will fail
+  failOnError: true
+```
+- Hook failure → Project status = `failed` (even if Renovate succeeded)
+- Use this when post-processing is critical
+
+**`failOnError: false`**
+```yaml
+postUpgrade:
+  image: curlimages/curl:latest
+  command: ["/bin/sh", "-c"]
+  args: ["curl https://invalid-url"]  # This will fail
+  failOnError: false
+```
+- Hook failure → Warning logged
+- Project status = `completed` (uses Renovate job's status)
+- Use this for best-effort operations (e.g., notifications, metrics)
+
+**Note**: If the Renovate job fails, the postUpgrade hook is **skipped entirely** and the project is marked as `failed`.
+
+## Data Exchange Between Hooks and Renovate
+
+Hooks share the `/tmp` volume with the Renovate container, enabling data exchange:
+
+```yaml
+preUpgrade:
+  image: alpine:3
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      echo "custom-config-value" > /tmp/config.txt
+      echo "PreUpgrade completed"
+
+# Renovate can read /tmp/config.txt
+
+postUpgrade:
+  image: alpine:3
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      if [ -f /tmp/renovate-logs.txt ]; then
+        cat /tmp/renovate-logs.txt
+      fi
+      echo "PostUpgrade completed"
+```
+
+### Available Volumes
+
+1. **`/tmp` (EmptyDir)**: Always available, shared between all phases
+2. **`ExtraVolumes`**: Any volumes defined in `spec.extraVolumes` are also available
+
+You can customize volume mounts for hooks:
+
+```yaml
+spec:
+  extraVolumes:
+    - name: shared-data
+      persistentVolumeClaim:
+        claimName: my-pvc
+
+  preUpgrade:
+    image: alpine:3
+    volumeMounts:
+      - name: shared-data
+        mountPath: /data
+      - name: tmp
+        mountPath: /tmp
+    command: ["/bin/sh", "-c"]
+    args: ["cp /data/config.json /tmp/"]
+```
+
+## Environment Variables
+
+Hooks can access environment variables from:
+
+1. **Direct `env` field**:
+```yaml
+preUpgrade:
+  image: alpine:3
+  env:
+    - name: LOG_LEVEL
+      value: "debug"
+    - name: PROJECT_NAME
+      value: "my-project"
+```
+
+2. **Secrets via `envFrom`**:
+```yaml
+preUpgrade:
+  image: alpine:3
+  envFrom:
+    - secretRef:
+        name: renovate-secret
+    - configMapRef:
+        name: renovate-config
+```
+
+## Resource Management
+
+Specify CPU and memory for hooks:
+
+```yaml
+preUpgrade:
+  image: my-heavy-validation:latest
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+```
+
+If not specified, hooks have no resource requests or limits (cluster defaults apply).
+
+## Scheduling and Security
+
+Hooks inherit scheduling and security settings from the `RenovateJob` spec:
+
+- **Node Selector**: `spec.nodeSelector`
+- **Affinity**: `spec.affinity`
+- **Tolerations**: `spec.tolerations`
+- **Security Context**: `spec.securityContext`
+- **Service Account**: `spec.serviceAccount`
+- **Image Pull Secrets**: `spec.imagePullSecrets`
+
+This ensures hooks run on the same nodes and with the same permissions as Renovate jobs.
+
+## Advanced Examples
+
+### PreUpgrade: Validate GitHub Token
+
+```yaml
+preUpgrade:
+  image: curlimages/curl:latest
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      echo "Validating GitHub token..."
+      response=$(curl -s -o /dev/null -w "%{http_code}" \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        https://api.github.com/user)
+
+      if [ "$response" = "200" ]; then
+        echo "Token is valid"
+        exit 0
+      else
+        echo "Token validation failed (HTTP $response)"
+        exit 1
+      fi
+  envFrom:
+    - secretRef:
+        name: renovate-secret
+  failOnError: true
+```
+
+### PostUpgrade: Send Slack Notification
+
+```yaml
+postUpgrade:
+  image: curlimages/curl:latest
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      WEBHOOK_URL="https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
+      PROJECT="${PROJECT_NAME:-unknown}"
+
+      curl -X POST "$WEBHOOK_URL" \
+        -H 'Content-Type: application/json' \
+        -d "{
+          \"text\": \"✅ Renovate completed for project: $PROJECT\",
+          \"username\": \"Renovate Bot\"
+        }"
+  env:
+    - name: PROJECT_NAME
+      value: "my-repo"
+  failOnError: false
+```
+
+### PreUpgrade: Download Configuration from S3
+
+```yaml
+preUpgrade:
+  image: amazon/aws-cli:latest
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      echo "Downloading config from S3..."
+      aws s3 cp s3://my-bucket/renovate-config.json /tmp/config.json
+      echo "Config downloaded successfully"
+  env:
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: aws-credentials
+          key: access-key-id
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: aws-credentials
+          key: secret-access-key
+  volumeMounts:
+    - name: tmp
+      mountPath: /tmp
+```
+
+### PostUpgrade: Upload Logs to S3
+
+```yaml
+postUpgrade:
+  image: amazon/aws-cli:latest
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+      LOG_FILE="/tmp/renovate-logs-${TIMESTAMP}.txt"
+
+      if [ -f /tmp/renovate-output.log ]; then
+        aws s3 cp /tmp/renovate-output.log \
+          "s3://my-logs-bucket/renovate/${PROJECT}/${TIMESTAMP}.log"
+        echo "Logs uploaded successfully"
+      else
+        echo "No logs found to upload"
+      fi
+  env:
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: aws-credentials
+          key: access-key-id
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: aws-credentials
+          key: secret-access-key
+    - name: PROJECT
+      value: "my-project"
+  failOnError: false
+```
+
+## Monitoring and Debugging
+
+### Viewing Hook Status
+
+Check the project status in the RenovateJob:
+
+```bash
+kubectl get renovatejob example-with-hooks -o yaml
+```
+
+Look for the `subStatus` field in the project status:
+
+```yaml
+status:
+  projects:
+    - name: my-project
+      status: running
+      subStatus: preUpgrade  # or "postUpgrade"
+      lastRun: "2024-01-15T10:00:00Z"
+```
+
+### Viewing Hook Logs
+
+List hook jobs:
+
+```bash
+# List all jobs for a RenovateJob
+kubectl get jobs -l renovate-operator.mogenius.com/job-name=<job-name>
+
+# Filter by job type
+kubectl get jobs -l renovate-operator.mogenius.com/job-type=preUpgrade
+kubectl get jobs -l renovate-operator.mogenius.com/job-type=postUpgrade
+```
+
+View hook logs:
+
+```bash
+# Get the pod name
+kubectl get pods -l job-name=<hook-job-name>
+
+# View logs
+kubectl logs <pod-name>
+```
+
+### Hook Job Lifecycle
+
+Hooks are implemented as Kubernetes Jobs with the same lifecycle settings as Renovate jobs:
+
+- **ActiveDeadlineSeconds**: Uses `JOB_TIMEOUT_SECONDS` environment variable
+- **BackoffLimit**: Uses `JOB_BACKOFF_LIMIT` environment variable
+- **TTLSecondsAfterFinished**: Uses `JOB_TTL_SECONDS_AFTER_FINISHED` environment variable
+- **DELETE_SUCCESSFUL_JOBS**: If set to `"true"`, completed hook jobs are automatically deleted
+
+## Troubleshooting
+
+### Hook Fails Immediately
+
+**Symptom**: Hook job fails right after creation
+
+**Possible causes**:
+1. Image pull error - verify the image exists and is accessible
+2. Invalid command or args - check the syntax
+3. Missing environment variables - verify secrets/configmaps exist
+4. Insufficient resources - check node capacity
+
+**Debug**:
+```bash
+kubectl describe job <hook-job-name>
+kubectl describe pod <hook-pod-name>
+```
+
+### Hook Hangs
+
+**Symptom**: Hook runs but never completes
+
+**Possible causes**:
+1. Command is waiting for input (hooks don't support interactive commands)
+2. Network timeout (no response from external service)
+3. Resource limits too low
+
+**Debug**:
+```bash
+kubectl logs <hook-pod-name> -f
+kubectl top pod <hook-pod-name>
+```
+
+### Renovate Never Starts
+
+**Symptom**: PreUpgrade completes but Renovate job doesn't start
+
+**Check**:
+1. Hook exit code - must be 0 for success
+2. `failOnError` setting
+3. Parallelism limits - check if max projects are already running
+
+### Data Not Shared Between Hooks
+
+**Symptom**: Files written in preUpgrade are not visible in postUpgrade
+
+**Cause**: Volume mounts not configured correctly
+
+**Solution**: Ensure all hooks mount the same volumes:
+```yaml
+volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+```
+
+## Security Considerations
+
+1. **Secrets**: Always use Kubernetes secrets for sensitive data, never hardcode
+2. **Image Security**: Use trusted images from verified registries
+3. **Least Privilege**: Hooks inherit the RenovateJob's service account - ensure it has minimal permissions
+4. **Network Policies**: Consider restricting network access for hook containers
+5. **Resource Limits**: Set appropriate limits to prevent resource exhaustion
+
+## Best Practices
+
+1. **Keep hooks simple**: Each hook should do one thing well
+2. **Use `failOnError` appropriately**: Critical operations should fail, best-effort operations should not
+3. **Add logging**: Echo status messages to help with debugging
+4. **Test independently**: Test your hook images separately before integrating
+5. **Monitor execution time**: Long-running hooks delay the entire workflow
+6. **Handle errors gracefully**: Always include error handling in your scripts
+7. **Use lightweight images**: Alpine-based images are faster to pull and start
+
+## Limitations
+
+1. **Sequential execution**: Hooks run one at a time (preUpgrade → renovate → postUpgrade)
+2. **Per-project isolation**: Each project gets its own hook jobs
+3. **No inter-project communication**: Hooks for different projects can't communicate
+4. **Timeout applies**: Hooks must complete within `JOB_TIMEOUT_SECONDS`
+5. **No retry logic**: Failed hooks are not automatically retried (they follow `JOB_BACKOFF_LIMIT`)
+
+## See Also
+
+- [RenovateJob CRD Reference](../charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml)
+- [Webhooks Documentation](./webhooks/webhook.md)
+- [Configuration Options](../README.md)

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -67,6 +67,10 @@ type RenovateJobSpec struct {
 	// Configuration for the scratch volume
 	// +optional
 	ScratchVolume *RenovateJobScratchVolume `json:"scratchVolume,omitempty"`
+	// Hook to run before renovate execution
+	PreUpgrade *RenovateHook `json:"preUpgrade,omitempty"`
+	// Hook to run after renovate execution
+	PostUpgrade *RenovateHook `json:"postUpgrade,omitempty"`
 }
 
 type RenovateJobScratchVolume struct {
@@ -140,6 +144,26 @@ type RenovateJobMetadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
+// Hook configuration for running commands before or after renovate execution
+type RenovateHook struct {
+	// Container image to use for the hook
+	Image string `json:"image"`
+	// Command to execute (e.g., ["/bin/sh", "-c"])
+	Command []string `json:"command,omitempty"`
+	// Arguments for the command
+	Args []string `json:"args,omitempty"`
+	// Environment variables for the hook
+	Env []corev1.EnvVar `json:"env,omitempty"`
+	// Environment from secrets/configmaps
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
+	// Whether hook failure should block execution (default: true)
+	FailOnError *bool `json:"failOnError,omitempty"`
+	// Resource requirements for the hook container
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Volume mounts for the hook container
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
+}
+
 /*
 Renovate Provider Information
 This will be used to fill "RENOVATE_ENDPOINT" and "RENOVATE_PLATFORM" environment variables in the renovate container
@@ -200,6 +224,8 @@ type ProjectStatus struct {
 	Duration             *string               `json:"duration,omitempty"`
 	Status               RenovateProjectStatus `json:"status"`
 	Priority             int32                 `json:"priority,omitempty"`
+	// Current execution phase (preUpgrade, postUpgrade, or empty for renovate)
+	SubStatus            *string               `json:"subStatus,omitempty"`
 	RenovateResultStatus *string               `json:"renovateResultStatus,omitempty"`
 	PRActivity           *PRActivity           `json:"prActivity,omitempty"`
 	LogIssues            *LogIssues            `json:"logIssues,omitempty"`

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -75,6 +75,10 @@ type RenovateJobSpec struct {
 	// RuntimeClassName for the resulting pod, used to select a non-default container runtime
 	// +optional
 	RuntimeClassName *string `json:"runtimeClassName,omitempty"`
+	// Hook to run before renovate execution
+	PreUpgrade *RenovateHook `json:"preUpgrade,omitempty"`
+	// Hook to run after renovate execution
+	PostUpgrade *RenovateHook `json:"postUpgrade,omitempty"`
 }
 
 type RenovateJobScratchVolume struct {
@@ -153,6 +157,26 @@ type RenovateJobMetadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
+// Hook configuration for running commands before or after renovate execution
+type RenovateHook struct {
+	// Container image to use for the hook
+	Image string `json:"image"`
+	// Command to execute (e.g., ["/bin/sh", "-c"])
+	Command []string `json:"command,omitempty"`
+	// Arguments for the command
+	Args []string `json:"args,omitempty"`
+	// Environment variables for the hook
+	Env []corev1.EnvVar `json:"env,omitempty"`
+	// Environment from secrets/configmaps
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty"`
+	// Whether hook failure should block execution (default: true)
+	FailOnError *bool `json:"failOnError,omitempty"`
+	// Resource requirements for the hook container
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Volume mounts for the hook container
+	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
+}
+
 /*
 Renovate Provider Information
 This will be used to fill "RENOVATE_ENDPOINT" and "RENOVATE_PLATFORM" environment variables in the renovate container
@@ -215,6 +239,8 @@ type ProjectStatus struct {
 	Duration             *string               `json:"duration,omitempty"`
 	Status               RenovateProjectStatus `json:"status"`
 	Priority             int32                 `json:"priority,omitempty"`
+	// Current execution phase (preUpgrade, postUpgrade, or empty for renovate)
+	SubStatus            *string               `json:"subStatus,omitempty"`
 	RenovateResultStatus *string               `json:"renovateResultStatus,omitempty"`
 	PRActivity           *PRActivity           `json:"prActivity,omitempty"`
 	LogIssues            *LogIssues            `json:"logIssues,omitempty"`

--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -24,8 +24,10 @@ const (
 type JobType string
 
 const (
-	DiscoveryJobType JobType = "discovery"
-	ExecutorJobType  JobType = "executor"
+	DiscoveryJobType   JobType = "discovery"
+	ExecutorJobType    JobType = "executor"
+	PreUpgradeJobType  JobType = "preUpgrade"
+	PostUpgradeJobType JobType = "postUpgrade"
 )
 
 type JobSelector struct {

--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -46,8 +46,10 @@ const (
 type JobType string
 
 const (
-	DiscoveryJobType JobType = "discovery"
-	ExecutorJobType  JobType = "executor"
+	DiscoveryJobType   JobType = "discovery"
+	ExecutorJobType    JobType = "executor"
+	PreUpgradeJobType  JobType = "preUpgrade"
+	PostUpgradeJobType JobType = "postUpgrade"
 )
 
 type JobSelector struct {

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -142,6 +142,23 @@ func (e *renovateExecutor) reconcileRunning(ctx context.Context, renovateJobs []
 				continue
 			}
 
+			// Check substatus to determine which phase we're in
+			if project.SubStatus != nil && *project.SubStatus == "preUpgrade" {
+				if err := e.handlePreUpgradeHook(ctx, renovateJob, project, &jobId); err != nil {
+					return 0, nil, err
+				}
+				globalRunning++
+				perJobRunning[key]++
+				continue
+			} else if project.SubStatus != nil && *project.SubStatus == "postUpgrade" {
+				if err := e.handlePostUpgradeHook(ctx, renovateJob, project, &jobId); err != nil {
+					return 0, nil, err
+				}
+				globalRunning++
+				perJobRunning[key]++
+				continue
+			}
+
 			k8sJob, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
 				JobName:   utils.ExecutorJobName(renovateJob, project.Name),
 				JobType:   crdManager.ExecutorJobType,
@@ -196,6 +213,35 @@ func (e *renovateExecutor) reconcileRunning(ctx context.Context, renovateJobs []
 			metricStore.SetRunFailed(renovateJob.Namespace, renovateJob.Name, project.Name, newStatus == api.JobStatusFailed)
 			metricStore.SetDependencyIssues(renovateJob.Namespace, renovateJob.Name, project.Name, hasIssues)
 			metricStore.CaptureRenovateProjectExecution(renovateJob.Namespace, renovateJob.Name, project.Name, string(newStatus))
+
+			// Check if postUpgrade hook should run
+			if newStatus == api.JobStatusCompleted && renovateJob.Spec.PostUpgrade != nil {
+				postUpgradeJob := newHookJob(renovateJob, project.Name, renovateJob.Spec.PostUpgrade, crdManager.PostUpgradeJobType)
+				if err := controllerutil.SetControllerReference(renovateJob, postUpgradeJob, e.scheme); err != nil {
+					return 0, nil, fmt.Errorf("failed to set controller reference for postUpgrade hook: %w", err)
+				}
+
+				_, err := crdManager.CreateJobWithGeneration(ctx, e.client, postUpgradeJob, crdManager.JobSelector{
+					JobName:   utils.PostUpgradeJobName(renovateJob, project.Name),
+					JobType:   crdManager.PostUpgradeJobType,
+					Namespace: renovateJob.Namespace,
+				})
+				if err != nil {
+					return 0, nil, fmt.Errorf("failed to create postUpgrade hook for project %s: %w", project.Name, err)
+				}
+
+				postUpgradeSubStatus := "postUpgrade"
+				if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
+					Status:    api.JobStatusRunning,
+					SubStatus: &postUpgradeSubStatus,
+				}); err != nil {
+					return 0, nil, err
+				}
+				e.logger.Info("started postUpgrade hook", "project", project.Name)
+				globalRunning++
+				perJobRunning[key]++
+				continue
+			}
 
 			if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, newProjectStatus); err != nil {
 				return 0, nil, err
@@ -281,28 +327,200 @@ func (e *renovateExecutor) dispatchScheduled(ctx context.Context, renovateJobs [
 			return fmt.Errorf("failed to ensure redis url secret: %w", err)
 		}
 
-		k8sJob := newRenovateJob(renovateJob, project.Name)
-		if err := controllerutil.SetControllerReference(renovateJob, k8sJob, e.scheme); err != nil {
-			return fmt.Errorf("failed to set controller reference: %w", err)
+		if renovateJob.Spec.PreUpgrade != nil {
+			preUpgradeJob := newHookJob(renovateJob, project.Name, renovateJob.Spec.PreUpgrade, crdManager.PreUpgradeJobType)
+			if err := controllerutil.SetControllerReference(renovateJob, preUpgradeJob, e.scheme); err != nil {
+				return fmt.Errorf("failed to set controller reference for preUpgrade hook: %w", err)
+			}
+
+			_, err := crdManager.CreateJobWithGeneration(ctx, e.client, preUpgradeJob, crdManager.JobSelector{
+				JobName:   utils.PreUpgradeJobName(renovateJob, project.Name),
+				JobType:   crdManager.PreUpgradeJobType,
+				Namespace: renovateJob.Namespace,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create preUpgrade hook for project %s: %w", project.Name, err)
+			}
+
+			preUpgradeSubStatus := "preUpgrade"
+			if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
+				Status:    api.JobStatusRunning,
+				SubStatus: &preUpgradeSubStatus,
+			}); err != nil {
+				return err
+			}
+			e.logger.Info("started preUpgrade hook", "project", project.Name)
+		} else {
+			k8sJob := newRenovateJob(renovateJob, project.Name)
+			if err := controllerutil.SetControllerReference(renovateJob, k8sJob, e.scheme); err != nil {
+				return fmt.Errorf("failed to set controller reference: %w", err)
+			}
+
+			_, err := crdManager.CreateJobWithGeneration(ctx, e.client, k8sJob, crdManager.JobSelector{
+				JobName:   utils.ExecutorJobName(renovateJob, project.Name),
+				JobType:   crdManager.ExecutorJobType,
+				Namespace: renovateJob.Namespace,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)
+			}
+
+			if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
+				Status: api.JobStatusRunning,
+			}); err != nil {
+				return err
+			}
 		}
 
-		_, err := crdManager.CreateJobWithGeneration(ctx, e.client, k8sJob, crdManager.JobSelector{
+		globalRunning++
+		perJobRunning[key]++
+	}
+
+	return nil
+}
+
+// handlePreUpgradeHook monitors the preUpgrade hook job and transitions to the main renovate job.
+// Returns true if the hook is still running (caller should count it), false if it finished.
+func (e *renovateExecutor) handlePreUpgradeHook(ctx context.Context, renovateJob *api.RenovateJob, project *api.ProjectStatus, jobId *crdManager.RenovateJobIdentifier) error {
+	job, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
+		JobName:   utils.PreUpgradeJobName(renovateJob, project.Name),
+		JobType:   crdManager.PreUpgradeJobType,
+		Namespace: renovateJob.Namespace,
+	})
+
+	var newStatus api.RenovateProjectStatus
+	var durationStr string
+	if err != nil {
+		if errors.IsNotFound(err) {
+			newStatus = api.JobStatusFailed
+		} else {
+			return err
+		}
+	} else {
+		newStatus, durationStr, err = getJobStatus(job)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Hook job has finished
+	if newStatus != api.JobStatusRunning {
+		failOnError := getFailOnError(renovateJob.Spec.PreUpgrade)
+
+		if newStatus == api.JobStatusFailed && failOnError {
+			// PreUpgrade failed and failOnError=true, fail the project
+			e.logger.Error(nil, "preUpgrade hook failed, failing project", "project", project.Name)
+			err = e.manager.UpdateProjectStatus(ctx, project.Name, *jobId, &types.RenovateStatusUpdate{
+				Status:    api.JobStatusFailed,
+				SubStatus: nil,
+				Duration:  &durationStr,
+			})
+			return err
+		}
+
+		if newStatus == api.JobStatusFailed && !failOnError {
+			// PreUpgrade failed but failOnError=false, log warning and continue
+			e.logger.Info("preUpgrade hook failed but failOnError=false, continuing", "project", project.Name)
+		}
+
+		// PreUpgrade succeeded or failed with failOnError=false, create main renovate job
+		renovateJobObj := newRenovateJob(renovateJob, project.Name)
+		if err := controllerutil.SetControllerReference(renovateJob, renovateJobObj, e.scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference for renovate job: %w", err)
+		}
+
+		_, err := crdManager.CreateJobWithGeneration(ctx, e.client, renovateJobObj, crdManager.JobSelector{
 			JobName:   utils.ExecutorJobName(renovateJob, project.Name),
 			JobType:   crdManager.ExecutorJobType,
 			Namespace: renovateJob.Namespace,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)
+			return fmt.Errorf("failed to create renovate job for project %s: %w", project.Name, err)
 		}
 
-		if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
-			Status: api.JobStatusRunning,
-		}); err != nil {
+		// Update status to indicate renovate is now running (clear substatus)
+		err = e.manager.UpdateProjectStatus(ctx, project.Name, *jobId, &types.RenovateStatusUpdate{
+			Status:    api.JobStatusRunning,
+			SubStatus: nil,
+		})
+		if err != nil {
 			return err
 		}
+		e.logger.Info("preUpgrade hook completed, started renovate job", "project", project.Name)
 
-		globalRunning++
-		perJobRunning[key]++
+		// Delete preUpgrade job if configured
+		deleteSuccessfulJobs := config.GetValue("DELETE_SUCCESSFUL_JOBS")
+		if newStatus == api.JobStatusCompleted && deleteSuccessfulJobs == "true" && job != nil {
+			err = crdManager.DeleteJob(ctx, e.client, job)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// handlePostUpgradeHook monitors the postUpgrade hook job and finalizes the project status
+func (e *renovateExecutor) handlePostUpgradeHook(ctx context.Context, renovateJob *api.RenovateJob, project *api.ProjectStatus, jobId *crdManager.RenovateJobIdentifier) error {
+	job, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
+		JobName:   utils.PostUpgradeJobName(renovateJob, project.Name),
+		JobType:   crdManager.PostUpgradeJobType,
+		Namespace: renovateJob.Namespace,
+	})
+
+	var newStatus api.RenovateProjectStatus
+	var durationStr string
+	if err != nil {
+		if errors.IsNotFound(err) {
+			newStatus = api.JobStatusFailed
+		} else {
+			return err
+		}
+	} else {
+		newStatus, durationStr, err = getJobStatus(job)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Hook job has finished
+	if newStatus != api.JobStatusRunning {
+		failOnError := getFailOnError(renovateJob.Spec.PostUpgrade)
+
+		var finalStatus api.RenovateProjectStatus
+		if newStatus == api.JobStatusFailed && failOnError {
+			// PostUpgrade failed and failOnError=true, fail the project
+			e.logger.Error(nil, "postUpgrade hook failed, failing project", "project", project.Name)
+			finalStatus = api.JobStatusFailed
+		} else {
+			if newStatus == api.JobStatusFailed && !failOnError {
+				// PostUpgrade failed but failOnError=false, log warning
+				e.logger.Info("postUpgrade hook failed but failOnError=false, using completed status", "project", project.Name)
+			}
+			// Use completed status (renovate must have succeeded to reach postUpgrade)
+			finalStatus = api.JobStatusCompleted
+		}
+
+		// Finalize project status
+		err = e.manager.UpdateProjectStatus(ctx, project.Name, *jobId, &types.RenovateStatusUpdate{
+			Status:    finalStatus,
+			SubStatus: nil,
+			Duration:  &durationStr,
+		})
+		if err != nil {
+			return err
+		}
+		e.logger.Info("postUpgrade hook completed", "project", project.Name, "finalStatus", finalStatus)
+
+		// Delete postUpgrade job if configured
+		deleteSuccessfulJobs := config.GetValue("DELETE_SUCCESSFUL_JOBS")
+		if newStatus == api.JobStatusCompleted && deleteSuccessfulJobs == "true" && job != nil {
+			err = crdManager.DeleteJob(ctx, e.client, job)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -28,6 +28,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
 	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -135,7 +136,7 @@ func (e *renovateExecutor) execute(ctx context.Context, options executionOptions
 
 	// Pass 1: check all currently running projects across all jobs, update their statuses,
 	// and count how many are still running globally and per job.
-	globalRunning, perJobRunning := e.countRunningProjects(renovateJobs)
+	globalRunning, perJobRunning := e.countRunningProjects(ctx, renovateJobs)
 
 	// Pass 2: collect all scheduled projects across all jobs, sort for fairness,
 	// and dispatch new jobs up to the global and per-job limits.
@@ -149,7 +150,7 @@ func (e *renovateExecutor) execute(ctx context.Context, options executionOptions
 
 // countRunningProjects returns the number of still-running projects globally and per job
 // (keyed by job fullname).
-func (e *renovateExecutor) countRunningProjects(renovateJobs []api.RenovateJob) (int, map[string]int) {
+func (e *renovateExecutor) countRunningProjects(ctx context.Context, renovateJobs []api.RenovateJob) (int, map[string]int) {
 	globalRunning := 0
 	perJobRunning := make(map[string]int, len(renovateJobs))
 
@@ -164,6 +165,24 @@ func (e *renovateExecutor) countRunningProjects(renovateJobs []api.RenovateJob) 
 			if project.Status != api.JobStatusRunning {
 				continue
 			}
+
+			// Check substatus to determine which phase we're in
+			if project.SubStatus != nil && *project.SubStatus == "preUpgrade" {
+				if err := e.handlePreUpgradeHook(ctx, renovateJob, project, &jobId); err != nil {
+					e.logger.Error(err, "failed to handle preUpgrade hook", "project", project.Name)
+				}
+				globalRunning++
+				perJobRunning[key]++
+				continue
+			} else if project.SubStatus != nil && *project.SubStatus == "postUpgrade" {
+				if err := e.handlePostUpgradeHook(ctx, renovateJob, project, &jobId); err != nil {
+					e.logger.Error(err, "failed to handle postUpgrade hook", "project", project.Name)
+				}
+				globalRunning++
+				perJobRunning[key]++
+				continue
+			}
+
 			globalRunning++
 			perJobRunning[key]++
 		}
@@ -349,36 +368,205 @@ func (e *renovateExecutor) dispatchScheduled(ctx context.Context, renovateJobs [
 
 		carrier := propagation.MapCarrier{}
 		otel.GetTextMapPropagator().Inject(ctx, carrier)
-		k8sJob := newRenovateJob(renovateJob, project.Name, carrier.Get("traceparent"))
-		if err := controllerutil.SetControllerReference(renovateJob, k8sJob, e.scheme); err != nil {
-			return fmt.Errorf("failed to set controller reference: %w", err)
-		}
+		traceparent := carrier.Get("traceparent")
 
-		_, err := crdManager.CreateJobWithGeneration(ctx, e.client, k8sJob, crdManager.JobSelector{
-			JobType:         crdManager.ExecutorJobType,
-			Namespace:       renovateJob.Namespace,
-			RenovateJobName: renovateJob.Name,
-			Project:         project.Name,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)
-		}
+		if renovateJob.Spec.PreUpgrade != nil {
+			preUpgradeJob := newHookJob(renovateJob, project.Name, renovateJob.Spec.PreUpgrade, crdManager.PreUpgradeJobType)
+			if err := controllerutil.SetControllerReference(renovateJob, preUpgradeJob, e.scheme); err != nil {
+				return fmt.Errorf("failed to set controller reference for preUpgrade hook: %w", err)
+			}
 
-		if span := trace.SpanFromContext(ctx); span.IsRecording() {
-			span.AddEvent("job.created", trace.WithAttributes(
-				semconv.K8SNamespaceName(renovateJob.Namespace),
-				semconv.K8SJobName(utils.ExecutorJobName(renovateJob, project.Name)),
-			))
-		}
+			_, err := crdManager.CreateJobWithGeneration(ctx, e.client, preUpgradeJob, crdManager.JobSelector{
+				RenovateJobName: renovateJob.Name,
+				Project:         project.Name,
+				JobType:         crdManager.PreUpgradeJobType,
+				Namespace:       renovateJob.Namespace,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create preUpgrade hook for project %s: %w", project.Name, err)
+			}
 
-		if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
-			Status: api.JobStatusRunning,
-		}); err != nil {
-			return err
+			preUpgradeSubStatus := "preUpgrade"
+			if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
+				Status:    api.JobStatusRunning,
+				SubStatus: &preUpgradeSubStatus,
+			}); err != nil {
+				return err
+			}
+			e.logger.Info("started preUpgrade hook", "project", project.Name)
+		} else {
+			k8sJob := newRenovateJob(renovateJob, project.Name, traceparent)
+			if err := controllerutil.SetControllerReference(renovateJob, k8sJob, e.scheme); err != nil {
+				return fmt.Errorf("failed to set controller reference: %w", err)
+			}
+
+			_, err := crdManager.CreateJobWithGeneration(ctx, e.client, k8sJob, crdManager.JobSelector{
+				JobType:         crdManager.ExecutorJobType,
+				Namespace:       renovateJob.Namespace,
+				RenovateJobName: renovateJob.Name,
+				Project:         project.Name,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)
+			}
+
+			if span := trace.SpanFromContext(ctx); span.IsRecording() {
+				span.AddEvent("job.created", trace.WithAttributes(
+					semconv.K8SNamespaceName(renovateJob.Namespace),
+					semconv.K8SJobName(utils.ExecutorJobName(renovateJob, project.Name)),
+				))
+			}
+
+			if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, &types.RenovateStatusUpdate{
+				Status: api.JobStatusRunning,
+			}); err != nil {
+				return err
+			}
 		}
 
 		globalRunning++
 		perJobRunning[key]++
+	}
+
+	return nil
+}
+
+// handlePreUpgradeHook monitors the preUpgrade hook job and transitions to the main renovate job.
+func (e *renovateExecutor) handlePreUpgradeHook(ctx context.Context, renovateJob *api.RenovateJob, project *api.ProjectStatus, jobId *crdManager.RenovateJobIdentifier) error {
+	job, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
+		RenovateJobName: renovateJob.Name,
+		Project:         project.Name,
+		JobType:         crdManager.PreUpgradeJobType,
+		Namespace:       renovateJob.Namespace,
+	})
+
+	var newStatus api.RenovateProjectStatus
+	var durationStr string
+	if err != nil {
+		if errors.IsNotFound(err) {
+			newStatus = api.JobStatusFailed
+		} else {
+			return err
+		}
+	} else {
+		newStatus, durationStr, err = getJobStatus(job)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Hook job has finished
+	if newStatus != api.JobStatusRunning {
+		failOnError := getFailOnError(renovateJob.Spec.PreUpgrade)
+
+		if newStatus == api.JobStatusFailed && failOnError {
+			e.logger.Error(nil, "preUpgrade hook failed, failing project", "project", project.Name)
+			err = e.manager.UpdateProjectStatus(ctx, project.Name, *jobId, &types.RenovateStatusUpdate{
+				Status:    api.JobStatusFailed,
+				SubStatus: nil,
+				Duration:  &durationStr,
+			})
+			return err
+		}
+
+		if newStatus == api.JobStatusFailed && !failOnError {
+			e.logger.Info("preUpgrade hook failed but failOnError=false, continuing", "project", project.Name)
+		}
+
+		// PreUpgrade succeeded or failed with failOnError=false, create main renovate job
+		carrier := propagation.MapCarrier{}
+		otel.GetTextMapPropagator().Inject(ctx, carrier)
+		renovateJobObj := newRenovateJob(renovateJob, project.Name, carrier.Get("traceparent"))
+		if err := controllerutil.SetControllerReference(renovateJob, renovateJobObj, e.scheme); err != nil {
+			return fmt.Errorf("failed to set controller reference for renovate job: %w", err)
+		}
+
+		_, err := crdManager.CreateJobWithGeneration(ctx, e.client, renovateJobObj, crdManager.JobSelector{
+			RenovateJobName: renovateJob.Name,
+			Project:         project.Name,
+			JobType:         crdManager.ExecutorJobType,
+			Namespace:       renovateJob.Namespace,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create renovate job for project %s: %w", project.Name, err)
+		}
+
+		err = e.manager.UpdateProjectStatus(ctx, project.Name, *jobId, &types.RenovateStatusUpdate{
+			Status:    api.JobStatusRunning,
+			SubStatus: nil,
+		})
+		if err != nil {
+			return err
+		}
+		e.logger.Info("preUpgrade hook completed, started renovate job", "project", project.Name)
+
+		if newStatus == api.JobStatusCompleted && config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" && job != nil {
+			err = crdManager.DeleteJob(ctx, e.client, job)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// handlePostUpgradeHook monitors the postUpgrade hook job and finalizes the project status
+func (e *renovateExecutor) handlePostUpgradeHook(ctx context.Context, renovateJob *api.RenovateJob, project *api.ProjectStatus, jobId *crdManager.RenovateJobIdentifier) error {
+	job, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
+		RenovateJobName: renovateJob.Name,
+		Project:         project.Name,
+		JobType:         crdManager.PostUpgradeJobType,
+		Namespace:       renovateJob.Namespace,
+	})
+
+	var newStatus api.RenovateProjectStatus
+	var durationStr string
+	if err != nil {
+		if errors.IsNotFound(err) {
+			newStatus = api.JobStatusFailed
+		} else {
+			return err
+		}
+	} else {
+		newStatus, durationStr, err = getJobStatus(job)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Hook job has finished
+	if newStatus != api.JobStatusRunning {
+		failOnError := getFailOnError(renovateJob.Spec.PostUpgrade)
+
+		var finalStatus api.RenovateProjectStatus
+		if newStatus == api.JobStatusFailed && failOnError {
+			e.logger.Error(nil, "postUpgrade hook failed, failing project", "project", project.Name)
+			finalStatus = api.JobStatusFailed
+		} else {
+			if newStatus == api.JobStatusFailed && !failOnError {
+				e.logger.Info("postUpgrade hook failed but failOnError=false, using completed status", "project", project.Name)
+			}
+			// Use completed status (renovate must have succeeded to reach postUpgrade)
+			finalStatus = api.JobStatusCompleted
+		}
+
+		err = e.manager.UpdateProjectStatus(ctx, project.Name, *jobId, &types.RenovateStatusUpdate{
+			Status:    finalStatus,
+			SubStatus: nil,
+			Duration:  &durationStr,
+		})
+		if err != nil {
+			return err
+		}
+		e.logger.Info("postUpgrade hook completed", "project", project.Name, "finalStatus", finalStatus)
+
+		if newStatus == api.JobStatusCompleted && config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" && job != nil {
+			err = crdManager.DeleteJob(ctx, e.client, job)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -414,3 +414,99 @@ func getScratchVolumePath(scratch *api.RenovateJobScratchVolume) string {
 	}
 	return "/tmp"
 }
+
+// getFailOnError returns true if the hook should fail the execution on error (default: true)
+func getFailOnError(hook *api.RenovateHook) bool {
+	if hook.FailOnError == nil {
+		return true
+	}
+	return *hook.FailOnError
+}
+
+// create a Job spec for a hook (preUpgrade or postUpgrade)
+func newHookJob(job *api.RenovateJob, project string, hook *api.RenovateHook, hookType crdmanager.JobType) *batchv1.Job {
+	// Build volumes - same as renovate job
+	volumes := []v1.Volume{
+		{
+			Name: "tmp",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	volumes = append(volumes, job.Spec.ExtraVolumes...)
+
+	// Build volume mounts - use hook's custom mounts or default to /tmp
+	volumeMounts := hook.VolumeMounts
+	if len(volumeMounts) == 0 {
+		volumeMounts = []v1.VolumeMount{
+			{
+				Name:      "tmp",
+				MountPath: "/tmp",
+			},
+		}
+	}
+
+	// Build container spec with hook configuration
+	container := v1.Container{
+		Name:            string(hookType),
+		Image:           hook.Image,
+		Command:         hook.Command,
+		Args:            hook.Args,
+		Env:             hook.Env,
+		EnvFrom:         hook.EnvFrom,
+		Resources:       hook.Resources,
+		VolumeMounts:    volumeMounts,
+		SecurityContext: getContainerSecurityContext(job.Spec),
+	}
+
+	// Create the job
+	batchJob := &batchv1.Job{
+		Spec: batchv1.JobSpec{
+			ActiveDeadlineSeconds:   getJobTimeoutSeconds(),
+			BackoffLimit:            getJobBackOffLimit(),
+			TTLSecondsAfterFinished: getJobTTLSecondsAfterFinished(),
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					ServiceAccountName:            getServiceAccountName(job.Spec),
+					ImagePullSecrets:              append(job.Spec.ImagePullSecrets, getDefaultImagePullSecrets()...),
+					TerminationGracePeriodSeconds: ptr.To(int64(0)),
+					Containers:                    []v1.Container{container},
+					SecurityContext:               getPodSecurityContext(job.Spec),
+					AutomountServiceAccountToken:  getAutoMountServiceAccountToken(job.Spec),
+					RestartPolicy:                 v1.RestartPolicyOnFailure,
+					DNSPolicy:                     getDNSPolicy(job.Spec),
+					NodeSelector:                  job.Spec.NodeSelector,
+					Affinity:                      job.Spec.Affinity,
+					Tolerations:                   job.Spec.Tolerations,
+					TopologySpreadConstraints:     job.Spec.TopologySpreadConstraints,
+					Volumes:                       volumes,
+				},
+			},
+		},
+	}
+
+	// Set job name based on hook type
+	var jobName string
+	if hookType == crdmanager.PreUpgradeJobType {
+		jobName = utils.PreUpgradeJobName(job, project)
+	} else {
+		jobName = utils.PostUpgradeJobName(job, project)
+	}
+
+	batchJob.GenerateName = jobName
+	batchJob.Namespace = job.Namespace
+
+	// Apply metadata annotations if configured
+	if job.Spec.Metadata != nil {
+		batchJob.Spec.Template.Annotations = job.Spec.Metadata.Annotations
+		batchJob.Annotations = job.Spec.Metadata.Annotations
+	}
+
+	// Set labels
+	labels := getJobLabels(job.Spec.Metadata, hookType, jobName)
+	batchJob.Labels = labels
+	batchJob.Spec.Template.Labels = labels
+
+	return batchJob
+}

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -6,6 +6,7 @@ import (
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/config"
 	"renovate-operator/github"
+	crdmanager "renovate-operator/internal/crdManager"
 	"renovate-operator/internal/utils"
 	"strconv"
 	"strings"
@@ -474,4 +475,100 @@ func getScratchVolumePath(scratch *api.RenovateJobScratchVolume) string {
 		return scratch.Path
 	}
 	return "/tmp"
+}
+
+// getFailOnError returns true if the hook should fail the execution on error (default: true)
+func getFailOnError(hook *api.RenovateHook) bool {
+	if hook.FailOnError == nil {
+		return true
+	}
+	return *hook.FailOnError
+}
+
+// create a Job spec for a hook (preUpgrade or postUpgrade)
+func newHookJob(job *api.RenovateJob, project string, hook *api.RenovateHook, hookType crdmanager.JobType) *batchv1.Job {
+	// Build volumes - same as renovate job
+	volumes := []v1.Volume{
+		{
+			Name: "tmp",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	volumes = append(volumes, job.Spec.ExtraVolumes...)
+
+	// Build volume mounts - use hook's custom mounts or default to /tmp
+	volumeMounts := hook.VolumeMounts
+	if len(volumeMounts) == 0 {
+		volumeMounts = []v1.VolumeMount{
+			{
+				Name:      "tmp",
+				MountPath: "/tmp",
+			},
+		}
+	}
+
+	// Build container spec with hook configuration
+	container := v1.Container{
+		Name:            strings.ToLower(string(hookType)),
+		Image:           hook.Image,
+		Command:         hook.Command,
+		Args:            hook.Args,
+		Env:             hook.Env,
+		EnvFrom:         hook.EnvFrom,
+		Resources:       hook.Resources,
+		VolumeMounts:    volumeMounts,
+		SecurityContext: getContainerSecurityContext(job.Spec),
+	}
+
+	// Create the job
+	batchJob := &batchv1.Job{
+		Spec: batchv1.JobSpec{
+			ActiveDeadlineSeconds:   getJobTimeoutSeconds(),
+			BackoffLimit:            getJobBackOffLimit(),
+			TTLSecondsAfterFinished: getJobTTLSecondsAfterFinished(),
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					ServiceAccountName:            getServiceAccountName(job.Spec),
+					ImagePullSecrets:              append(job.Spec.ImagePullSecrets, getDefaultImagePullSecrets()...),
+					TerminationGracePeriodSeconds: new(int64(0)),
+					Containers:                    []v1.Container{container},
+					SecurityContext:               getPodSecurityContext(job.Spec),
+					AutomountServiceAccountToken:  getAutoMountServiceAccountToken(job.Spec),
+					RestartPolicy:                 v1.RestartPolicyOnFailure,
+					DNSPolicy:                     getDNSPolicy(job.Spec),
+					NodeSelector:                  job.Spec.NodeSelector,
+					Affinity:                      job.Spec.Affinity,
+					Tolerations:                   job.Spec.Tolerations,
+					TopologySpreadConstraints:     job.Spec.TopologySpreadConstraints,
+					Volumes:                       volumes,
+				},
+			},
+		},
+	}
+
+	// Set job name based on hook type
+	var jobName string
+	if hookType == crdmanager.PreUpgradeJobType {
+		jobName = utils.PreUpgradeJobName(job, project)
+	} else {
+		jobName = utils.PostUpgradeJobName(job, project)
+	}
+
+	batchJob.GenerateName = jobName
+	batchJob.Namespace = job.Namespace
+
+	// Apply metadata annotations if configured
+	if job.Spec.Metadata != nil {
+		batchJob.Spec.Template.Annotations = job.Spec.Metadata.Annotations
+		batchJob.Annotations = job.Spec.Metadata.Annotations
+	}
+
+	if job.Spec.Metadata != nil {
+		batchJob.Labels = job.Spec.Metadata.Labels
+		batchJob.Spec.Template.Labels = job.Spec.Metadata.Labels
+	}
+
+	return batchJob
 }

--- a/src/internal/types/renovateStatusUpdate.go
+++ b/src/internal/types/renovateStatusUpdate.go
@@ -9,6 +9,7 @@ import (
 type RenovateStatusUpdate struct {
 	Status               api.RenovateProjectStatus
 	Priority             int32
+	SubStatus            *string
 	RenovateResultStatus *string
 	PRActivity           *api.PRActivity
 	LogIssues            *api.LogIssues

--- a/src/internal/utils/jobNames.go
+++ b/src/internal/utils/jobNames.go
@@ -56,3 +56,53 @@ func DiscoveryJobName(in *api.RenovateJob) string {
 
 	return baseName + "-discovery-" + hashStr
 }
+
+// jobname for the preUpgrade hook job for a project. normalized for kubernetes resourcenames
+func PreUpgradeJobName(in *api.RenovateJob, project string) string {
+	fullName := in.Name + "-" + project + "-preupgrade"
+	fullName = kubernetesCompatibleName(fullName)
+
+	// Generate hash of the full name
+	hash := sha256.Sum256([]byte(fullName))
+	hashStr := fmt.Sprintf("%x", hash[:4]) // Use first 4 bytes (8 hex chars)
+
+	// Trim to 54 chars and append hash
+	if len(fullName) > 54 {
+		fullName = fullName[:54]
+	}
+
+	return fullName + "-" + hashStr
+}
+
+// jobname for the postUpgrade hook job for a project. normalized for kubernetes resourcenames
+func PostUpgradeJobName(in *api.RenovateJob, project string) string {
+	fullName := in.Name + "-" + project + "-postupgrade"
+	fullName = kubernetesCompatibleName(fullName)
+
+	// Generate hash of the full name
+	hash := sha256.Sum256([]byte(fullName))
+	hashStr := fmt.Sprintf("%x", hash[:4]) // Use first 4 bytes (8 hex chars)
+
+	// Trim to 54 chars and append hash
+	if len(fullName) > 54 {
+		fullName = fullName[:54]
+	}
+
+	return fullName + "-" + hashStr
+}
+
+// LEGACY functions - to be removed February 2026
+func LegacyExecutorJobName(in *api.RenovateJob, project string) string {
+	jobName := in.Name + "-" + project
+	jobName = strings.ReplaceAll(jobName, "/", "-") // Replace slashes to avoid issues with Kubernetes naming
+	jobName = strings.ReplaceAll(jobName, "_", "-")
+	jobName = strings.ReplaceAll(jobName, ".", "-")
+	jobName = strings.ToLower(jobName) // Ensure lowercase for consistency
+	return jobName
+}
+
+// LEGACY functions - to be removed February 2026
+func LegacyDiscoveryJobName(in *api.RenovateJob) string {
+	jobName := in.Name + "-discovery"
+	return jobName
+}

--- a/src/internal/utils/jobNames.go
+++ b/src/internal/utils/jobNames.go
@@ -70,3 +70,53 @@ func DiscoveryJobName(in *api.RenovateJob) string {
 
 	return baseName + "-discovery-" + hashStr
 }
+
+// jobname for the preUpgrade hook job for a project. normalized for kubernetes resourcenames
+func PreUpgradeJobName(in *api.RenovateJob, project string) string {
+	fullName := in.Name + "-" + project + "-preupgrade"
+	fullName = KubernetesCompatibleName(fullName)
+
+	// Generate hash of the full name
+	hash := sha256.Sum256([]byte(fullName))
+	hashStr := fmt.Sprintf("%x", hash[:4]) // Use first 4 bytes (8 hex chars)
+
+	// Trim to 54 chars and append hash
+	if len(fullName) > 54 {
+		fullName = fullName[:54]
+	}
+
+	return fullName + "-" + hashStr
+}
+
+// jobname for the postUpgrade hook job for a project. normalized for kubernetes resourcenames
+func PostUpgradeJobName(in *api.RenovateJob, project string) string {
+	fullName := in.Name + "-" + project + "-postupgrade"
+	fullName = KubernetesCompatibleName(fullName)
+
+	// Generate hash of the full name
+	hash := sha256.Sum256([]byte(fullName))
+	hashStr := fmt.Sprintf("%x", hash[:4]) // Use first 4 bytes (8 hex chars)
+
+	// Trim to 54 chars and append hash
+	if len(fullName) > 54 {
+		fullName = fullName[:54]
+	}
+
+	return fullName + "-" + hashStr
+}
+
+// LEGACY functions - to be removed February 2026
+func LegacyExecutorJobName(in *api.RenovateJob, project string) string {
+	jobName := in.Name + "-" + project
+	jobName = strings.ReplaceAll(jobName, "/", "-") // Replace slashes to avoid issues with Kubernetes naming
+	jobName = strings.ReplaceAll(jobName, "_", "-")
+	jobName = strings.ReplaceAll(jobName, ".", "-")
+	jobName = strings.ToLower(jobName) // Ensure lowercase for consistency
+	return jobName
+}
+
+// LEGACY functions - to be removed February 2026
+func LegacyDiscoveryJobName(in *api.RenovateJob) string {
+	jobName := in.Name + "-discovery"
+	return jobName
+}

--- a/src/internal/utils/projectStatus.go
+++ b/src/internal/utils/projectStatus.go
@@ -34,6 +34,7 @@ func validateProjectStatusScheduled(projectStatus *api.ProjectStatus, desiredSta
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
+	updateSubStatus(projectStatus, desiredStatus.SubStatus)
 	return projectStatus
 }
 
@@ -47,6 +48,7 @@ func validateProjectStatusRunning(projectStatus *api.ProjectStatus, desiredStatu
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
+	updateSubStatus(projectStatus, desiredStatus.SubStatus)
 	return projectStatus
 }
 
@@ -61,6 +63,7 @@ func validateProjectStatusCompleted(projectStatus *api.ProjectStatus, desiredSta
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
+	updateSubStatus(projectStatus, desiredStatus.SubStatus)
 	return projectStatus
 }
 
@@ -75,6 +78,7 @@ func validateProjectStatusFailed(projectStatus *api.ProjectStatus, desiredStatus
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
+	updateSubStatus(projectStatus, desiredStatus.SubStatus)
 	return projectStatus
 }
 
@@ -94,4 +98,9 @@ func updateLogIssues(projectStatus *api.ProjectStatus, issues *api.LogIssues) {
 	if issues != nil {
 		projectStatus.LogIssues = issues
 	}
+}
+
+func updateSubStatus(projectStatus *api.ProjectStatus, subStatus *string) {
+	// Always update SubStatus, even if it's nil (to clear it)
+	projectStatus.SubStatus = subStatus
 }

--- a/src/internal/utils/projectStatus.go
+++ b/src/internal/utils/projectStatus.go
@@ -36,6 +36,7 @@ func validateProjectStatusScheduled(projectStatus *api.ProjectStatus, desiredSta
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
+	updateSubStatus(projectStatus, desiredStatus.SubStatus)
 	return projectStatus
 }
 
@@ -49,6 +50,7 @@ func validateProjectStatusRunning(projectStatus *api.ProjectStatus, desiredStatu
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
+	updateSubStatus(projectStatus, desiredStatus.SubStatus)
 	return projectStatus
 }
 
@@ -63,6 +65,7 @@ func validateProjectStatusCompleted(projectStatus *api.ProjectStatus, desiredSta
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
+	updateSubStatus(projectStatus, desiredStatus.SubStatus)
 	return projectStatus
 }
 
@@ -77,6 +80,7 @@ func validateProjectStatusFailed(projectStatus *api.ProjectStatus, desiredStatus
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
 	updatePRActivity(projectStatus, desiredStatus.PRActivity)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
+	updateSubStatus(projectStatus, desiredStatus.SubStatus)
 	return projectStatus
 }
 
@@ -110,4 +114,9 @@ func updateLogIssues(projectStatus *api.ProjectStatus, issues *api.LogIssues) {
 	if issues != nil {
 		projectStatus.LogIssues = issues
 	}
+}
+
+func updateSubStatus(projectStatus *api.ProjectStatus, subStatus *string) {
+	// Always update SubStatus, even if it's nil (to clear it)
+	projectStatus.SubStatus = subStatus
 }


### PR DESCRIPTION
# Summary
                                                                                                                                               
  - Adds `preUpgrade` and `postUpgrade` hooks to RenovateJobSpec, allowing users to run arbitrary init/cleanup containers before and after each Renovate execution (similarly to the official helm chart [preCommand and postCommand](https://github.com/renovatebot/helm-charts/blob/main/charts/renovate/values.yaml#L63-L72))
  - Introduces a `SubStatus` field on `ProjectStatus` to track which phase a project is currently in (`preUpgrade`, `postUpgrade`, or empty for the main Renovate run)
  - Executor state machine extended: `dispatchScheduled` launches the `preUpgrade` hook instead of the Renovate job when configured, reconcileRunning monitors hook jobs and advances the pipeline — `preUpgrade` → `renovate` → `postUpgrade` → final status
  - Hook failures are configurable: `failOnError`: true (default) marks the project failed; `failOnError`: false logs a warning and proceeds
  - Hook jobs reuse the existing job infrastructure: `TTL cleanup`, `DELETE_SUCCESSFUL_JOBS`, `controller ownership`, `label-based selection`, and pod-level settings (`node selector`, `affinity`, `security contexts`, `image pull secrets`) are all inherited
