### PR TITLE
fix(ui): allow re-prioritizing scheduled projects via Trigger button

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1837,19 +1837,22 @@
                                   }
                                   disabled={
                                     project.triggering ||
-                                    project.status === "running" ||
-                                    project.status === "scheduled"
+                                    project.status === "running"
                                   }
-                                  className={`bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all w-[90px]`}
+                                  className={`bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all w-[100px]`}
                                   aria-label={
                                     project.triggering
                                       ? "Triggering renovate"
+                                      : project.status === "scheduled"
+                                      ? `Prioritize renovate for ${project.name}`
                                       : `Trigger renovate for ${project.name}`
                                   }
                                 >
                                   <span>
                                     {project.triggering
                                       ? "Triggering..."
+                                      : project.status === "scheduled"
+                                      ? "Prioritize"
                                       : "Trigger"}
                                   </span>
                                 </button>
@@ -2002,18 +2005,23 @@
                             onClick={() => onTriggerRenovate(job, project)}
                             disabled={
                               project.triggering ||
-                              project.status === "running" ||
-                              project.status === "scheduled"
+                              project.status === "running"
                             }
                             className={`bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all w-[110px]`}
                             aria-label={
                               project.triggering
                                 ? "Triggering renovate"
+                                : project.status === "scheduled"
+                                ? `Prioritize renovate for ${project.name}`
                                 : `Trigger renovate for ${project.name}`
                             }
                           >
                             <span>
-                              {project.triggering ? "Triggering..." : "Trigger"}
+                              {project.triggering
+                                ? "Triggering..."
+                                : project.status === "scheduled"
+                                ? "Prioritize"
+                                : "Trigger"}
                             </span>
                           </button>
                           <a


### PR DESCRIPTION
Fixes #309

## Summary

Once a project was in `scheduled` status, the per-project **Trigger** button in the web UI was disabled, leaving no way to nudge a specific repository to run next. On a deployment with ~200 repos and `parallelism: 3`, discovery fills the queue with ~150 scheduled projects, and the user has no way to influence ordering — they have to wait.

The backend already supports priority-bumping end to end:
- `POST /api/v1/renovate` schedules with `Priority = 2` (`src/ui/renovateController.go:395-406`).
- `validateProjectStatusScheduled` will raise a project's priority even when it is already scheduled (`src/internal/utils/projectStatus.go:26-38`).
- The executor's dispatch pass sorts candidates by `Priority DESC`, then oldest wait (`src/internal/renovate/executor.go:256-261`).

So only the frontend was blocking the request.

## What changed

- `src/static/index.html`: dropped `project.status === "scheduled"` from the `disabled` check in both the table view and the card view.
- When the project's status is `scheduled`, the button is relabeled **Prioritize** (with a matching `aria-label`) to communicate the effect.
- Running projects remain disabled — cannot interrupt.
- Minor: widened the table-view button from `w-[90px]` to `w-[100px]` to accommodate the new label.

## Non-goals

This only reorders the scheduled queue. If all parallel slots are occupied by long-running jobs, the bumped project still waits for one to finish. Preemption of running jobs is intentionally out of scope — see #309.

## Test plan

- [ ] Load the UI with a RenovateJob that has projects in `scheduled` status.
- [ ] Verify the Trigger button is **enabled** for scheduled projects and labeled **Prioritize**.
- [ ] Click Prioritize → verify the POST to `/api/v1/renovate` succeeds and the project's `Priority` is raised to 2 in the CRD status.
- [ ] Verify the executor dispatches the bumped project ahead of other scheduled projects on the next tick.
- [ ] Verify the button remains **disabled** and labeled **Trigger** ("Triggering..." during in-flight) while a project is `running`.
- [ ] Check both the table view and the card (mobile) view.