### PR TITLE
fix: delete successful discovery jobs when DELETE_SUCCESSFUL_JOBS=true

### DIFF
--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	api "renovate-operator/api/v1alpha1"
 	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/config"
 	"renovate-operator/internal/telemetry"
 	"renovate-operator/internal/utils"
 	"sync"
@@ -132,6 +133,15 @@ func (e *discoveryAgent) WaitForDiscoveryJob(ctx context.Context, job *api.Renov
 		return nil, fmt.Errorf("failed to get discovered projects from job logs: %w", err)
 	}
 	log.FromContext(ctx).V(2).Info("Discovered projects", "count", len(projects), "job", job.Fullname())
+
+	// DELETE_SUCCESSFUL_JOBS applies to both executor and discovery jobs.
+	// Previously only executor jobs were deleted; discovery jobs accumulated
+	// indefinitely even when the setting was enabled.
+	if config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" {
+		if err := crdManager.DeleteJob(ctx, e.client, existingDiscoveryJob); err != nil {
+			log.FromContext(ctx).Error(err, "failed to delete successful discovery job", "job", job.Fullname())
+		}
+	}
 
 	return projects, nil
 }

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	api "renovate-operator/api/v1alpha1"
 	crdManager "renovate-operator/internal/crdManager"
-	"renovate-operator/internal/config"
+	"renovate-operator/config"
 	"renovate-operator/internal/telemetry"
 	"renovate-operator/internal/utils"
 	"sync"


### PR DESCRIPTION
## Problem

Closes #327.

`DELETE_SUCCESSFUL_JOBS=true` (set via `config.deleteSuccessfulJobs=true` in the Helm chart) only deleted **executor** (per-project) K8s `batch/v1/Job` resources through `reconcileRunning` in `executor.go`. **Discovery** K8s Jobs were never deleted, so they accumulated indefinitely even when the setting was explicitly enabled.

## Root cause

`executor.go` line 240 correctly deletes executor jobs:
```go
if newStatus == api.JobStatusCompleted && config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" && k8sJob != nil {
    crdManager.DeleteJob(ctx, e.client, k8sJob)
}
```

But `discoveryAgent.go`'s `WaitForDiscoveryJob` fetches the completed discovery K8s Job (to read project logs) and then returns — never deleting it.

## Fix

After extracting discovered projects from the completed discovery job's logs, call `crdManager.DeleteJob` if `DELETE_SUCCESSFUL_JOBS=true`:

```go
if config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" {
    if err := crdManager.DeleteJob(ctx, e.client, existingDiscoveryJob); err != nil {
        log.FromContext(ctx).Error(err, "failed to delete successful discovery job", ...)
    }
}
```

Errors during deletion are logged but do not abort the discovery flow — projects have already been extracted at that point.