### PR TITLE
fix(deployment): valkey: wrong path of usersExistingSecret

### DIFF
--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -195,7 +195,7 @@ spec:
             - name: VALKEY_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.valkey.usersExistingSecret | default (printf "%s-valkey-auth" .Release.Name) }}
+                  name: {{ .Values.valkey.auth.usersExistingSecret | default (printf "%s-valkey-auth" .Release.Name) }}
                   key: {{ .Values.valkey.auth.aclUsers.default.passwordKey | default "default-password" }}
             {{- end }}
             {{- end }}

--- a/charts/renovate-operator/unittests/deployment/deployment.yaml
+++ b/charts/renovate-operator/unittests/deployment/deployment.yaml
@@ -26,8 +26,8 @@ tests:
   set:
     valkey:
       enabled: true
-      usersExistingSecret: my-custom-secret
       auth:
+        usersExistingSecret: my-custom-secret
         aclUsers:
           default:
             passwordKey: my-custom-secret-key

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -277,10 +277,8 @@ logging:
 
 # -- optional: deploy a Valkey instance for session storage (recommended for multi-replica)
 valkey:
+  # Enable Valkey for session storage. When enabled, the operator will create a Valkey deployment and use it to store sessions.
   enabled: false
-
-  # Use an existing secret for user passwords. Key defaults to username.
-  usersExistingSecret: ""
 
   # -- name of an existing secret containing the Valkey URL for session storage
   # -- Use this to provide a Valkey URL (e.g., "redis://:password@valkey:6379/0") via a Kubernetes secret
@@ -289,7 +287,15 @@ valkey:
   # -- key in the existing secret that contains the Valkey URL
   existingSecretKey: "valkey-url"
   auth:
+    # Enable ACL-based authentication
+    # IMPORTANT: When authentication is enabled, the 'default' user MUST be defined in either
+    # aclUsers or aclConfig. Without a default user, anyone can access the database without
+    # credentials, creating a security risk.
     enabled: true
+
+    # Use an existing secret for user passwords. Key defaults to username.
+    usersExistingSecret: ""
+
     aclUsers:
       default:
         password: ""


### PR DESCRIPTION
I recently submitted a [patch](https://github.com/mogenius/renovate-operator/pull/351), which introduces the `valkey.usersExistingSecret` property.

After 4.9.0 was released, I realized that my change had no effect. I currently assume that when adding usersExistingSecret to `values.yaml`, I mistakenly used the wrong path. I probably based it on `enabled` and didn’t notice that there are `valkey.enabled` and `valkey.auth.enabled`. In testing values.yaml file, it was defined correctly, therefore I did not noticed the wrong path. Sorry for the inconvenience.

The following patch now moves `usersExistingSecret` under `valkey.auth`, as defined in the upstream [chart](https://github.com/valkey-io/valkey-helm/blob/39a708f93a145b5cd254e9f36ffa735d929a08d0/valkey/values.yaml#L183):

```yaml
auth:
  # Enable ACL-based authentication
  # IMPORTANT: When authentication is enabled, the 'default' user MUST be defined in either
  # aclUsers or aclConfig. Without a default user, anyone can access the database without
  # credentials, creating a security risk.
  enabled: false

  # Use an existing secret for user passwords. Key defaults to username.
  usersExistingSecret: ""
```

I have also added the description of `valkey.auth.enabled` from upstream.