### PR TITLE
feat: add Azure DevOps provider with contract tests

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -1,0 +1,38 @@
+# Acknowledgments
+
+This project's testing patterns for the Azure DevOps integration were
+inspired by the following open-source projects. No code was directly copied;
+only architectural patterns and testing approaches were adopted.
+
+## FluxCD notification-controller
+
+- **Repository:** https://github.com/fluxcd/notification-controller
+- **License:** Apache-2.0
+- **What we learned:** Thin interface boundary pattern — define a minimal
+  interface (only the methods you call) at the consuming site, inject via
+  exported struct field, and use hand-written fakes (no mocking library) for
+  unit tests. Integration tests gated behind `//go:build integration` with
+  real infrastructure.
+
+## mcdafydd/go-azuredevops
+
+- **Repository:** https://github.com/mcdafydd/go-azuredevops
+- **License:** BSD-3-Clause
+- **What we learned:** The `httptest.NewServer` + `setup()` pattern
+  (originated in google/go-github) for testing HTTP API clients. Testdata
+  fixtures for webhook event payloads. Table-driven tests with shared
+  assertion helpers.
+
+## google/go-github
+
+- **Repository:** https://github.com/google/go-github
+- **License:** BSD-3-Clause
+- **What we learned:** The canonical Go pattern for testing HTTP API clients:
+  `setup()` returns `(client, mux, serverURL, teardown)`, handlers verify
+  request shape and return canned JSON, assertions use `google/go-cmp`.
+
+## Azure DevOps REST API Documentation
+
+- **URL:** https://learn.microsoft.com/en-us/rest/api/azure/devops/?view=azure-devops-rest-7.2
+- **Used for:** Response schema definitions in testdata fixtures and contract
+  test struct definitions.

--- a/src/gitProviderClients/azuredevopsProvider/azuredevops.go
+++ b/src/gitProviderClients/azuredevopsProvider/azuredevops.go
@@ -1,0 +1,73 @@
+package azuredevopsProvider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"renovate-operator/gitProviderClients"
+)
+
+// AzureDevOpsClient implements GitProviderClient for the Azure DevOps REST API.
+type AzureDevOpsClient struct {
+	Endpoint   string
+	Token      string
+	HTTPClient *http.Client
+}
+
+func (c *AzureDevOpsClient) IsFork(ctx context.Context, project string) (bool, error) {
+	// project format: "ProjectName/RepoName"
+	parts := strings.SplitN(project, "/", 2)
+	if len(parts) != 2 {
+		return false, fmt.Errorf("invalid Azure DevOps project format %q, expected \"Project/Repo\"", project)
+	}
+	adoProject := url.PathEscape(parts[0])
+	repoName := url.PathEscape(parts[1])
+
+	apiURL := fmt.Sprintf("%s/%s/_apis/git/repositories/%s?api-version=7.1", c.Endpoint, adoProject, repoName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return false, err
+	}
+	req.SetBasicAuth("", c.Token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("azure devops API returned status %d for %s: %s", resp.StatusCode, project, string(body))
+	}
+
+	var repo struct {
+		IsFork bool `json:"isFork"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&repo); err != nil {
+		return false, fmt.Errorf("failed to decode Azure DevOps API response for %s: %w", project, err)
+	}
+	return repo.IsFork, nil
+}
+
+func (c *AzureDevOpsClient) SearchReposByTopic(_ context.Context, _ string) ([]gitProviderClients.Repository, error) {
+	return nil, fmt.Errorf("searching repositories by topic is not supported by Azure DevOps provider")
+}
+
+func (c *AzureDevOpsClient) ListRepoWebhooks(_ context.Context, _, _ string) ([]gitProviderClients.Webhook, error) {
+	return nil, fmt.Errorf("listing webhooks is not supported by Azure DevOps provider")
+}
+
+func (c *AzureDevOpsClient) CreateRepoWebhook(_ context.Context, _, _ string, _ gitProviderClients.CreateWebhookOptions) (*gitProviderClients.Webhook, error) {
+	return nil, fmt.Errorf("creating webhooks is not supported by Azure DevOps provider")
+}
+
+func (c *AzureDevOpsClient) DeleteRepoWebhook(_ context.Context, _, _ string, _ int64) error {
+	return fmt.Errorf("deleting webhooks is not supported by Azure DevOps provider")
+}

--- a/src/gitProviderClients/azuredevopsProvider/azuredevops_test.go
+++ b/src/gitProviderClients/azuredevopsProvider/azuredevops_test.go
@@ -1,0 +1,137 @@
+package azuredevopsProvider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestIsFork_True(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/MyProject/_apis/git/repositories/my-repo" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"isFork": true})
+	}))
+	defer server.Close()
+
+	client := &AzureDevOpsClient{Endpoint: server.URL, Token: "test-pat", HTTPClient: server.Client()}
+	isFork, err := client.IsFork(context.Background(), "MyProject/my-repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isFork {
+		t.Error("expected isFork=true, got false")
+	}
+}
+
+func TestIsFork_False(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"isFork": false})
+	}))
+	defer server.Close()
+
+	client := &AzureDevOpsClient{Endpoint: server.URL, Token: "test-pat", HTTPClient: server.Client()}
+	isFork, err := client.IsFork(context.Background(), "MyProject/my-repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isFork {
+		t.Error("expected isFork=false, got true")
+	}
+}
+
+func TestIsFork_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"unauthorized"}`))
+	}))
+	defer server.Close()
+
+	client := &AzureDevOpsClient{Endpoint: server.URL, Token: "bad-token", HTTPClient: server.Client()}
+	_, err := client.IsFork(context.Background(), "MyProject/my-repo")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "azure devops API returned status 401") {
+		t.Errorf("expected error to contain status 401, got %q", err.Error())
+	}
+}
+
+func TestIsFork_BasicAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		if !ok {
+			t.Error("expected Basic auth, got none")
+		}
+		if username != "" {
+			t.Errorf("expected empty username, got %q", username)
+		}
+		if password != "my-pat-token" {
+			t.Errorf("expected password 'my-pat-token', got %q", password)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"isFork": false})
+	}))
+	defer server.Close()
+
+	client := &AzureDevOpsClient{Endpoint: server.URL, Token: "my-pat-token", HTTPClient: server.Client()}
+	_, err := client.IsFork(context.Background(), "Project/Repo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestIsFork_ProjectParsing(t *testing.T) {
+	tests := []struct {
+		name         string
+		project      string
+		expectedPath string
+		expectErr    bool
+	}{
+		{
+			name:         "standard format",
+			project:      "MyProject/my-repo",
+			expectedPath: "/MyProject/_apis/git/repositories/my-repo",
+		},
+		{
+			name:         "project with spaces gets encoded",
+			project:      "My Project/my-repo",
+			expectedPath: "/My Project/_apis/git/repositories/my-repo",
+		},
+		{
+			name:      "missing slash",
+			project:   "just-a-name",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Path
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"isFork": false})
+			}))
+			defer server.Close()
+
+			client := &AzureDevOpsClient{Endpoint: server.URL, Token: "pat", HTTPClient: server.Client()}
+			_, err := client.IsFork(context.Background(), tt.project)
+
+			if tt.expectErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if capturedPath != tt.expectedPath {
+				t.Errorf("expected path %q, got %q", tt.expectedPath, capturedPath)
+			}
+		})
+	}
+}

--- a/src/gitProviderClients/azuredevopsProvider/contract_test.go
+++ b/src/gitProviderClients/azuredevopsProvider/contract_test.go
@@ -1,0 +1,150 @@
+package azuredevopsProvider
+
+// Contract tests validate that the Azure DevOps REST API response shapes
+// (captured in testdata/) deserialize correctly into our Go types.
+//
+// These fixtures are based on the Azure DevOps REST API 7.2 documentation:
+// https://learn.microsoft.com/en-us/rest/api/azure/devops/?view=azure-devops-rest-7.2
+//
+// Re-record the testdata fixtures periodically (or when bumping API versions)
+// by capturing real responses from the ADO API. The tests will fail if the
+// response structure drifts from what our code expects.
+//
+// Testing approach inspired by:
+// - FluxCD notification-controller (thin interface + hand-written fakes)
+//   https://github.com/fluxcd/notification-controller
+//   Licensed under Apache-2.0
+// - mcdafydd/go-azuredevops (httptest server pattern from google/go-github)
+//   https://github.com/mcdafydd/go-azuredevops
+//   Licensed under BSD-3-Clause
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// repositoryResponse represents the full Azure DevOps Git Repository response.
+// Uses DisallowUnknownFields decoding so that if the testdata fixture contains
+// fields not covered by this struct, the test fails — forcing us to update the
+// struct when the API response shape changes.
+//
+// Schema: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/repositories/get?view=azure-devops-rest-7.2
+type repositoryResponse struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Project struct {
+		ID         string `json:"id"`
+		Name       string `json:"name"`
+		State      string `json:"state"`
+		Visibility string `json:"visibility"`
+	} `json:"project"`
+	DefaultBranch    string              `json:"defaultBranch"`
+	Size             int                 `json:"size"`
+	RemoteURL        string              `json:"remoteUrl"`
+	SshURL           string              `json:"sshUrl"`
+	IsFork           bool                `json:"isFork"`
+	ParentRepository *parentRepositoryOf `json:"parentRepository"`
+}
+
+type parentRepositoryOf struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Project struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"project"`
+}
+
+func loadTestdata(t *testing.T, filename string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", filename))
+	if err != nil {
+		t.Fatalf("failed to read testdata/%s: %v", filename, err)
+	}
+	return data
+}
+
+// unmarshalStrict decodes JSON with DisallowUnknownFields so that any field
+// present in the fixture but missing from the target struct causes a test failure.
+func unmarshalStrict(t *testing.T, data []byte, v interface{}) {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		t.Fatalf("strict unmarshal failed (unknown field in fixture?): %v", err)
+	}
+}
+
+func TestContract_GetRepository(t *testing.T) {
+	data := loadTestdata(t, "get_repository.json")
+
+	var repo repositoryResponse
+	unmarshalStrict(t, data, &repo)
+
+	// Verify required fields are populated (contract assertions)
+	if repo.ID == "" {
+		t.Error("contract violation: repository ID must not be empty")
+	}
+	if repo.Name == "" {
+		t.Error("contract violation: repository name must not be empty")
+	}
+	if repo.Project.ID == "" {
+		t.Error("contract violation: project ID must not be empty")
+	}
+	if repo.Project.Name == "" {
+		t.Error("contract violation: project name must not be empty")
+	}
+	if repo.DefaultBranch == "" {
+		t.Error("contract violation: defaultBranch must not be empty")
+	}
+
+	// Verify the field our client actually uses
+	if repo.IsFork != false {
+		t.Errorf("expected isFork=false in non-fork fixture, got %v", repo.IsFork)
+	}
+	if repo.ParentRepository != nil {
+		t.Error("expected parentRepository=nil for non-fork repository")
+	}
+}
+
+func TestContract_GetRepository_Fork(t *testing.T) {
+	data := loadTestdata(t, "get_repository_fork.json")
+
+	var repo repositoryResponse
+	unmarshalStrict(t, data, &repo)
+
+	if !repo.IsFork {
+		t.Error("contract violation: expected isFork=true for fork fixture")
+	}
+	if repo.ParentRepository == nil {
+		t.Fatal("contract violation: fork must have parentRepository")
+	}
+	if repo.ParentRepository.ID == "" {
+		t.Error("contract violation: parentRepository.id must not be empty")
+	}
+	if repo.ParentRepository.Name == "" {
+		t.Error("contract violation: parentRepository.name must not be empty")
+	}
+}
+
+// TestContract_GetRepository_MinimalDecode verifies that the minimal struct
+// used in our actual client (only isFork field) correctly deserializes from
+// a full API response. This catches if the field path or JSON tag breaks.
+func TestContract_GetRepository_MinimalDecode(t *testing.T) {
+	data := loadTestdata(t, "get_repository_fork.json")
+
+	// This is the exact struct used in AzureDevOpsClient.IsFork()
+	var minimal struct {
+		IsFork bool `json:"isFork"`
+	}
+	if err := json.Unmarshal(data, &minimal); err != nil {
+		t.Fatalf("failed to unmarshal into minimal struct: %v", err)
+	}
+	if !minimal.IsFork {
+		t.Error("minimal decode failed: expected isFork=true")
+	}
+}

--- a/src/gitProviderClients/azuredevopsProvider/testdata/get_repository.json
+++ b/src/gitProviderClients/azuredevopsProvider/testdata/get_repository.json
@@ -1,0 +1,17 @@
+{
+  "id": "5e52f5a3-1234-4f9e-9c7a-8b9d6e3a1f2c",
+  "name": "my-application",
+  "url": "https://dev.azure.com/ExampleOrg/_apis/git/repositories/5e52f5a3-1234-4f9e-9c7a-8b9d6e3a1f2c",
+  "project": {
+    "id": "a1b2c3d4-5678-9012-3456-789012345678",
+    "name": "MyProject",
+    "state": "wellFormed",
+    "visibility": "private"
+  },
+  "defaultBranch": "refs/heads/main",
+  "size": 12345,
+  "remoteUrl": "https://ExampleOrg@dev.azure.com/ExampleOrg/MyProject/_git/my-application",
+  "sshUrl": "git@ssh.dev.azure.com:v3/ExampleOrg/MyProject/my-application",
+  "isFork": false,
+  "parentRepository": null
+}

--- a/src/gitProviderClients/azuredevopsProvider/testdata/get_repository_fork.json
+++ b/src/gitProviderClients/azuredevopsProvider/testdata/get_repository_fork.json
@@ -1,0 +1,24 @@
+{
+  "id": "9f8e7d6c-5b4a-3c2d-1e0f-a9b8c7d6e5f4",
+  "name": "my-application",
+  "url": "https://dev.azure.com/ExampleOrg/_apis/git/repositories/9f8e7d6c-5b4a-3c2d-1e0f-a9b8c7d6e5f4",
+  "project": {
+    "id": "a1b2c3d4-5678-9012-3456-789012345678",
+    "name": "MyProject",
+    "state": "wellFormed",
+    "visibility": "private"
+  },
+  "defaultBranch": "refs/heads/main",
+  "size": 8901,
+  "remoteUrl": "https://ExampleOrg@dev.azure.com/ExampleOrg/MyProject/_git/my-application",
+  "sshUrl": "git@ssh.dev.azure.com:v3/ExampleOrg/MyProject/my-application",
+  "isFork": true,
+  "parentRepository": {
+    "id": "5e52f5a3-1234-4f9e-9c7a-8b9d6e3a1f2c",
+    "name": "my-application",
+    "project": {
+      "id": "a1b2c3d4-5678-9012-3456-789012345678",
+      "name": "MyProject"
+    }
+  }
+}

--- a/src/gitProviderClients/factory/gitProviderClientFactory.go
+++ b/src/gitProviderClients/factory/gitProviderClientFactory.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/gitProviderClients"
+	"renovate-operator/gitProviderClients/azuredevopsProvider"
 	"renovate-operator/gitProviderClients/bitbucketProvider"
 	"renovate-operator/gitProviderClients/forgejoProvider"
 	"renovate-operator/gitProviderClients/giteaProvider"
@@ -64,6 +65,8 @@ func (f *gitProviderClientFactory) NewClient(ctx context.Context, job *api.Renov
 		return &forgejoProvider.ForgejoClient{Endpoint: endpoint, Token: token, HTTPClient: httpClient}, nil
 	case "bitbucket":
 		return &bitbucketProvider.BitbucketClient{Endpoint: endpoint, Token: token, HTTPClient: httpClient}, nil
+	case "azure":
+		return &azuredevopsProvider.AzureDevOpsClient{Endpoint: endpoint, Token: token, HTTPClient: httpClient}, nil
 	default:
 		return nil, fmt.Errorf("skipForks is not supported for platform %q", platform)
 	}
@@ -87,11 +90,11 @@ func readToken(ctx context.Context, c client.Client, job *api.RenovateJob) (stri
 	}
 
 	// Try common token key names in order of preference
-	for _, key := range []string{"RENOVATE_TOKEN", "GITHUB_COM_TOKEN", "GITLAB_TOKEN", "BITBUCKET_TOKEN", "GITEA_TOKEN", "FORGEJO_TOKEN"} {
+	for _, key := range []string{"RENOVATE_TOKEN", "AZURE_DEVOPS_TOKEN", "GITHUB_COM_TOKEN", "GITLAB_TOKEN", "BITBUCKET_TOKEN", "GITEA_TOKEN", "FORGEJO_TOKEN"} {
 		if val, ok := secret.Data[key]; ok && len(val) > 0 {
 			return string(val), nil
 		}
 	}
 
-	return "", fmt.Errorf("no platform token found in secret %s (expected one of: RENOVATE_TOKEN, GITHUB_COM_TOKEN, GITLAB_TOKEN, BITBUCKET_TOKEN, GITEA_TOKEN, FORGEJO_TOKEN)", job.Spec.SecretRef)
+	return "", fmt.Errorf("no platform token found in secret %s (expected one of: RENOVATE_TOKEN, AZURE_DEVOPS_TOKEN, GITHUB_COM_TOKEN, GITLAB_TOKEN, BITBUCKET_TOKEN, GITEA_TOKEN, FORGEJO_TOKEN)", job.Spec.SecretRef)
 }

--- a/src/internal/utils/platformEndpoints.go
+++ b/src/internal/utils/platformEndpoints.go
@@ -15,6 +15,11 @@ func GetPlatformAndEndpoint(provider *api.RenovateProvider) (string, string) {
 			endpoint = "https://api.github.com"
 		case "gitlab":
 			endpoint = "https://gitlab.com/api/v4"
+		case "azure":
+			// No default: Azure DevOps URLs require an organization segment
+			// (e.g., https://dev.azure.com/{org}). The user must configure
+			// provider.endpoint explicitly with their organization.
+			endpoint = ""
 		}
 	}
 	return provider.Name, endpoint

--- a/src/webhook/azuredevops.go
+++ b/src/webhook/azuredevops.go
@@ -1,0 +1,88 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+
+	api "renovate-operator/api/v1alpha1"
+	crdmanager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/types"
+)
+
+type AzureDevOpsEvent struct {
+	EventType string                       `json:"eventType"`
+	Resource  AzureDevOpsEventResource     `json:"resource"`
+}
+
+type AzureDevOpsEventResource struct {
+	Repository AzureDevOpsRepository `json:"repository"`
+}
+
+type AzureDevOpsRepository struct {
+	Name    string             `json:"name"`
+	Project AzureDevOpsProject `json:"project"`
+}
+
+type AzureDevOpsProject struct {
+	Name string `json:"name"`
+}
+
+func (s *Server) azureDevOpsWebhook(w http.ResponseWriter, r *http.Request) {
+	var payload AzureDevOpsEvent
+	err := json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		s.logger.Error(err, "failed to decode Azure DevOps webhook payload")
+		s.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to decode payload"})
+		return
+	}
+
+	valid, reason := isValidAzureDevOpsEvent(&payload)
+	if !valid {
+		s.logger.Info("ignoring Azure DevOps webhook event", "reason", reason)
+		s.writeJSON(w, http.StatusOK, map[string]string{"message": "event ignored", "reason": reason})
+		return
+	}
+
+	namespace := r.URL.Query().Get("namespace")
+	job := r.URL.Query().Get("job")
+	if namespace == "" || job == "" {
+		s.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing namespace or job query parameter"})
+		return
+	}
+
+	project := payload.Resource.Repository.Project.Name + "/" + payload.Resource.Repository.Name
+
+	s.logger.Info("received Azure DevOps push event", "repository", project, "priority", 1)
+	err = s.manager.UpdateProjectStatus(
+		r.Context(),
+		project,
+		crdmanager.RenovateJobIdentifier{
+			Name:      job,
+			Namespace: namespace,
+		},
+		&types.RenovateStatusUpdate{
+			Status:   api.JobStatusScheduled,
+			Priority: 1,
+		},
+	)
+	if err != nil {
+		s.logger.Error(err, "Failed to process Azure DevOps webhook for repo", "repo", project)
+		s.writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to process webhook"})
+		return
+	}
+
+	s.writeJSON(w, http.StatusAccepted, map[string]string{"message": "renovate job scheduled", "repository": project})
+}
+
+func isValidAzureDevOpsEvent(payload *AzureDevOpsEvent) (bool, string) {
+	if payload.EventType != "git.push" {
+		return false, "event type is not git.push"
+	}
+	if payload.Resource.Repository.Name == "" {
+		return false, "missing repository name in event"
+	}
+	if payload.Resource.Repository.Project.Name == "" {
+		return false, "missing project name in event"
+	}
+	return true, ""
+}

--- a/src/webhook/azuredevops_integration_test.go
+++ b/src/webhook/azuredevops_integration_test.go
@@ -1,0 +1,181 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	api "renovate-operator/api/v1alpha1"
+	crdmanager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/types"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestAzureDevOpsWebhook_Integration(t *testing.T) {
+	tests := []struct {
+		name             string
+		payload          AzureDevOpsEvent
+		namespace        string
+		job              string
+		expectedStatus   int
+		expectedMessage  string
+		shouldCallUpdate bool
+		expectedProject  string
+	}{
+		{
+			name: "valid push event triggers schedule",
+			payload: AzureDevOpsEvent{
+				EventType: "git.push",
+				Resource: AzureDevOpsEventResource{
+					Repository: AzureDevOpsRepository{
+						Name:    "hetzner-k8s-platform",
+						Project: AzureDevOpsProject{Name: "MIA-Guild-DevOps"},
+					},
+				},
+			},
+			namespace:        "renovate",
+			job:              "platform",
+			expectedStatus:   http.StatusAccepted,
+			expectedMessage:  "renovate job scheduled",
+			shouldCallUpdate: true,
+			expectedProject:  "MIA-Guild-DevOps/hetzner-k8s-platform",
+		},
+		{
+			name: "non-push event is ignored",
+			payload: AzureDevOpsEvent{
+				EventType: "git.pullrequest.created",
+				Resource: AzureDevOpsEventResource{
+					Repository: AzureDevOpsRepository{
+						Name:    "some-repo",
+						Project: AzureDevOpsProject{Name: "MyProject"},
+					},
+				},
+			},
+			namespace:        "renovate",
+			job:              "platform",
+			expectedStatus:   http.StatusOK,
+			expectedMessage:  "event ignored",
+			shouldCallUpdate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateCalled := false
+			mockManager := &mockWebhookManager{
+				updateProjectStatusFunc: func(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
+					updateCalled = true
+					if project != tt.expectedProject {
+						t.Errorf("expected project %s, got %s", tt.expectedProject, project)
+					}
+					if jobId.Name != tt.job {
+						t.Errorf("expected job name %s, got %s", tt.job, jobId.Name)
+					}
+					if jobId.Namespace != tt.namespace {
+						t.Errorf("expected namespace %s, got %s", tt.namespace, jobId.Namespace)
+					}
+					if status.Status != api.JobStatusScheduled {
+						t.Errorf("expected status %s, got %s", api.JobStatusScheduled, status.Status)
+					}
+					if status.Priority != 1 {
+						t.Errorf("expected priority 1, got %d", status.Priority)
+					}
+					return nil
+				},
+			}
+
+			server := &Server{
+				manager: mockManager,
+				logger:  logr.Discard(),
+			}
+
+			body, err := json.Marshal(tt.payload)
+			if err != nil {
+				t.Fatalf("failed to marshal payload: %v", err)
+			}
+
+			url := "/webhook/v1/azure?namespace=" + tt.namespace + "&job=" + tt.job
+			req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			server.azureDevOpsWebhook(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+
+			var response map[string]string
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+			if message, ok := response["message"]; ok {
+				if message != tt.expectedMessage {
+					t.Errorf("expected message %q, got %q", tt.expectedMessage, message)
+				}
+			}
+			if updateCalled != tt.shouldCallUpdate {
+				t.Errorf("expected updateCalled=%v, got %v", tt.shouldCallUpdate, updateCalled)
+			}
+		})
+	}
+}
+
+func TestAzureDevOpsWebhook_MissingQueryParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		namespace      string
+		job            string
+		expectedStatus int
+	}{
+		{name: "missing namespace", namespace: "", job: "test-job", expectedStatus: http.StatusBadRequest},
+		{name: "missing job", namespace: "default", job: "", expectedStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &Server{manager: &mockWebhookManager{}, logger: logr.Discard()}
+
+			payload := AzureDevOpsEvent{
+				EventType: "git.push",
+				Resource: AzureDevOpsEventResource{
+					Repository: AzureDevOpsRepository{
+						Name:    "repo",
+						Project: AzureDevOpsProject{Name: "project"},
+					},
+				},
+			}
+			body, _ := json.Marshal(payload)
+
+			url := "/webhook/v1/azure?"
+			if tt.namespace != "" {
+				url += "namespace=" + tt.namespace + "&"
+			}
+			if tt.job != "" {
+				url += "job=" + tt.job
+			}
+			req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+			w := httptest.NewRecorder()
+			server.azureDevOpsWebhook(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+		})
+	}
+}
+
+func TestAzureDevOpsWebhook_InvalidJSON(t *testing.T) {
+	server := &Server{manager: &mockWebhookManager{}, logger: logr.Discard()}
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/v1/azure?namespace=default&job=test", bytes.NewReader([]byte("not json")))
+	w := httptest.NewRecorder()
+	server.azureDevOpsWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}

--- a/src/webhook/azuredevops_test.go
+++ b/src/webhook/azuredevops_test.go
@@ -1,0 +1,78 @@
+package webhook
+
+import "testing"
+
+func TestAzureDevOpsEventValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload AzureDevOpsEvent
+		valid   bool
+		reason  string
+	}{
+		{
+			name: "valid git.push event",
+			payload: AzureDevOpsEvent{
+				EventType: "git.push",
+				Resource: AzureDevOpsEventResource{
+					Repository: AzureDevOpsRepository{
+						Name:    "hetzner-k8s-platform",
+						Project: AzureDevOpsProject{Name: "MIA-Guild-DevOps"},
+					},
+				},
+			},
+			valid:  true,
+			reason: "",
+		},
+		{
+			name: "invalid event type",
+			payload: AzureDevOpsEvent{
+				EventType: "git.pullrequest.created",
+				Resource: AzureDevOpsEventResource{
+					Repository: AzureDevOpsRepository{
+						Name:    "some-repo",
+						Project: AzureDevOpsProject{Name: "MyProject"},
+					},
+				},
+			},
+			valid:  false,
+			reason: "event type is not git.push",
+		},
+		{
+			name: "missing repository name",
+			payload: AzureDevOpsEvent{
+				EventType: "git.push",
+				Resource: AzureDevOpsEventResource{
+					Repository: AzureDevOpsRepository{
+						Name:    "",
+						Project: AzureDevOpsProject{Name: "MyProject"},
+					},
+				},
+			},
+			valid:  false,
+			reason: "missing repository name in event",
+		},
+		{
+			name: "missing project name",
+			payload: AzureDevOpsEvent{
+				EventType: "git.push",
+				Resource: AzureDevOpsEventResource{
+					Repository: AzureDevOpsRepository{
+						Name:    "my-repo",
+						Project: AzureDevOpsProject{Name: ""},
+					},
+				},
+			},
+			valid:  false,
+			reason: "missing project name in event",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, reason := isValidAzureDevOpsEvent(&tt.payload)
+			if valid != tt.valid || reason != tt.reason {
+				t.Errorf("expected valid=%v, reason=%q; got valid=%v, reason=%q", tt.valid, tt.reason, valid, reason)
+			}
+		})
+	}
+}

--- a/src/webhook/contract_test.go
+++ b/src/webhook/contract_test.go
@@ -1,0 +1,179 @@
+package webhook
+
+// Contract tests validate that Azure DevOps webhook event payloads
+// (captured in testdata/) deserialize correctly into our Go types.
+//
+// These fixtures are based on the Azure DevOps Service Hooks event documentation:
+// https://learn.microsoft.com/en-us/azure/devops/service-hooks/events?view=azure-devops
+//
+// Testing approach inspired by:
+// - FluxCD notification-controller (thin interface + hand-written fakes)
+//   https://github.com/fluxcd/notification-controller
+//   Licensed under Apache-2.0
+// - mcdafydd/go-azuredevops (testdata fixtures for webhook events)
+//   https://github.com/mcdafydd/go-azuredevops
+//   Licensed under BSD-3-Clause
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fullGitPushEvent represents the complete Azure DevOps git.push webhook payload.
+// Decoded with DisallowUnknownFields so the test fails if the fixture contains
+// fields not covered by this struct — forcing us to keep the struct in sync with
+// the real API response shape.
+//
+// Schema: https://learn.microsoft.com/en-us/azure/devops/service-hooks/events?view=azure-devops#git.push
+type fullGitPushEvent struct {
+	SubscriptionID string `json:"subscriptionId"`
+	NotificationID int    `json:"notificationId"`
+	ID             string `json:"id"`
+	EventType      string `json:"eventType"`
+	PublisherID    string `json:"publisherId"`
+	Message        struct {
+		Text string `json:"text"`
+	} `json:"message"`
+	DetailedMessage struct {
+		Text string `json:"text"`
+	} `json:"detailedMessage"`
+	Resource struct {
+		Commits []struct {
+			CommitID  string `json:"commitId"`
+			Author    struct {
+				Name  string `json:"name"`
+				Email string `json:"email"`
+				Date  string `json:"date"`
+			} `json:"author"`
+			Committer struct {
+				Name  string `json:"name"`
+				Email string `json:"email"`
+				Date  string `json:"date"`
+			} `json:"committer"`
+			Comment string `json:"comment"`
+			URL     string `json:"url"`
+		} `json:"commits"`
+		RefUpdates []struct {
+			Name        string `json:"name"`
+			OldObjectID string `json:"oldObjectId"`
+			NewObjectID string `json:"newObjectId"`
+		} `json:"refUpdates"`
+		Repository struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			URL     string `json:"url"`
+			Project struct {
+				ID         string `json:"id"`
+				Name       string `json:"name"`
+				State      string `json:"state"`
+				Visibility string `json:"visibility"`
+			} `json:"project"`
+			DefaultBranch string `json:"defaultBranch"`
+			RemoteURL     string `json:"remoteUrl"`
+		} `json:"repository"`
+		PushedBy struct {
+			DisplayName string `json:"displayName"`
+			UniqueName  string `json:"uniqueName"`
+			ID          string `json:"id"`
+		} `json:"pushedBy"`
+		PushID int    `json:"pushId"`
+		Date   string `json:"date"`
+		URL    string `json:"url"`
+	} `json:"resource"`
+	ResourceVersion    string `json:"resourceVersion"`
+	ResourceContainers struct {
+		Collection struct {
+			ID string `json:"id"`
+		} `json:"collection"`
+		Account struct {
+			ID string `json:"id"`
+		} `json:"account"`
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+	} `json:"resourceContainers"`
+	CreatedDate string `json:"createdDate"`
+}
+
+func loadWebhookTestdata(t *testing.T, filename string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", filename))
+	if err != nil {
+		t.Fatalf("failed to read testdata/%s: %v", filename, err)
+	}
+	return data
+}
+
+// unmarshalWebhookStrict decodes JSON with DisallowUnknownFields so that any
+// field present in the fixture but missing from the target struct causes a failure.
+func unmarshalWebhookStrict(t *testing.T, data []byte, v interface{}) {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		t.Fatalf("strict unmarshal failed (unknown field in fixture?): %v", err)
+	}
+}
+
+func TestContract_GitPushWebhook_FullPayload(t *testing.T) {
+	data := loadWebhookTestdata(t, "azure_devops_git_push.json")
+
+	var event fullGitPushEvent
+	unmarshalWebhookStrict(t, data, &event)
+
+	// Verify required fields present in the full payload
+	if event.EventType == "" {
+		t.Error("contract violation: eventType must not be empty")
+	}
+	if event.EventType != "git.push" {
+		t.Errorf("contract violation: expected eventType 'git.push', got %q", event.EventType)
+	}
+	if event.Resource.Repository.Name == "" {
+		t.Error("contract violation: resource.repository.name must not be empty")
+	}
+	if event.Resource.Repository.Project.Name == "" {
+		t.Error("contract violation: resource.repository.project.name must not be empty")
+	}
+	if len(event.Resource.Commits) == 0 {
+		t.Error("contract violation: resource.commits must not be empty for a push event")
+	}
+	if len(event.Resource.RefUpdates) == 0 {
+		t.Error("contract violation: resource.refUpdates must not be empty for a push event")
+	}
+	if event.Resource.PushedBy.DisplayName == "" {
+		t.Error("contract violation: resource.pushedBy.displayName must not be empty")
+	}
+}
+
+// TestContract_GitPushWebhook_OurStruct verifies that the real webhook payload
+// deserializes correctly into our actual AzureDevOpsEvent struct — the one used
+// in production code. This uses standard Unmarshal (not strict) because our
+// production struct intentionally only captures the subset of fields we route on.
+func TestContract_GitPushWebhook_OurStruct(t *testing.T) {
+	data := loadWebhookTestdata(t, "azure_devops_git_push.json")
+
+	var event AzureDevOpsEvent
+	if err := json.Unmarshal(data, &event); err != nil {
+		t.Fatalf("failed to unmarshal into AzureDevOpsEvent: %v", err)
+	}
+
+	// Validate our struct captured the fields we route on
+	if event.EventType != "git.push" {
+		t.Errorf("expected eventType 'git.push', got %q", event.EventType)
+	}
+	if event.Resource.Repository.Name != "my-application" {
+		t.Errorf("expected repository name 'my-application', got %q", event.Resource.Repository.Name)
+	}
+	if event.Resource.Repository.Project.Name != "MyProject" {
+		t.Errorf("expected project name 'MyProject', got %q", event.Resource.Repository.Project.Name)
+	}
+
+	// Validate through the same validation function used in production
+	valid, reason := isValidAzureDevOpsEvent(&event)
+	if !valid {
+		t.Errorf("expected valid event, got invalid: %s", reason)
+	}
+}

--- a/src/webhook/server.go
+++ b/src/webhook/server.go
@@ -43,6 +43,7 @@ func (s *Server) Run() {
 	sub.HandleFunc("/gitlab", s.gitLabWebhook).Methods("POST")
 	sub.HandleFunc("/github", s.githubWebhook).Methods("POST")
 	sub.HandleFunc("/forgejo", s.forgejoWebhook).Methods("POST")
+	sub.HandleFunc("/azure", s.azureDevOpsWebhook).Methods("POST")
 
 	port := config.GetValue("WEBHOOK_SERVER_PORT")
 

--- a/src/webhook/testdata/azure_devops_git_push.json
+++ b/src/webhook/testdata/azure_devops_git_push.json
@@ -1,0 +1,73 @@
+{
+  "subscriptionId": "00000000-0000-0000-0000-000000000000",
+  "notificationId": 1,
+  "id": "03c164c2-8912-4c0a-9740-c7412916ba0c",
+  "eventType": "git.push",
+  "publisherId": "tfs",
+  "message": {
+    "text": "Jane Doe pushed updates to branch main of MyProject/my-application"
+  },
+  "detailedMessage": {
+    "text": "Jane Doe pushed 1 commit to branch main of MyProject/my-application\n- fix: resolve token revocation a1b2c3d4"
+  },
+  "resource": {
+    "commits": [
+      {
+        "commitId": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "author": {
+          "name": "Jane Doe",
+          "email": "jane@example.com",
+          "date": "2026-05-04T10:00:00Z"
+        },
+        "committer": {
+          "name": "Jane Doe",
+          "email": "jane@example.com",
+          "date": "2026-05-04T10:00:00Z"
+        },
+        "comment": "fix: resolve token revocation",
+        "url": "https://dev.azure.com/ExampleOrg/_apis/git/repositories/5e52f5a3-1234-4f9e-9c7a-8b9d6e3a1f2c/commits/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+      }
+    ],
+    "refUpdates": [
+      {
+        "name": "refs/heads/main",
+        "oldObjectId": "0000000000000000000000000000000000000000",
+        "newObjectId": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+      }
+    ],
+    "repository": {
+      "id": "5e52f5a3-1234-4f9e-9c7a-8b9d6e3a1f2c",
+      "name": "my-application",
+      "url": "https://dev.azure.com/ExampleOrg/_apis/git/repositories/5e52f5a3-1234-4f9e-9c7a-8b9d6e3a1f2c",
+      "project": {
+        "id": "a1b2c3d4-5678-9012-3456-789012345678",
+        "name": "MyProject",
+        "state": "wellFormed",
+        "visibility": "private"
+      },
+      "defaultBranch": "refs/heads/main",
+      "remoteUrl": "https://ExampleOrg@dev.azure.com/ExampleOrg/MyProject/_git/my-application"
+    },
+    "pushedBy": {
+      "displayName": "Jane Doe",
+      "uniqueName": "jane@example.com",
+      "id": "00000000-0000-0000-0000-000000000000"
+    },
+    "pushId": 42,
+    "date": "2026-05-04T10:00:00Z",
+    "url": "https://dev.azure.com/ExampleOrg/_apis/git/repositories/5e52f5a3-1234-4f9e-9c7a-8b9d6e3a1f2c/pushes/42"
+  },
+  "resourceVersion": "1.0",
+  "resourceContainers": {
+    "collection": {
+      "id": "00000000-0000-0000-0000-000000000000"
+    },
+    "account": {
+      "id": "00000000-0000-0000-0000-000000000000"
+    },
+    "project": {
+      "id": "a1b2c3d4-5678-9012-3456-789012345678"
+    }
+  },
+  "createdDate": "2026-05-04T10:00:01Z"
+}


### PR DESCRIPTION
## Summary

- Adds Azure DevOps REST API client implementing `GitProviderClient` interface (fork detection via Repositories API 7.1)
- Adds webhook handler for `git.push` events at `POST /webhook/v1/azure`
- Introduces contract tests that validate deserialization against ADO REST 7.2 response schemas
- Includes testdata fixtures based on documented API response shapes for drift detection

## Testing approach

Inspired by established open-source patterns (see `ACKNOWLEDGMENTS.md`):
- **Thin interface boundary** (FluxCD pattern) — only wrap the methods actually used
- **httptest server** (google/go-github pattern) — unit tests for the HTTP client layer
- **Contract tests** — validate real API response shapes deserialize into our structs correctly
- **Integration tests** — table-driven tests exercising the full webhook handler with mock manager

## Test plan

- [x] `go test ./gitProviderClients/azuredevopsProvider/...` passes
- [x] `go test ./webhook/...` passes
- [ ] Re-record testdata fixtures from live ADO when bumping API version