### PR TITLE
feat(ui): add All filter badge to clear active project filter

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -482,6 +482,7 @@
         const [loading, setLoading] = useState(true);
         const [error, setError] = useState(null);
         const [stats, setStats] = useState({
+          total: 0,
           scheduled: 0,
           running: 0,
           completed: 0,
@@ -583,6 +584,7 @@
 
         const calculateStats = (jobsList) => {
           const newStats = {
+            total: 0,
             scheduled: 0,
             running: 0,
             completed: 0,
@@ -593,6 +595,7 @@
           };
           jobsList.forEach((job) => {
             if (Array.isArray(job.projects)) {
+              newStats.total += job.projects.length;
               job.projects.forEach((project) => {
                 const status = (project.status || "").toLowerCase();
                 if (newStats.hasOwnProperty(status)) {
@@ -881,6 +884,13 @@
             <ToastContainer toasts={toasts} onRemove={removeToast} />
 
             <SiteHeader version={version} authInfo={authInfo}>
+              <StatBadge
+                label="All"
+                value={loading ? "—" : stats.total}
+                onClick={clearStatFilter}
+                selected={!selectedStatFilter}
+                title="Show all projects"
+              />
               <StatBadge
                 label="Failed"
                 value={loading ? "—" : stats.failed}


### PR DESCRIPTION
## Summary
- Adds an "All" badge as the first filter in the dashboard header showing the total number of projects discovered across all RenovateJobs
- Clicking it clears any active filter, mirroring the toggle-off behavior of the other filter badges
- Highlighted as selected whenever no filter is active, giving a clear visual indicator of the unfiltered state

## Test plan
- [ ] Open the dashboard and verify the All badge shows the sum of all projects
- [ ] Select a filter (e.g. Failed) and confirm clicking All clears it and re-selects All
- [ ] Refresh the page with a filter active and confirm All un-highlights while the chosen filter stays selected