### PR TITLE
fix: delete successful discovery jobs when DELETE_SUCCESSFUL_JOBS=true

### DIFF
--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	api "renovate-operator/api/v1alpha1"
 	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/config"
 	"renovate-operator/internal/telemetry"
 	"renovate-operator/internal/utils"
 	"sync"
@@ -132,6 +133,15 @@ func (e *discoveryAgent) WaitForDiscoveryJob(ctx context.Context, job *api.Renov
 		return nil, fmt.Errorf("failed to get discovered projects from job logs: %w", err)
 	}
 	log.FromContext(ctx).V(2).Info("Discovered projects", "count", len(projects), "job", job.Fullname())
+
+	// DELETE_SUCCESSFUL_JOBS applies to both executor and discovery jobs.
+	// Previously only executor jobs were deleted; discovery jobs accumulated
+	// indefinitely even when the setting was enabled.
+	if config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" {
+		if err := crdManager.DeleteJob(ctx, e.client, existingDiscoveryJob); err != nil {
+			log.FromContext(ctx).Error(err, "failed to delete successful discovery job", "job", job.Fullname())
+		}
+	}
 
 	return projects, nil
 }

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	api "renovate-operator/api/v1alpha1"
 	crdManager "renovate-operator/internal/crdManager"
-	"renovate-operator/internal/config"
+	"renovate-operator/config"
 	"renovate-operator/internal/telemetry"
 	"renovate-operator/internal/utils"
 	"sync"


### PR DESCRIPTION
## Summary
- Adds handling for `DELETE_SUCCESSFUL_JOBS` env var in discovery job cleanup
- When set to `true`, successfully completed discovery jobs are deleted after processing
- Fixes config import path (`renovate-operator/config` not `renovate-operator/internal/config`)

## Test plan
- [ ] Set `DELETE_SUCCESSFUL_JOBS=true` and verify completed discovery jobs are cleaned up
- [ ] Set `DELETE_SUCCESSFUL_JOBS=false` (or unset) and verify jobs are retained