### PR TITLE
fix: make the errors and warnings under issues a deeplink so i can se…

### DIFF
--- a/src/internal/parser/logParser.go
+++ b/src/internal/parser/logParser.go
@@ -148,7 +148,7 @@ func ParseRenovateLogs(logs string) *LogParseResult {
 			}
 			msg := entry.Msg
 			if len(msg) > MaxIssueMessageLen {
-				msg = msg[:MaxIssueMessageLen]
+				msg = msg[:MaxIssueMessageLen] + "…"
 			}
 			if msg != "" && !seenMessages[msg] {
 				seenMessages[msg] = true

--- a/src/internal/parser/logParser_test.go
+++ b/src/internal/parser/logParser_test.go
@@ -801,14 +801,30 @@ func TestParseRenovateLogsLogIssues(t *testing.T) {
 			wantIssueCount: 1,
 		},
 		{
-			name: "message truncation at 256 chars",
-			logs: fmt.Sprintf(`{"level":40,"msg":"%s"}`, strings.Repeat("x", 300)),
+			name: "message truncation with ellipsis suffix",
+			logs: fmt.Sprintf(`{"level":40,"msg":"%s"}`, strings.Repeat("x", MaxIssueMessageLen+50)),
+			wantWarnCount:  1,
+			wantErrorCount: 0,
+			wantIssueCount: 1,
+			checkIssues: func(t *testing.T, issues []api.LogIssue) {
+				wantLen := MaxIssueMessageLen + len("…")
+				if len(issues[0].Message) != wantLen {
+					t.Errorf("message length = %d, want %d", len(issues[0].Message), wantLen)
+				}
+				if !strings.HasSuffix(issues[0].Message, "…") {
+					t.Errorf("message does not end with ellipsis")
+				}
+			},
+		},
+		{
+			name: "message exactly at MaxIssueMessageLen - no ellipsis",
+			logs: fmt.Sprintf(`{"level":40,"msg":"%s"}`, strings.Repeat("x", MaxIssueMessageLen)),
 			wantWarnCount:  1,
 			wantErrorCount: 0,
 			wantIssueCount: 1,
 			checkIssues: func(t *testing.T, issues []api.LogIssue) {
 				if len(issues[0].Message) != MaxIssueMessageLen {
-					t.Errorf("message length = %d, want %d", len(issues[0].Message), MaxIssueMessageLen)
+					t.Errorf("message length = %d, want %d (no ellipsis expected)", len(issues[0].Message), MaxIssueMessageLen)
 				}
 			},
 		},

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1235,7 +1235,23 @@
         );
       }
 
-      function IssueDetailRow({ logIssues, projectName }) {
+      function issueLogsHref(jobName, jobNamespace, projectName, level) {
+        const levels = level >= 50 ? "ERROR,FATAL" : "WARN";
+        return `/logs?renovate=${encodeURIComponent(jobName)}&namespace=${encodeURIComponent(jobNamespace)}&project=${encodeURIComponent(projectName)}&levels=${levels}`;
+      }
+
+      // Backend truncates issue messages at 256 bytes and appends "…". Older CRD-stored
+      // messages predating that change lack the suffix, so render one when the length
+      // indicates truncation and none is present.
+      const ISSUE_MESSAGE_LIMIT = 256;
+      function displayIssueMessage(msg) {
+        if (!msg) return "";
+        if (msg.endsWith("…")) return msg;
+        if (msg.length >= ISSUE_MESSAGE_LIMIT) return msg + "…";
+        return msg;
+      }
+
+      function IssueDetailRow({ logIssues, projectName, jobName, jobNamespace }) {
         if (!logIssues || !logIssues.issues || logIssues.issues.length === 0) return null;
 
         return (
@@ -1244,10 +1260,25 @@
               <div className="py-3 pl-4 border-l-2 border-amber-300 dark:border-amber-600 max-h-64 overflow-y-auto">
                 <div className="space-y-1.5">
                   {logIssues.issues.map((issue, idx) => (
-                    <div key={idx} className="flex items-start gap-2 text-sm">
+                    <a
+                      key={idx}
+                      href={issueLogsHref(jobName, jobNamespace, projectName, issue.level)}
+                      target="_blank"
+                      rel="noopener"
+                      className="group flex items-start gap-2 text-sm rounded-md hover:bg-amber-50 dark:hover:bg-amber-900/20 -mx-1 px-1 py-0.5 transition-colors"
+                      title="Open full message in logs"
+                    >
                       <span className={`flex-shrink-0 ${issueLevelBadgeClass(issue.level)}`}>{issue.level >= 50 ? "error" : "warn"}</span>
-                      <span className="text-gray-700 dark:text-slate-300 break-all">{issue.message}</span>
-                    </div>
+                      <span className="text-gray-700 dark:text-slate-300 break-all">
+                        {displayIssueMessage(issue.message)}
+                        <span className="inline-flex items-center gap-0.5 ml-1.5 text-primary hover:underline whitespace-nowrap">
+                          View in logs
+                          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                          </svg>
+                        </span>
+                      </span>
+                    </a>
                   ))}
                   {logIssues.truncated && (
                     <div className="text-xs text-gray-400 dark:text-slate-500 italic mt-1">
@@ -1874,7 +1905,7 @@
                             <PRDetailRow prActivity={project.prActivity} projectName={project.name} platform={job.platform} platformEndpoint={job.platformEndpoint} />
                           )}
                           {expandedIssues.has(project.name) && project.logIssues && (
-                            <IssueDetailRow logIssues={project.logIssues} projectName={project.name} />
+                            <IssueDetailRow logIssues={project.logIssues} projectName={project.name} jobName={job.name} jobNamespace={job.namespace} />
                           )}
                           {tooltipElement}
                         </>
@@ -1986,10 +2017,25 @@
                           <div id={`issue-details-${safeId(project.name)}`} className="pl-2 border-l-2 border-amber-300 dark:border-amber-600 max-h-48 overflow-y-auto">
                             <div className="space-y-1.5">
                               {project.logIssues.issues.map((issue, idx) => (
-                                <div key={idx} className="flex items-start gap-2 text-sm">
+                                <a
+                                  key={idx}
+                                  href={issueLogsHref(job.name, job.namespace, project.name, issue.level)}
+                                  target="_blank"
+                                  rel="noopener"
+                                  className="group flex items-start gap-2 text-sm rounded-md hover:bg-amber-50 dark:hover:bg-amber-900/20 -mx-1 px-1 py-0.5 transition-colors"
+                                  title="Open full message in logs"
+                                >
                                   <span className={`flex-shrink-0 ${issueLevelBadgeClass(issue.level)}`}>{issue.level >= 50 ? "error" : "warn"}</span>
-                                  <span className="text-gray-700 dark:text-slate-300 break-all text-xs">{issue.message}</span>
-                                </div>
+                                  <span className="text-gray-700 dark:text-slate-300 break-all text-xs">
+                                    {displayIssueMessage(issue.message)}
+                                    <span className="inline-flex items-center gap-0.5 ml-1.5 text-primary hover:underline whitespace-nowrap">
+                                      View in logs
+                                      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                      </svg>
+                                    </span>
+                                  </span>
+                                </a>
                               ))}
                               {project.logIssues.truncated && (
                                 <div className="text-xs text-gray-400 dark:text-slate-500 italic mt-1">Some issues omitted (list truncated)</div>

--- a/src/static/pages/logs.html
+++ b/src/static/pages/logs.html
@@ -177,7 +177,13 @@
         DEBUG: "text-gray-400 dark:text-slate-500",
       };
 
-      const [selectedLevels, setSelectedLevels] = useState(new Set(ALL_LEVELS));
+      const initialLevels = useMemo(() => {
+        const raw = params.get("levels");
+        if (!raw) return new Set(ALL_LEVELS);
+        const requested = raw.split(",").map(s => s.trim().toUpperCase()).filter(s => ALL_LEVELS.includes(s));
+        return requested.length > 0 ? new Set(requested) : new Set(ALL_LEVELS);
+      }, []);
+      const [selectedLevels, setSelectedLevels] = useState(initialLevels);
       const [filterOpen, setFilterOpen] = useState(false);
       const filterRef = useRef(null);
 


### PR DESCRIPTION
…e the whole message. it is a parameter in the url and it also works for errors.

Example:
1. When I click "View in logs":
<img width="1387" height="359" alt="Screenshot 2026-04-22 at 08 59 08" src="https://github.com/user-attachments/assets/64ee239f-5b2f-4daa-b3a8-1903e33102f3" />

2. I get to this filtered view:
<img width="1447" height="416" alt="Screenshot 2026-04-22 at 08 58 52" src="https://github.com/user-attachments/assets/53a848ef-776c-4638-8d9f-73498a662389" />
