### PR TITLE
fix(helm): render DEFAULT_ALLOWED_GROUPS independent of Valkey

### DIFF
--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -196,10 +196,10 @@ spec:
             {{- end }}
             - name: VALKEY_FORWARD_CACHE_TO_JOBS
               value: {{ .Values.config.forwardCacheToJobs | quote }}
+            {{- end }}
             {{- if .Values.auth.defaultAllowedGroups }}
             - name: DEFAULT_ALLOWED_GROUPS
               value: {{ .Values.auth.defaultAllowedGroups | quote }}
-            {{- end }}
             {{- end }}
             - name: GLOBAL_PARALLELISM_LIMIT
               value: {{ .Values.config.globalParallelismLimit | quote }}


### PR DESCRIPTION
## Summary
- Fixes Helm env rendering so `DEFAULT_ALLOWED_GROUPS` is no longer gated by Valkey configuration.
- Moves `DEFAULT_ALLOWED_GROUPS` out of the `valkey` conditional block in the Deployment template.
- Preserves existing behavior of only setting `DEFAULT_ALLOWED_GROUPS` when `auth.defaultAllowedGroups` is non-empty.

## Root Cause
- Regression introduced in commit d1cebd7a5706d4570c3fdf623d52f9995297b437 ("fix: allow the user to disable cache forwarding to renovate jobs").
- That change added `VALKEY_FORWARD_CACHE_TO_JOBS` and shifted conditional boundaries, causing `DEFAULT_ALLOWED_GROUPS` to be rendered only when `valkey.enabled=true` and no external `valkey.existingSecret` is used.

## Validation
- Rendered chart with `valkey.enabled=false` and confirmed `DEFAULT_ALLOWED_GROUPS` is present.
- Rendered chart with `valkey.enabled=true` and `valkey.auth.enabled=false` and confirmed `VALKEY_HOST`, `VALKEY_FORWARD_CACHE_TO_JOBS`, and `DEFAULT_ALLOWED_GROUPS` are present.
- Ran:
  - `just build`
  - `just test-unit`
  - `just generate`