### PR TITLE
fix(deployment): support custom valkey auth secret

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-        
+
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
@@ -23,3 +23,12 @@ jobs:
       - name: Run Helm template
         run: |
           helm dependency update ./charts/renovate-operator && helm template --set=metrics.dashboard.enabled=true ./charts/renovate-operator
+
+      - env:
+          HELM_UNITTEST_VERSION: v1.0.0 # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+        name: Install helm-unittest
+        run: helm plugin install --verify=false --version "${HELM_UNITTEST_VERSION}" https://github.com/helm-unittest/helm-unittest
+
+      - name: Execute helm unittests
+        run: helm unittest --strict --file 'unittests/**/*.yaml' .
+        working-directory: ./charts/renovate-operator

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/helm-unittest/helm-unittest/v1.1.0/schema/helm-testsuite.json": [
+      "/charts/renovate-operator/unittests/**/*.yaml"
+    ]
+  }
+}

--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -195,8 +195,8 @@ spec:
             - name: VALKEY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-valkey-auth
-                  key: default-password
+                  name: {{ .Values.valkey.usersExistingSecret | default (printf "%s-valkey-auth" .Release.Name) }}
+                  key: {{ .Values.valkey.auth.aclUsers.default.passwordKey | default "default-password" }}
             {{- end }}
             {{- end }}
             - name: VALKEY_FORWARD_CACHE_TO_JOBS

--- a/charts/renovate-operator/unittests/deployment/deployment.yaml
+++ b/charts/renovate-operator/unittests/deployment/deployment.yaml
@@ -1,0 +1,42 @@
+chart:
+  appVersion: 0.1.0
+  version: 0.1.0
+suite: Template deployment
+release:
+  name: renovate-operator-unittest
+  namespace: testing
+templates:
+- templates/deployment.yaml
+tests:
+- it: Test default valkey credential secret
+  set:
+    valkey:
+      enabled: true
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: renovate-operator-unittest-valkey-auth
+            key: default-password
+
+- it: Test existing valkey credential secret
+  set:
+    valkey:
+      enabled: true
+      usersExistingSecret: my-custom-secret
+      auth:
+        aclUsers:
+          default:
+            passwordKey: my-custom-secret-key
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: my-custom-secret
+            key: my-custom-secret-key

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -278,6 +278,10 @@ logging:
 # -- optional: deploy a Valkey instance for session storage (recommended for multi-replica)
 valkey:
   enabled: false
+
+  # Use an existing secret for user passwords. Key defaults to username.
+  usersExistingSecret: ""
+
   # -- name of an existing secret containing the Valkey URL for session storage
   # -- Use this to provide a Valkey URL (e.g., "redis://:password@valkey:6379/0") via a Kubernetes secret
   # -- When set, sessions are stored in Valkey (recommended for multi-replica deployments)
@@ -289,6 +293,7 @@ valkey:
     aclUsers:
       default:
         password: ""
+        passwordKey: ""
         permissions: "~* &* +@all"
   dataStorage:
     enabled: false


### PR DESCRIPTION
The upstream Helm chart "valkey" supports an alternative custom secret that contains the users' passwords via `auth.usersExistingSecret`. Additionally provides the helm chart a configuration property to define the key inside the secret via `auth.aclUsers.default.passwordKey`.

https://github.com/valkey-io/valkey-helm/blob/39a708f93a145b5cd254e9f36ffa735d929a08d0/valkey/values.yaml#L183

```yaml
auth:
  # Use an existing secret for user passwords. Key defaults to username.
  usersExistingSecret: ""

  # Map of users to create with ACL permissions.
  # If usersExistingSecret is set, passwords from the secret take priority over inline passwords.
  # NOTE: If using aclUsers, the 'default' user must be included here.
  aclUsers: {}
  # Example:
  # default:
  #   permissions: "~* &* +@all"
  #   password: "secretpass"        # Inline password (fallback if usersExistingSecret not set)
  #   passwordKey: "admin-pwd"      # Key in usersExistingSecret (defaults to username)

```

The deployment of the renovate-operator fails, if `valkey.auth.enabled` is set to `true`, because valkey expect that either `auth.aclUsers.default.password` is set or an existing secret is defined via `auth.usersExistingSecret`.

If `auth.usersExistingSecret` is used, the deployment of the renovate-operator fails, because the hard coded secret `{{ .ReleaseName }}-valkey-auth` can not be found.

The upstream properties `auth.usersExistingSecret` and `auth.aclUsers.default.passwordKey` will now be respected.

I've added an addtional step into the GitHub Action workflow `helm-lint` to install helm unittest to execute the implemented unittests defined in `charts/renovate-operator/unittests`. These tests only verify whether my change is templated as intended. They do not take anything else into account. However, this change lays the groundwork for future unit tests.

Since the OSS version of VSCode does not load the Helm unittest YAML schema, I created a settings.json file that adds the YAML schema to the project and will help developers write unit tests in the future.