### PR TITLE
feat: reconciler based job processing

### DIFF
--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -342,4 +342,3 @@ func (in *RenovateJobList) DeepCopyObject() runtime.Object {
 	}
 	return out
 }
-

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -494,6 +494,12 @@ func main() {
 		}
 	}()
 
+	err = (&controllers.JobReconciler{
+		Executor:  executor,
+		K8sClient: mgr.GetClient(),
+	}).SetupWithJobManager(mgr)
+	assert.NoError(err, "failed to setup job manager")
+
 	err = (&controllers.RenovateJobReconciler{
 		Scheduler: cronManager,
 		Manager:   jobMgr,

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -26,6 +26,7 @@ import (
 	"renovate-operator/internal/logStore"
 	"renovate-operator/internal/renovate"
 	"renovate-operator/internal/telemetry"
+	"renovate-operator/internal/webhookSync"
 	"renovate-operator/metricStore"
 	"renovate-operator/scheduler"
 	"renovate-operator/ui"
@@ -456,6 +457,7 @@ func main() {
 		mgr.GetScheme(),
 		mgr.GetClient(),
 		ctrl.Log.WithName("renovate-discovery"),
+		jobMgr,
 	)
 
 	cronManager := scheduler.NewScheduler(ctrl.Log.WithName("scheduler"), health)
@@ -482,6 +484,7 @@ func main() {
 	)
 
 	githubAppToken := github.NewGitHubAppTokenCreatorWithLogger(mgr.GetClient(), ctrl.Log.WithName("github-app-token"))
+	webhookSyncMgr := webhookSync.NewWebhookSyncManager(mgr.GetClient(), jobMgr)
 
 	// Executor and scheduler must only run on the leader to prevent duplicate jobs.
 	// When leadership is lost, controller-runtime cancels ctx and the process exits.
@@ -495,17 +498,20 @@ func main() {
 	}()
 
 	err = (&controllers.JobReconciler{
-		Executor:  executor,
-		K8sClient: mgr.GetClient(),
-	}).SetupWithJobManager(mgr)
+		Executor:    executor,
+		Discovery:   discovery,
+		WebhookSync: webhookSyncMgr,
+		K8sClient:   mgr.GetClient(),
+	}).SetupWithManager(mgr)
 	assert.NoError(err, "failed to setup job manager")
 
 	err = (&controllers.RenovateJobReconciler{
-		Scheduler: cronManager,
-		Manager:   jobMgr,
-		Discovery: discovery,
-		K8sClient: mgr.GetClient(),
-		GithubApp: githubAppToken,
+		Scheduler:   cronManager,
+		Manager:     jobMgr,
+		Discovery:   discovery,
+		K8sClient:   mgr.GetClient(),
+		GithubApp:   githubAppToken,
+		WebhookSync: webhookSyncMgr,
 	}).SetupWithManager(mgr)
 	assert.NoError(err, "failed to setup manager")
 

--- a/src/controllers/job_controller.go
+++ b/src/controllers/job_controller.go
@@ -57,6 +57,10 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	if job.Annotations[crdManager.JOB_ANNOTATION_PROCESSED] == "true" {
+		return ctrl.Result{}, nil
+	}
+
 	jobId := crdManager.RenovateJobIdentifier{
 		Namespace: job.Namespace,
 		Name:      renovateJobName,

--- a/src/controllers/job_controller.go
+++ b/src/controllers/job_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	context "context"
 	"renovate-operator/internal/renovate"
+	"renovate-operator/internal/webhookSync"
 
 	batchv1 "k8s.io/api/batch/v1"
 
@@ -14,12 +15,14 @@ import (
 )
 
 /*
-Reconciler for RenovateJob resources
-Watching for create/update/delete events and managing the schedules accordingly
+Reconciler for batchv1.Job resources owned by the operator.
+Handles completion of discovery and executor jobs reactively.
 */
 type JobReconciler struct {
-	Executor  renovate.RenovateExecutor
-	K8sClient client.Client
+	Executor    renovate.RenovateExecutor
+	Discovery   renovate.DiscoveryAgent
+	WebhookSync webhookSync.WebhookSyncManager
+	K8sClient   client.Client
 }
 
 func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -44,6 +47,11 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	switch jobType {
 	case string(crdManager.DiscoveryJobType):
+		if err := r.Discovery.ProcessDiscoveryJobResult(ctx, job, renovateJobName, job.Namespace); err != nil {
+			logger.Error(err, "Error processing discovery job result", "jobName", job.Name)
+			return ctrl.Result{}, err
+		}
+		r.WebhookSync.RunSync(ctx, logger, renovateJobName, job.Namespace)
 	case string(crdManager.ExecutorJobType):
 		project := job.Annotations[crdManager.JOB_ANNOTATION_PROJECT]
 		jobId := crdManager.RenovateJobIdentifier{
@@ -63,7 +71,7 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	return ctrl.Result{}, nil
 }
 
-func (r *JobReconciler) SetupWithJobManager(mgr ctrl.Manager) error {
+func (r *JobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&batchv1.Job{}).
 		Complete(r)

--- a/src/controllers/job_controller.go
+++ b/src/controllers/job_controller.go
@@ -3,8 +3,11 @@ package controllers
 import (
 	context "context"
 	"renovate-operator/internal/renovate"
+	"renovate-operator/internal/telemetry"
 	"renovate-operator/internal/webhookSync"
 
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
 	batchv1 "k8s.io/api/batch/v1"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -26,6 +29,15 @@ type JobReconciler struct {
 }
 
 func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, span := reconcilerTracer.Start(ctx, "Job.Reconcile",
+		trace.WithAttributes(
+			semconv.K8SNamespaceName(req.Namespace),
+			semconv.CICDPipelineName(req.Name),
+		),
+	)
+	defer span.End()
+	ctx = telemetry.ContextWithTraceLogger(ctx, log.FromContext(ctx).WithName("job-controller"))
+
 	logger := log.FromContext(ctx)
 
 	job := &batchv1.Job{}

--- a/src/controllers/job_controller.go
+++ b/src/controllers/job_controller.go
@@ -57,19 +57,21 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	jobId := crdManager.RenovateJobIdentifier{
+		Namespace: job.Namespace,
+		Name:      renovateJobName,
+	}
+
 	switch jobType {
 	case string(crdManager.DiscoveryJobType):
-		if err := r.Discovery.ProcessDiscoveryJobResult(ctx, job, renovateJobName, job.Namespace); err != nil {
+		if err := r.Discovery.ProcessDiscoveryJobResult(ctx, job, jobId); err != nil {
 			logger.Error(err, "Error processing discovery job result", "jobName", job.Name)
 			return ctrl.Result{}, err
 		}
-		r.WebhookSync.RunSync(ctx, logger, renovateJobName, job.Namespace)
+		r.WebhookSync.RunSync(ctx, logger, jobId)
 	case string(crdManager.ExecutorJobType):
 		project := job.Annotations[crdManager.JOB_ANNOTATION_PROJECT]
-		jobId := crdManager.RenovateJobIdentifier{
-			Namespace: job.Namespace,
-			Name:      renovateJobName,
-		}
+
 		err := r.Executor.ProcessProjectJobResult(ctx, job, project, jobId)
 		if err != nil {
 			logger.Error(err, "Error processing job result", "jobName", job.Name, "project", project)

--- a/src/controllers/job_controller.go
+++ b/src/controllers/job_controller.go
@@ -1,0 +1,70 @@
+package controllers
+
+import (
+	context "context"
+	"renovate-operator/internal/renovate"
+
+	batchv1 "k8s.io/api/batch/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	crdManager "renovate-operator/internal/crdManager"
+)
+
+/*
+Reconciler for RenovateJob resources
+Watching for create/update/delete events and managing the schedules accordingly
+*/
+type JobReconciler struct {
+	Executor  renovate.RenovateExecutor
+	K8sClient client.Client
+}
+
+func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	job := &batchv1.Job{}
+	err := r.K8sClient.Get(ctx, req.NamespacedName, job)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if job.Labels == nil {
+		return ctrl.Result{}, nil
+	}
+	jobType := job.Labels[crdManager.JOB_LABEL_TYPE]
+	renovateJobName := job.Labels[crdManager.JOB_LABEL_RENOVATEJOB]
+
+	// only handle jobs that are managed by us (identified by the presence of our labels)
+	if renovateJobName == "" || jobType == "" {
+		return ctrl.Result{}, nil
+	}
+
+	switch jobType {
+	case string(crdManager.DiscoveryJobType):
+	case string(crdManager.ExecutorJobType):
+		project := job.Annotations[crdManager.JOB_ANNOTATION_PROJECT]
+		jobId := crdManager.RenovateJobIdentifier{
+			Namespace: job.Namespace,
+			Name:      renovateJobName,
+		}
+		err := r.Executor.ProcessProjectJobResult(ctx, job, project, jobId)
+		if err != nil {
+			logger.Error(err, "Error processing job result", "jobName", job.Name, "project", project)
+			return ctrl.Result{}, err
+		}
+	default:
+		logger.Info("Ignoring job with unrecognized type", "jobName", job.Name, "jobType", jobType)
+		return ctrl.Result{}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *JobReconciler) SetupWithJobManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&batchv1.Job{}).
+		Complete(r)
+}

--- a/src/controllers/renovatejob_controller.go
+++ b/src/controllers/renovatejob_controller.go
@@ -6,6 +6,7 @@ import (
 	"renovate-operator/github"
 	"renovate-operator/internal/renovate"
 	"renovate-operator/internal/telemetry"
+	"renovate-operator/internal/types"
 	"renovate-operator/internal/webhookSync"
 	"renovate-operator/scheduler"
 	"time"
@@ -55,6 +56,7 @@ func (r *RenovateJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if err == nil {
 		// renovatejob object read without problem -> create the schedule
+		r.resetOrphanedRunning(ctx, renovateJob)
 		r.WebhookSync.EnsureSyncer(ctx, logger, renovateJob)
 		createScheduler(logger, renovateJob, r)
 		if err := r.GithubApp.EnsureToken(ctx, renovateJob); err != nil {
@@ -124,10 +126,56 @@ func createScheduler(logger logr.Logger, renovateJob *api.RenovateJob, reconcile
 	logger.V(2).Info("Added schedule for RenovateJob", "schedule", expr)
 }
 
+// resetOrphanedRunning resets Running projects whose k8s Job no longer exists (e.g. deleted
+// while the operator was scaled down). Uses a single list call to avoid per-project API calls.
+func (r *RenovateJobReconciler) resetOrphanedRunning(ctx context.Context, renovateJob *api.RenovateJob) {
+	hasRunning := false
+	for _, p := range renovateJob.Status.Projects {
+		if p.Status == api.JobStatusRunning {
+			hasRunning = true
+			break
+		}
+	}
+	if !hasRunning {
+		return
+	}
+
+	logger := log.FromContext(ctx)
+	jobId := crdManager.RenovateJobIdentifier{Name: renovateJob.Name, Namespace: renovateJob.Namespace}
+
+	existingJobs, err := crdManager.GetJobsByLabel(ctx, r.K8sClient, crdManager.JobSelector{
+		RenovateJobName: renovateJob.Name,
+		JobType:         crdManager.ExecutorJobType,
+		Namespace:       renovateJob.Namespace,
+	})
+	if err != nil {
+		logger.Error(err, "failed to list executor jobs for orphan check")
+		return
+	}
+
+	activeProjects := make(map[string]struct{}, len(existingJobs))
+	for _, j := range existingJobs {
+		if name := j.Annotations[crdManager.JOB_ANNOTATION_PROJECT]; name != "" {
+			activeProjects[name] = struct{}{}
+		}
+	}
+
+	isOrphaned := func(p api.ProjectStatus) bool {
+		if p.Status != api.JobStatusRunning {
+			return false
+		}
+		_, active := activeProjects[p.Name]
+		return !active
+	}
+
+	if err := r.Manager.UpdateProjectStatusBatched(ctx, isOrphaned, jobId, &types.RenovateStatusUpdate{Status: api.JobStatusFailed}); err != nil {
+		logger.Error(err, "failed to reset orphaned running projects")
+	}
+}
+
 func (r *RenovateJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.RenovateJob{}).
 		Owns(&batchv1.Job{}).
 		Complete(r)
 }
-

--- a/src/controllers/renovatejob_controller.go
+++ b/src/controllers/renovatejob_controller.go
@@ -2,29 +2,20 @@ package controllers
 
 import (
 	context "context"
-	"encoding/json"
-	"fmt"
-	"net/url"
 	api "renovate-operator/api/v1alpha1"
-	"renovate-operator/gitProviderClients/forgejoProvider"
 	"renovate-operator/github"
 	"renovate-operator/internal/renovate"
 	"renovate-operator/internal/telemetry"
-	"renovate-operator/internal/types"
-	"renovate-operator/internal/utils"
 	"renovate-operator/internal/webhookSync"
 	"renovate-operator/scheduler"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -36,24 +27,17 @@ import (
 
 var reconcilerTracer = otel.Tracer("renovate-operator/reconciler")
 
-const webhookSyncStateAnnotation = "renovate-operator.mogenius.com/webhook-sync-managed-repos"
-
 /*
 Reconciler for RenovateJob resources
 Watching for create/update/delete events and managing the schedules accordingly
 */
 type RenovateJobReconciler struct {
-	Discovery      renovate.DiscoveryAgent
-	Manager        crdManager.RenovateJobManager
-	Scheduler      scheduler.Scheduler
-	K8sClient      client.Client
-	webhookSyncers map[string]*webhookSyncerEntry
-	GithubApp      github.GithubAppToken
-}
-
-type webhookSyncerEntry struct {
-	syncer      *webhookSync.WebhookSyncer
-	fingerprint string
+	Discovery   renovate.DiscoveryAgent
+	Manager     crdManager.RenovateJobManager
+	Scheduler   scheduler.Scheduler
+	K8sClient   client.Client
+	WebhookSync webhookSync.WebhookSyncManager
+	GithubApp   github.GithubAppToken
 }
 
 func (r *RenovateJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -71,7 +55,7 @@ func (r *RenovateJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if err == nil {
 		// renovatejob object read without problem -> create the schedule
-		r.ensureWebhookSyncer(ctx, logger, renovateJob)
+		r.WebhookSync.EnsureSyncer(ctx, logger, renovateJob)
 		createScheduler(logger, renovateJob, r)
 		if err := r.GithubApp.EnsureToken(ctx, renovateJob); err != nil {
 			logger.Error(err, "failed to ensure github app token")
@@ -82,7 +66,7 @@ func (r *RenovateJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// the github app token secret is owned by the RenovateJob and cleaned up by Kubernetes GC
 		name := req.Name + "-" + req.Namespace
 		r.Scheduler.RemoveSchedule(name)
-		delete(r.webhookSyncers, name)
+		r.WebhookSync.RemoveSyncer(name)
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	} else {
 		span.RecordError(err)
@@ -120,55 +104,14 @@ func createScheduler(logger logr.Logger, renovateJob *api.RenovateJob, reconcile
 			return
 		}
 
-		projects, err := reconciler.Discovery.Discover(ctx, currentJob)
+		_, err = reconciler.Discovery.CreateDiscoveryJob(ctx, *currentJob, true)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			logger.Error(err, "Failed to discover projects for RenovateJob")
+			logger.Error(err, "Failed to create discovery job for RenovateJob")
 			return
 		}
-		span.AddEvent("discovery.complete", trace.WithAttributes(
-			attribute.Int("project.count", len(projects)),
-		))
-		logger.V(2).Info("Successfully discovered projects", "count", len(projects))
-
-		err = reconciler.Manager.ReconcileProjects(ctx, currentJob, projects)
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			logger.Error(err, "failed to reconcile projects")
-			return
-		}
-		logger.V(2).Info("Successfully reconciled Projects")
-
-		isNotRunning := func(p api.ProjectStatus) bool {
-			return p.Status != api.JobStatusRunning
-		}
-		err = reconciler.Manager.UpdateProjectStatusBatched(ctx, isNotRunning, crdManager.RenovateJobIdentifier{
-			Name:      jobName,
-			Namespace: jobNamespace,
-		}, &types.RenovateStatusUpdate{
-			Status: api.JobStatusScheduled,
-		})
-
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			logger.Error(err, "failed to schedule projects")
-			return
-		}
-		logger.V(2).Info("Successfully scheduled RenovateJob")
-
-		// Run Forgejo webhook sync after discovery completes
-		if entry, ok := reconciler.webhookSyncers[name]; ok {
-			state, err := entry.syncer.RunOnce(ctx)
-			if err != nil {
-				logger.Error(err, "webhook sync failed")
-			}
-			if state != nil {
-				reconciler.saveWebhookSyncState(ctx, logger, jobName, jobNamespace, entry.syncer, state)
-			}
-		}
+		logger.V(2).Info("Discovery job created, completion handled by job controller")
 	}
 
 	// adding the schedule if it does not exist
@@ -181,189 +124,10 @@ func createScheduler(logger logr.Logger, renovateJob *api.RenovateJob, reconcile
 	logger.V(2).Info("Added schedule for RenovateJob", "schedule", expr)
 }
 
-// ensureWebhookSyncer creates, updates, or removes the WebhookSyncer for a RenovateJob
-// based on the webhook.forgejo.sync configuration.
-func (r *RenovateJobReconciler) ensureWebhookSyncer(ctx context.Context, logger logr.Logger, renovateJob *api.RenovateJob) {
-	name := renovateJob.Fullname()
-
-	if renovateJob.Spec.Webhook == nil || renovateJob.Spec.Webhook.Forgejo == nil || renovateJob.Spec.Webhook.Forgejo.Sync == nil || !renovateJob.Spec.Webhook.Forgejo.Sync.Enabled {
-		delete(r.webhookSyncers, name)
-		return
-	}
-
-	syncCfg := renovateJob.Spec.Webhook.Forgejo.Sync
-	_, providerEndpoint := utils.GetPlatformAndEndpoint(renovateJob.Spec.Provider)
-	fp := syncFingerprint(syncCfg, providerEndpoint, renovateJob.Spec.DiscoverTopics, renovateJob.Namespace, renovateJob.Name)
-
-	// Config unchanged — nothing to do
-	if entry, exists := r.webhookSyncers[name]; exists && entry.fingerprint == fp {
-		return
-	}
-
-	jobNamespace := renovateJob.Namespace
-
-	if syncCfg.TokenSecretRef == nil {
-		logger.Error(fmt.Errorf("tokenSecretRef is required when webhook sync is enabled"), "cannot initialize webhook syncer without a Forgejo API token")
-		return
-	}
-
-	forgejoToken, err := r.readSecretKey(ctx, syncCfg.TokenSecretRef, jobNamespace)
-	if err != nil {
-		logger.Error(err, "failed to read Forgejo API token for webhook sync")
-		return
-	}
-
-	var authToken string
-	if syncCfg.AuthTokenSecretRef != nil {
-		authToken, err = r.readSecretKey(ctx, syncCfg.AuthTokenSecretRef, jobNamespace)
-		if err != nil {
-			logger.Error(err, "failed to read auth token for webhook sync")
-			return
-		}
-	}
-
-	topic := syncCfg.Topic
-	if topic == "" && len(renovateJob.Spec.DiscoverTopics) > 0 {
-		topic = renovateJob.Spec.DiscoverTopics[0]
-	}
-
-	webhookURL := syncCfg.WebhookURL
-	parsed, err := url.Parse(webhookURL)
-	if err != nil {
-		logger.Error(err, "failed to parse webhookURL")
-		return
-	}
-	q := parsed.Query()
-	q.Set("namespace", renovateJob.Namespace)
-	q.Set("job", renovateJob.Name)
-	parsed.RawQuery = q.Encode()
-	webhookURL = parsed.String()
-
-	if providerEndpoint == "" {
-		logger.Error(fmt.Errorf("provider endpoint is required when webhook sync is enabled"), "cannot initialize webhook syncer without a Forgejo endpoint")
-		return
-	}
-
-	forgejoClient := forgejoProvider.NewClient(providerEndpoint, forgejoToken)
-	syncer := webhookSync.NewWebhookSyncer(
-		forgejoClient,
-		webhookURL,
-		authToken,
-		topic,
-		syncCfg.Events,
-		logger.WithName("webhook-sync"),
-	)
-
-	// Transfer managed repos state: prefer in-memory state from old syncer,
-	// fall back to persisted annotation (covers operator restart).
-	if oldEntry, exists := r.webhookSyncers[name]; exists {
-		syncer.SetManagedRepos(oldEntry.syncer.ManagedRepos())
-	} else {
-		state := r.loadWebhookSyncState(renovateJob)
-		if len(state) > 0 {
-			syncer.SetManagedRepos(state)
-			logger.V(2).Info("restored webhook sync state from annotation", "repos", len(state))
-		}
-	}
-
-	r.webhookSyncers[name] = &webhookSyncerEntry{syncer: syncer, fingerprint: fp}
-}
-
-// syncFingerprint produces a string that changes when any sync-relevant config changes.
-func syncFingerprint(cfg *api.RenovateWebhookForgejoSync, endpoint string, defaultTopic []string, namespace, jobName string) string {
-	topic := cfg.Topic
-	if topic == "" && len(defaultTopic) > 0 {
-		topic = defaultTopic[0]
-	}
-	tokenRef := ""
-	if cfg.TokenSecretRef != nil {
-		tokenRef = cfg.TokenSecretRef.Name + "/" + cfg.TokenSecretRef.Key
-	}
-	authRef := ""
-	if cfg.AuthTokenSecretRef != nil {
-		authRef = cfg.AuthTokenSecretRef.Name + "/" + cfg.AuthTokenSecretRef.Key
-	}
-	events := strings.Join(cfg.Events, ",")
-	return fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s", endpoint, cfg.WebhookURL, topic, events, tokenRef, authRef, namespace+"/"+jobName)
-}
-
-func (r *RenovateJobReconciler) loadWebhookSyncState(renovateJob *api.RenovateJob) map[string]int64 {
-	if renovateJob.Annotations == nil {
-		return nil
-	}
-	raw, ok := renovateJob.Annotations[webhookSyncStateAnnotation]
-	if !ok || raw == "" {
-		return nil
-	}
-	var state map[string]int64
-	if err := json.Unmarshal([]byte(raw), &state); err != nil {
-		return nil
-	}
-	return state
-}
-
-func (r *RenovateJobReconciler) saveWebhookSyncState(ctx context.Context, logger logr.Logger, jobName, jobNamespace string, syncer *webhookSync.WebhookSyncer, state map[string]int64) {
-	renovateJob, err := r.Manager.GetRenovateJob(ctx, jobName, jobNamespace)
-	if err != nil {
-		logger.Error(err, "failed to fetch RenovateJob for saving webhook sync state")
-		return
-	}
-
-	data, err := json.Marshal(state)
-	if err != nil {
-		logger.Error(err, "failed to marshal webhook sync state")
-		return
-	}
-
-	newVal := string(data)
-	if renovateJob.Annotations != nil && renovateJob.Annotations[webhookSyncStateAnnotation] == newVal {
-		return // no change
-	}
-
-	// Remember what was previously persisted so we can roll back on failure
-	var previousState map[string]int64
-	if raw, ok := renovateJob.Annotations[webhookSyncStateAnnotation]; ok && raw != "" {
-		if err := json.Unmarshal([]byte(raw), &previousState); err != nil {
-			previousState = nil
-		}
-	}
-
-	if renovateJob.Annotations == nil {
-		renovateJob.Annotations = make(map[string]string)
-	}
-	renovateJob.Annotations[webhookSyncStateAnnotation] = newVal
-
-	if err := r.K8sClient.Update(ctx, renovateJob); err != nil {
-		logger.Error(err, "failed to save webhook sync state annotation, rolling back in-memory state to last persisted value")
-		if previousState != nil {
-			syncer.SetManagedRepos(previousState)
-		}
-	}
-}
-
-func (r *RenovateJobReconciler) readSecretKey(ctx context.Context, ref *api.RenovateSecretKeyReference, namespace string) (string, error) {
-	if ref == nil {
-		return "", fmt.Errorf("secret reference is nil")
-	}
-	secret := &corev1.Secret{}
-	err := r.K8sClient.Get(ctx, client.ObjectKey{
-		Name:      ref.Name,
-		Namespace: namespace,
-	}, secret)
-	if err != nil {
-		return "", fmt.Errorf("reading secret %s: %w", ref.Name, err)
-	}
-	data, ok := secret.Data[ref.Key]
-	if !ok {
-		return "", fmt.Errorf("key %s not found in secret %s", ref.Key, ref.Name)
-	}
-	return string(data), nil
-}
-
 func (r *RenovateJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.webhookSyncers = make(map[string]*webhookSyncerEntry)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.RenovateJob{}).
 		Owns(&batchv1.Job{}).
 		Complete(r)
 }
+

--- a/src/controllers/renovatejob_controller_test.go
+++ b/src/controllers/renovatejob_controller_test.go
@@ -111,7 +111,7 @@ func (f *fakeDiscovery) CreateDiscoveryJob(ctx context.Context, renovateJob api.
 	}
 	return "gen-1", nil
 }
-func (f *fakeDiscovery) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
+func (f *fakeDiscovery) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error) {
 	return api.JobStatusCompleted, nil
 }
 func (f *fakeDiscovery) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobId crdManager.RenovateJobIdentifier) error {

--- a/src/controllers/renovatejob_controller_test.go
+++ b/src/controllers/renovatejob_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"renovate-operator/internal/types"
 
 	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -80,6 +81,14 @@ func (f *fakeManager) IsWebhookSignatureValid(ctx context.Context, job crdManage
 	return true, nil
 }
 
+type fakeWebhookSync struct{}
+
+func (f *fakeWebhookSync) EnsureSyncer(ctx context.Context, logger logr.Logger, renovateJob *api.RenovateJob) {
+}
+func (f *fakeWebhookSync) RunSync(ctx context.Context, logger logr.Logger, jobName, jobNamespace string) {
+}
+func (f *fakeWebhookSync) RemoveSyncer(name string) {}
+
 type fakeGithubAppToken struct{}
 
 func (worker *fakeGithubAppToken) EnsureToken(ctx context.Context, job *api.RenovateJob) error {
@@ -93,23 +102,20 @@ func (worker *fakeGithubAppToken) CreateGithubAppToken(appID, installationID, pe
 }
 
 type fakeDiscovery struct {
-	discoverFn func(ctx context.Context, job *api.RenovateJob) ([]string, error)
+	createDiscoveryJobFn func(ctx context.Context, job api.RenovateJob) (string, error)
 }
 
-func (f *fakeDiscovery) Discover(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-	if f.discoverFn != nil {
-		return f.discoverFn(ctx, job)
+func (f *fakeDiscovery) CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob, scheduleAfterCompletion bool) (string, error) {
+	if f.createDiscoveryJobFn != nil {
+		return f.createDiscoveryJobFn(ctx, renovateJob)
 	}
-	return []string{}, nil
-}
-func (f *fakeDiscovery) CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	return "gen-1", nil
 }
 func (f *fakeDiscovery) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
 	return api.JobStatusCompleted, nil
 }
-func (f *fakeDiscovery) WaitForDiscoveryJob(ctx context.Context, job *api.RenovateJob, generation string) ([]string, error) {
-	return []string{}, nil
+func (f *fakeDiscovery) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobName string, namespace string) error {
+	return nil
 }
 
 type fakeScheduler struct {
@@ -143,24 +149,11 @@ func (f *fakeScheduler) AddSchedule(expr string, name string, fn func()) error {
 }
 func (f *fakeScheduler) GetNextRunOnSchedule(schedule string) time.Time { return time.Time{} }
 
-// Test createScheduler: ensure the scheduled function performs discovery and manager calls
+// Test createScheduler: ensure the scheduled function creates a discovery job
 func TestCreateScheduler_DiscoveryAndManagerInteraction(t *testing.T) {
-	calledReconcile := false
-	var gotProjects []string
-	calledUpdate := false
+	calledCreate := false
 
 	mgr := &fakeManager{}
-	mgr.reconcileProjectsFn = func(ctx context.Context, job *api.RenovateJob, projects []string) error {
-		calledReconcile = true
-		gotProjects = projects
-		return nil
-	}
-	mgr.updateProjectStatusBatchedFn = func(ctx context.Context, fn func(p api.ProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
-		calledUpdate = true
-		// run the predicate on a sample project to ensure no panic
-		_ = fn(api.ProjectStatus{Name: "p1", Status: api.JobStatusRunning})
-		return nil
-	}
 	mgr.getFn = func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
 		return &api.RenovateJob{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -171,22 +164,16 @@ func TestCreateScheduler_DiscoveryAndManagerInteraction(t *testing.T) {
 	}
 
 	disc := &fakeDiscovery{}
-	disc.discoverFn = func(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-		return []string{"p1", "p2"}, nil
+	disc.createDiscoveryJobFn = func(ctx context.Context, job api.RenovateJob) (string, error) {
+		calledCreate = true
+		return "gen-1", nil
 	}
 
 	sched := &fakeScheduler{}
-
-	reconciler := &RenovateJobReconciler{
-		Manager:   mgr,
-		Scheduler: sched,
-		Discovery: disc,
-	}
-
+	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: disc, WebhookSync: &fakeWebhookSync{}}
 	logger := logr.Discard()
 	renovateJob := &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "*/1 * * * *"}}
 
-	// create the schedule (stores the function)
 	createScheduler(logger, renovateJob, reconciler)
 
 	if !sched.addCalled {
@@ -196,45 +183,27 @@ func TestCreateScheduler_DiscoveryAndManagerInteraction(t *testing.T) {
 		t.Fatalf("expected stored schedule function to be set")
 	}
 
-	// invoke the scheduled function and assert interactions
 	sched.storedFn()
 
-	if !calledReconcile {
-		t.Fatalf("expected ReconcileProjects to be called")
-	}
-	if !calledUpdate {
-		t.Fatalf("expected UpdateProjectStatusBatched to be called")
-	}
-	if len(gotProjects) != 2 || gotProjects[0] != "p1" || gotProjects[1] != "p2" {
-		t.Fatalf("unexpected projects discovered: %v", gotProjects)
+	if !calledCreate {
+		t.Fatalf("expected CreateDiscoveryJob to be called")
 	}
 }
 
-// Test: when Discovery returns an error, the scheduled function should abort and not call manager methods
+// Test: when CreateDiscoveryJob returns an error, the scheduled function should abort
 func TestCreateScheduler_DiscoveryErrorAborts(t *testing.T) {
-	calledReconcile := false
-	calledUpdate := false
-
 	mgr := &fakeManager{}
-	mgr.reconcileProjectsFn = func(ctx context.Context, job *api.RenovateJob, projects []string) error {
-		calledReconcile = true
-		return nil
-	}
-	mgr.updateProjectStatusBatchedFn = func(ctx context.Context, fn func(p api.ProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
-		calledUpdate = true
-		return nil
-	}
 	mgr.getFn = func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
 		return &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}, nil
 	}
 
 	disc := &fakeDiscovery{}
-	disc.discoverFn = func(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-		return nil, fmt.Errorf("discover boom")
+	disc.createDiscoveryJobFn = func(ctx context.Context, job api.RenovateJob) (string, error) {
+		return "", fmt.Errorf("create boom")
 	}
 
 	sched := &fakeScheduler{}
-	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: disc}
+	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: disc, WebhookSync: &fakeWebhookSync{}}
 	logger := logr.Discard()
 	renovateJob := &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "*/1 * * * *"}}
 
@@ -242,116 +211,15 @@ func TestCreateScheduler_DiscoveryErrorAborts(t *testing.T) {
 	if sched.storedFn == nil {
 		t.Fatalf("expected stored function to be set")
 	}
-	// invoke
+	// should not panic
 	sched.storedFn()
-
-	if calledReconcile {
-		t.Fatalf("expected ReconcileProjects NOT to be called when discovery fails")
-	}
-	if calledUpdate {
-		t.Fatalf("expected UpdateProjectStatusBatched NOT to be called when discovery fails")
-	}
 }
 
-// Test: when ReconcileProjects returns an error, the scheduled function should abort and not call UpdateProjectStatusBatched
-func TestCreateScheduler_ReconcileErrorAborts(t *testing.T) {
-	calledReconcile := false
-	calledUpdate := false
-
-	mgr := &fakeManager{}
-	mgr.reconcileProjectsFn = func(ctx context.Context, job *api.RenovateJob, projects []string) error {
-		calledReconcile = true
-		return fmt.Errorf("reconcile boom")
-	}
-	mgr.updateProjectStatusBatchedFn = func(ctx context.Context, fn func(p api.ProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
-		calledUpdate = true
-		return nil
-	}
-	mgr.getFn = func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
-		return &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}, nil
-	}
-
-	disc := &fakeDiscovery{}
-	disc.discoverFn = func(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-		return []string{"p1"}, nil
-	}
-
-	sched := &fakeScheduler{}
-	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: disc}
-	logger := logr.Discard()
-	renovateJob := &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "*/1 * * * *"}}
-
-	createScheduler(logger, renovateJob, reconciler)
-	if sched.storedFn == nil {
-		t.Fatalf("expected stored function to be set")
-	}
-	// invoke
-	sched.storedFn()
-
-	if !calledReconcile {
-		t.Fatalf("expected ReconcileProjects to be called")
-	}
-	if calledUpdate {
-		t.Fatalf("expected UpdateProjectStatusBatched NOT to be called when reconcile fails")
-	}
-}
-
-// Test: when UpdateProjectStatusBatched returns an error, it should be invoked and handled
-func TestCreateScheduler_UpdateProjectStatusBatchedError(t *testing.T) {
-	calledReconcile := false
-	calledUpdate := false
-
-	mgr := &fakeManager{}
-	mgr.reconcileProjectsFn = func(ctx context.Context, job *api.RenovateJob, projects []string) error {
-		calledReconcile = true
-		return nil
-	}
-	mgr.updateProjectStatusBatchedFn = func(ctx context.Context, fn func(p api.ProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
-		calledUpdate = true
-		return fmt.Errorf("update batched boom")
-	}
-	mgr.getFn = func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
-		return &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}, nil
-	}
-
-	disc := &fakeDiscovery{}
-	disc.discoverFn = func(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-		return []string{"p1"}, nil
-	}
-
-	sched := &fakeScheduler{}
-	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: disc}
-	logger := logr.Discard()
-	renovateJob := &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "*/1 * * * *"}}
-
-	createScheduler(logger, renovateJob, reconciler)
-	if sched.storedFn == nil {
-		t.Fatalf("expected stored function to be set")
-	}
-
-	// invoke
-	sched.storedFn()
-
-	if !calledReconcile {
-		t.Fatalf("expected ReconcileProjects to be called")
-	}
-	if !calledUpdate {
-		t.Fatalf("expected UpdateProjectStatusBatched to be called")
-	}
-}
-
-// Test: when the RenovateJob is updated after createScheduler, the scheduled function should use the fresh RenovateJob
+// Test: the scheduled function uses the freshly fetched RenovateJob, not the one captured at schedule-creation time
 func TestCreateScheduler_UsesFreshRenovateJob(t *testing.T) {
 	var discoveredJob *api.RenovateJob
 
 	mgr := &fakeManager{}
-	mgr.reconcileProjectsFn = func(ctx context.Context, job *api.RenovateJob, projects []string) error {
-		return nil
-	}
-	mgr.updateProjectStatusBatchedFn = func(ctx context.Context, fn func(p api.ProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
-		return nil
-	}
-	// Return a RenovateJob with an updated image when re-fetched
 	mgr.getFn = func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
 		return &api.RenovateJob{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -360,62 +228,47 @@ func TestCreateScheduler_UsesFreshRenovateJob(t *testing.T) {
 	}
 
 	disc := &fakeDiscovery{}
-	disc.discoverFn = func(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-		discoveredJob = job
-		return []string{"p1"}, nil
+	disc.createDiscoveryJobFn = func(ctx context.Context, job api.RenovateJob) (string, error) {
+		discoveredJob = &job
+		return "gen-1", nil
 	}
 
 	sched := &fakeScheduler{}
-	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: disc}
+	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: disc, WebhookSync: &fakeWebhookSync{}}
 	logger := logr.Discard()
 
-	// Create scheduler with old image
 	originalJob := &api.RenovateJob{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
 		Spec:       api.RenovateJobSpec{Schedule: "*/1 * * * *", Image: "renovate/renovate:38"},
 	}
 	createScheduler(logger, originalJob, reconciler)
-
-	// Execute the scheduled function — it should re-fetch and use the updated image
 	sched.storedFn()
 
 	if discoveredJob == nil {
-		t.Fatalf("expected Discover to be called")
+		t.Fatalf("expected CreateDiscoveryJob to be called")
 	}
 	if discoveredJob.Spec.Image != "renovate/renovate:39" {
-		t.Fatalf("expected discovery to use updated image 'renovate/renovate:39', got '%s'", discoveredJob.Spec.Image)
+		t.Fatalf("expected fresh image 'renovate/renovate:39', got '%s'", discoveredJob.Spec.Image)
 	}
 }
 
-// Test: when Scheduler.AddScheduleReplaceExisting returns an error, createScheduler should not panic and should log the error
+// Test: when Scheduler.AddScheduleReplaceExisting returns an error, createScheduler should not panic
 func TestCreateScheduler_SchedulerAddError(t *testing.T) {
 	mgr := &fakeManager{}
-	mgr.reconcileProjectsFn = func(ctx context.Context, job *api.RenovateJob, projects []string) error {
-		return nil
-	}
-	mgr.updateProjectStatusBatchedFn = func(ctx context.Context, fn func(p api.ProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
-		return nil
-	}
 	mgr.getFn = func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
 		return &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}, nil
 	}
 
-	disc := &fakeDiscovery{}
-	disc.discoverFn = func(ctx context.Context, job *api.RenovateJob) ([]string, error) { return []string{}, nil }
-
 	sched := &fakeScheduler{addErr: fmt.Errorf("add boom")}
-	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: disc}
+	reconciler := &RenovateJobReconciler{Manager: mgr, Scheduler: sched, Discovery: &fakeDiscovery{}, WebhookSync: &fakeWebhookSync{}}
 	logger := logr.Discard()
 	renovateJob := &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"}, Spec: api.RenovateJobSpec{Schedule: "*/1 * * * *"}}
 
-	// should not panic
 	createScheduler(logger, renovateJob, reconciler)
 
-	// AddScheduleReplaceExisting was called but returned an error, so storedFn should be set but Add returned error
 	if !sched.addCalled {
 		t.Fatalf("expected AddScheduleReplaceExisting to be called")
 	}
-	// Because AddScheduleReplaceExisting returned an error, we expect storedFn to be set (it is stored before error)
 	if sched.storedFn == nil {
 		t.Fatalf("expected storedFn to be present even if add failed")
 	}
@@ -441,7 +294,7 @@ func TestReconcile_CreateSchedule(t *testing.T) {
 		Manager:        mgr,
 		Scheduler:      sched,
 		Discovery:      &fakeDiscovery{},
-		webhookSyncers: make(map[string]*webhookSyncerEntry),
+		WebhookSync: &fakeWebhookSync{},
 		GithubApp:      &fakeGithubAppToken{},
 	}
 
@@ -475,7 +328,7 @@ func TestReconcile_RemoveScheduleOnNotFound(t *testing.T) {
 		Manager:        mgr,
 		Scheduler:      sched,
 		Discovery:      &fakeDiscovery{},
-		webhookSyncers: make(map[string]*webhookSyncerEntry),
+		WebhookSync: &fakeWebhookSync{},
 		GithubApp:      &fakeGithubAppToken{},
 	}
 
@@ -509,7 +362,7 @@ func TestReconcile_ReturnsErrorOnManagerFailure(t *testing.T) {
 		Manager:        mgr,
 		Scheduler:      sched,
 		Discovery:      &fakeDiscovery{},
-		webhookSyncers: make(map[string]*webhookSyncerEntry),
+		WebhookSync: &fakeWebhookSync{},
 	}
 
 	req := ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: "test", Namespace: "default"}}

--- a/src/controllers/renovatejob_controller_test.go
+++ b/src/controllers/renovatejob_controller_test.go
@@ -85,7 +85,7 @@ type fakeWebhookSync struct{}
 
 func (f *fakeWebhookSync) EnsureSyncer(ctx context.Context, logger logr.Logger, renovateJob *api.RenovateJob) {
 }
-func (f *fakeWebhookSync) RunSync(ctx context.Context, logger logr.Logger, jobName, jobNamespace string) {
+func (f *fakeWebhookSync) RunSync(ctx context.Context, logger logr.Logger, jobId crdManager.RenovateJobIdentifier) {
 }
 func (f *fakeWebhookSync) RemoveSyncer(name string) {}
 
@@ -114,7 +114,7 @@ func (f *fakeDiscovery) CreateDiscoveryJob(ctx context.Context, renovateJob api.
 func (f *fakeDiscovery) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
 	return api.JobStatusCompleted, nil
 }
-func (f *fakeDiscovery) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobName string, namespace string) error {
+func (f *fakeDiscovery) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobId crdManager.RenovateJobIdentifier) error {
 	return nil
 }
 
@@ -291,11 +291,11 @@ func TestReconcile_CreateSchedule(t *testing.T) {
 	sched := &fakeScheduler{}
 
 	reconciler := &RenovateJobReconciler{
-		Manager:        mgr,
-		Scheduler:      sched,
-		Discovery:      &fakeDiscovery{},
+		Manager:     mgr,
+		Scheduler:   sched,
+		Discovery:   &fakeDiscovery{},
 		WebhookSync: &fakeWebhookSync{},
-		GithubApp:      &fakeGithubAppToken{},
+		GithubApp:   &fakeGithubAppToken{},
 	}
 
 	req := ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: "test", Namespace: "default"}}
@@ -325,11 +325,11 @@ func TestReconcile_RemoveScheduleOnNotFound(t *testing.T) {
 	sched := &fakeScheduler{}
 
 	reconciler := &RenovateJobReconciler{
-		Manager:        mgr,
-		Scheduler:      sched,
-		Discovery:      &fakeDiscovery{},
+		Manager:     mgr,
+		Scheduler:   sched,
+		Discovery:   &fakeDiscovery{},
 		WebhookSync: &fakeWebhookSync{},
-		GithubApp:      &fakeGithubAppToken{},
+		GithubApp:   &fakeGithubAppToken{},
 	}
 
 	req := ctrl.Request{NamespacedName: k8stypes.NamespacedName{Name: "test", Namespace: "default"}}
@@ -359,9 +359,9 @@ func TestReconcile_ReturnsErrorOnManagerFailure(t *testing.T) {
 	sched := &fakeScheduler{}
 
 	reconciler := &RenovateJobReconciler{
-		Manager:        mgr,
-		Scheduler:      sched,
-		Discovery:      &fakeDiscovery{},
+		Manager:     mgr,
+		Scheduler:   sched,
+		Discovery:   &fakeDiscovery{},
 		WebhookSync: &fakeWebhookSync{},
 	}
 

--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -14,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -89,7 +88,7 @@ func GetJobsByLabel(ctx context.Context, client crclient.Client, selector JobSel
 		JOB_LABEL_TYPE:        string(selector.JobType),
 		JOB_LABEL_RENOVATEJOB: selector.RenovateJobName,
 	}
-	if selector.JobType == ExecutorJobType {
+	if selector.JobType == ExecutorJobType && selector.Project != "" {
 		matcher[JOB_LABEL_PROJECT] = utils.KubernetesCompatibleName(selector.Project)
 	}
 
@@ -168,7 +167,7 @@ func cleanupOldGenerations(ctx context.Context, client crclient.Client, selector
 	}
 
 	// TODO: Remove this cleanup logic after we have confidence that the new labels have propagated
-	stub := &api.RenovateJob{ObjectMeta: v1.ObjectMeta{Name: selector.RenovateJobName, Namespace: selector.Namespace}}
+	stub := &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: selector.RenovateJobName, Namespace: selector.Namespace}}
 	name := ""
 	if selector.JobType == DiscoveryJobType {
 		name = utils.DiscoveryJobName(stub)

--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -3,6 +3,9 @@ package crdmanager
 import (
 	"context"
 	"fmt"
+	api "renovate-operator/api/v1alpha1"
+	"renovate-operator/assert"
+	"renovate-operator/internal/utils"
 	"sort"
 	"strconv"
 	"time"
@@ -11,14 +14,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	JOB_LABEL_TYPE       = "renovate-operator.mogenius.com/job-type"
-	JOB_LABEL_NAME       = "renovate-operator.mogenius.com/job-name"
-	JOB_LABEL_GENERATION = "renovate-operator.mogenius.com/generation"
+	JOB_LABEL_TYPE        = "renovate-operator.mogenius.com/type"
+	JOB_LABEL_RENOVATEJOB = "renovate-operator.mogenius.com/renovatejob"
+	JOB_LABEL_PROJECT     = "renovate-operator.mogenius.com/project"
+	JOB_LABEL_GENERATION  = "renovate-operator.mogenius.com/generation"
 )
 
 type JobType string
@@ -29,9 +34,10 @@ const (
 )
 
 type JobSelector struct {
-	JobName   string
-	JobType   JobType
-	Namespace string
+	RenovateJobName string
+	Project         string
+	JobType         JobType
+	Namespace       string
 	// optional generation to filter by - if not provided, the most recent job will be returned
 	Generation *string
 }
@@ -45,7 +51,7 @@ func GetJobByLabel(ctx context.Context, client crclient.Client, selector JobSele
 		return nil, err
 	}
 	if len(allJobs) == 0 {
-		return nil, errors.NewNotFound(batchv1.Resource("jobs"), selector.JobName)
+		return nil, errors.NewNotFound(batchv1.Resource("jobs"), selector.Project)
 	}
 	// get the newest job in case there are multiple jobs for the same project (e.g. due to multiple executions)
 	var currentJob *batchv1.Job
@@ -73,16 +79,20 @@ func GetJobByLabel(ctx context.Context, client crclient.Client, selector JobSele
 func GetJobsByLabel(ctx context.Context, client crclient.Client, selector JobSelector) ([]batchv1.Job, error) {
 
 	matcher := crclient.MatchingLabels{
-		JOB_LABEL_NAME: selector.JobName,
-		JOB_LABEL_TYPE: string(selector.JobType),
+		JOB_LABEL_TYPE:        string(selector.JobType),
+		JOB_LABEL_RENOVATEJOB: selector.RenovateJobName,
 	}
+	if selector.JobType == ExecutorJobType {
+		matcher[JOB_LABEL_PROJECT] = utils.KubernetesCompatibleName(selector.Project)
+	}
+
 	if selector.Generation != nil && *selector.Generation != "" {
 		matcher[JOB_LABEL_GENERATION] = *selector.Generation
 	}
 	jobList := &batchv1.JobList{}
 	err := client.List(ctx, jobList, crclient.InNamespace(selector.Namespace), crclient.MatchingLabels(matcher))
 	if err != nil {
-		return nil, fmt.Errorf("listing jobs with label %s: %w", selector.JobName, err)
+		return nil, fmt.Errorf("listing jobs with label RenvateJob: %s Project: %s Error: %w", selector.RenovateJobName, selector.Project, err)
 	}
 	return jobList.Items, nil
 }
@@ -97,10 +107,22 @@ func DeleteJob(ctx context.Context, client crclient.Client, job *batchv1.Job) er
 	return nil
 }
 func CreateJobWithGeneration(ctx context.Context, client crclient.Client, job *batchv1.Job, selector JobSelector) (string, error) {
+	assert.Assert(selector.JobType != "", "JobType is required in selector")
+	assert.Assert(selector.RenovateJobName != "", "RenovateJobName is required in selector")
+
 	generation := fmt.Sprintf("%d", time.Now().Unix())
 
-	job.Labels[JOB_LABEL_GENERATION] = generation
+	if job.Labels == nil {
+		job.Labels = make(map[string]string)
+	}
 
+	job.Labels[JOB_LABEL_GENERATION] = generation
+	job.Labels[JOB_LABEL_TYPE] = string(selector.JobType)
+	job.Labels[JOB_LABEL_RENOVATEJOB] = selector.RenovateJobName
+
+	if selector.JobType == ExecutorJobType {
+		job.Labels[JOB_LABEL_PROJECT] = utils.KubernetesCompatibleName(selector.Project)
+	}
 	// Create immediately - no deletion needed first
 	err := client.Create(ctx, job)
 	if err != nil {
@@ -132,6 +154,30 @@ func cleanupOldGenerations(ctx context.Context, client crclient.Client, selector
 			// This is an old generation - safe to delete
 			_ = DeleteJob(ctx, client, &job)
 		}
+	}
+
+	// TODO: Remove this cleanup logic after we have confidence that the new labels have propagated
+	stub := &api.RenovateJob{ObjectMeta: v1.ObjectMeta{Name: selector.RenovateJobName, Namespace: selector.Namespace}}
+	name := ""
+	if selector.JobType == DiscoveryJobType {
+		name = utils.DiscoveryJobName(stub)
+	} else {
+		name = utils.ExecutorJobName(stub, selector.Project)
+	}
+
+	matcher := crclient.MatchingLabels{
+		"renovate-operator.mogenius.com/job-type": string(selector.JobType),
+		"renovate-operator.mogenius.com/job-name": name,
+	}
+
+	jobList := &batchv1.JobList{}
+	err = client.List(ctx, jobList, crclient.InNamespace(selector.Namespace), crclient.MatchingLabels(matcher))
+	if err != nil {
+		return fmt.Errorf("listing jobs for cleanup with label RenvateJob: %s Project: %s Error: %w", selector.RenovateJobName, selector.Project, err)
+	}
+
+	for _, job := range jobList.Items {
+		_ = DeleteJob(ctx, client, &job)
 	}
 	return nil
 }

--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -27,6 +27,10 @@ const (
 	// JOB_ANNOTATION_PROJECT stores the original project name (may contain slashes etc.)
 	// Use this instead of JOB_LABEL_PROJECT when you need the exact CRD status key.
 	JOB_ANNOTATION_PROJECT = "renovate-operator.mogenius.com/project"
+	// JOB_ANNOTATION_SCHEDULE_AFTER_DISCOVERY indicates that ProcessDiscoveryJobResult should
+	// schedule all non-running projects after reconciling. Set to "true" for cron-triggered
+	// discovery; omit or "false" for UI-triggered discovery (project list refresh only).
+	JOB_ANNOTATION_SCHEDULE_AFTER_DISCOVERY = "renovate-operator.mogenius.com/schedule-after-discovery"
 )
 
 type JobType string

--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -24,6 +24,9 @@ const (
 	JOB_LABEL_RENOVATEJOB = "renovate-operator.mogenius.com/renovatejob"
 	JOB_LABEL_PROJECT     = "renovate-operator.mogenius.com/project"
 	JOB_LABEL_GENERATION  = "renovate-operator.mogenius.com/generation"
+	// JOB_ANNOTATION_PROJECT stores the original project name (may contain slashes etc.)
+	// Use this instead of JOB_LABEL_PROJECT when you need the exact CRD status key.
+	JOB_ANNOTATION_PROJECT = "renovate-operator.mogenius.com/project"
 )
 
 type JobType string
@@ -122,6 +125,10 @@ func CreateJobWithGeneration(ctx context.Context, client crclient.Client, job *b
 
 	if selector.JobType == ExecutorJobType {
 		job.Labels[JOB_LABEL_PROJECT] = utils.KubernetesCompatibleName(selector.Project)
+		if job.Annotations == nil {
+			job.Annotations = make(map[string]string)
+		}
+		job.Annotations[JOB_ANNOTATION_PROJECT] = selector.Project
 	}
 	// Create immediately - no deletion needed first
 	err := client.Create(ctx, job)

--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -30,6 +30,10 @@ const (
 	// schedule all non-running projects after reconciling. Set to "true" for cron-triggered
 	// discovery; omit or "false" for UI-triggered discovery (project list refresh only).
 	JOB_ANNOTATION_SCHEDULE_AFTER_DISCOVERY = "renovate-operator.mogenius.com/schedule-after-discovery"
+	// JOB_ANNOTATION_PROCESSED is stamped on a Job after its result has been fully processed.
+	// The JobReconciler checks this annotation to skip already-processed jobs on informer resyncs,
+	// preventing completed discovery jobs from re-scheduling all projects every ~10h.
+	JOB_ANNOTATION_PROCESSED = "renovate-operator.mogenius.com/processed"
 )
 
 type JobType string
@@ -111,6 +115,17 @@ func DeleteJob(ctx context.Context, client crclient.Client, job *batchv1.Job) er
 		return fmt.Errorf("failed to delete job %s: %w", job.Name, err)
 	}
 	return nil
+}
+
+// MarkJobProcessed stamps JOB_ANNOTATION_PROCESSED on the Job so the JobReconciler
+// can skip it on subsequent informer resyncs without re-processing its result.
+func MarkJobProcessed(ctx context.Context, c crclient.Client, job *batchv1.Job) error {
+	patch := crclient.MergeFrom(job.DeepCopy())
+	if job.Annotations == nil {
+		job.Annotations = make(map[string]string)
+	}
+	job.Annotations[JOB_ANNOTATION_PROCESSED] = "true"
+	return c.Patch(ctx, job, patch)
 }
 func CreateJobWithGeneration(ctx context.Context, client crclient.Client, job *batchv1.Job, selector JobSelector) (string, error) {
 	assert.Assert(selector.JobType != "", "JobType is required in selector")

--- a/src/internal/crdManager/jobManager_test.go
+++ b/src/internal/crdManager/jobManager_test.go
@@ -23,8 +23,9 @@ func TestGetJob(t *testing.T) {
 			Name:      "test-job",
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				JOB_LABEL_NAME: "test-job",
-				JOB_LABEL_TYPE: string(ExecutorJobType),
+				JOB_LABEL_RENOVATEJOB: "test-job",
+				JOB_LABEL_PROJECT:     "test-project",
+				JOB_LABEL_TYPE:        string(ExecutorJobType),
 			},
 		},
 	}
@@ -33,9 +34,10 @@ func TestGetJob(t *testing.T) {
 
 	t.Run("existing job", func(t *testing.T) {
 		got, err := GetJobByLabel(context.Background(), client, JobSelector{
-			JobName:   "test-job",
-			JobType:   ExecutorJobType,
-			Namespace: "test-ns",
+			RenovateJobName: "test-job",
+			JobType:         ExecutorJobType,
+			Project:         "test-project",
+			Namespace:       "test-ns",
 		})
 		if err != nil {
 			t.Fatalf("GetJob returned error: %v", err)
@@ -47,9 +49,9 @@ func TestGetJob(t *testing.T) {
 
 	t.Run("non-existing job", func(t *testing.T) {
 		_, err := GetJobByLabel(context.Background(), client, JobSelector{
-			JobName:   "non-existing",
-			JobType:   ExecutorJobType,
-			Namespace: "test-ns",
+			RenovateJobName: "non-existing",
+			JobType:         ExecutorJobType,
+			Namespace:       "test-ns",
 		})
 		if err == nil {
 			t.Error("GetJob should return error for non-existing job")
@@ -70,8 +72,8 @@ func TestCreateJob(t *testing.T) {
 			Name:      "new-job",
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				JOB_LABEL_NAME: "new-job",
-				JOB_LABEL_TYPE: string(ExecutorJobType),
+				JOB_LABEL_RENOVATEJOB: "new-job",
+				JOB_LABEL_TYPE:        string(ExecutorJobType),
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -90,9 +92,9 @@ func TestCreateJob(t *testing.T) {
 	}
 
 	_, err := CreateJobWithGeneration(context.Background(), client, job, JobSelector{
-		JobName:   "new-job",
-		JobType:   ExecutorJobType,
-		Namespace: "test-ns",
+		RenovateJobName: "new-job",
+		JobType:         ExecutorJobType,
+		Namespace:       "test-ns",
 	})
 	if err != nil {
 		t.Fatalf("CreateJob returned error: %v", err)
@@ -100,9 +102,9 @@ func TestCreateJob(t *testing.T) {
 
 	// Verify job was created
 	got, err := GetJobByLabel(context.Background(), client, JobSelector{
-		JobName:   "new-job",
-		JobType:   ExecutorJobType,
-		Namespace: "test-ns",
+		RenovateJobName: "new-job",
+		JobType:         ExecutorJobType,
+		Namespace:       "test-ns",
 	})
 	if err != nil {
 		t.Fatalf("Failed to get created job: %v", err)
@@ -134,8 +136,8 @@ func TestDeleteJob(t *testing.T) {
 			Name:      "test-pod",
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				JOB_LABEL_NAME: "test-job",
-				JOB_LABEL_TYPE: string(ExecutorJobType),
+				JOB_LABEL_RENOVATEJOB: "test-job",
+				JOB_LABEL_TYPE:        string(ExecutorJobType),
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -157,9 +159,9 @@ func TestDeleteJob(t *testing.T) {
 
 	// Verify job was deleted
 	_, err = GetJobByLabel(context.Background(), client, JobSelector{
-		JobName:   "test-job",
-		JobType:   ExecutorJobType,
-		Namespace: "test-ns",
+		RenovateJobName: "test-job",
+		JobType:         ExecutorJobType,
+		Namespace:       "test-ns",
 	})
 	if err == nil {
 		t.Error("Job should be deleted but still exists")
@@ -188,8 +190,8 @@ func TestDeleteJobWithWait(t *testing.T) {
 			Name:      "test-pod",
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				JOB_LABEL_NAME: "test-job",
-				JOB_LABEL_TYPE: string(ExecutorJobType),
+				JOB_LABEL_RENOVATEJOB: "test-job",
+				JOB_LABEL_TYPE:        string(ExecutorJobType),
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -211,9 +213,9 @@ func TestDeleteJobWithWait(t *testing.T) {
 
 	// Verify job was deleted
 	_, err = GetJobByLabel(context.Background(), client, JobSelector{
-		JobName:   "test-job",
-		JobType:   ExecutorJobType,
-		Namespace: "test-ns",
+		RenovateJobName: "test-job",
+		JobType:         ExecutorJobType,
+		Namespace:       "test-ns",
 	})
 	if err == nil {
 		t.Error("Job should be deleted but still exists")

--- a/src/internal/crdManager/renovateJobManager.go
+++ b/src/internal/crdManager/renovateJobManager.go
@@ -335,12 +335,11 @@ func (r *renovateJobManager) GetLogsForProject(ctx context.Context, job Renovate
 		}
 	}
 
-	executorJobName := utils.ExecutorJobName(renovateJob, project)
-
 	executorJob, jobErr := GetJobByLabel(ctx, r.client, JobSelector{
-		JobName:   executorJobName,
-		JobType:   ExecutorJobType,
-		Namespace: job.Namespace,
+		JobType:         ExecutorJobType,
+		Namespace:       job.Namespace,
+		RenovateJobName: job.Name,
+		Project:         project,
 	})
 
 	if jobErr == nil {
@@ -445,11 +444,11 @@ func (r *renovateJobManager) IsWebhookSignatureValid(ctx context.Context, job Re
 }
 
 func (r *renovateJobManager) CancelProjectJob(ctx context.Context, project string, job RenovateJobIdentifier) error {
-	stub := &api.RenovateJob{ObjectMeta: v1.ObjectMeta{Name: job.Name, Namespace: job.Namespace}}
 	executorJob, err := GetJobByLabel(ctx, r.client, JobSelector{
-		JobName:   utils.ExecutorJobName(stub, project),
-		JobType:   ExecutorJobType,
-		Namespace: job.Namespace,
+		JobType:         ExecutorJobType,
+		Namespace:       job.Namespace,
+		Project:         project,
+		RenovateJobName: job.Name,
 	})
 	if err == nil && executorJob != nil {
 		if delErr := DeleteJob(ctx, r.client, executorJob); delErr != nil {

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -7,7 +7,6 @@ import (
 	"renovate-operator/config"
 	crdManager "renovate-operator/internal/crdManager"
 	"renovate-operator/internal/telemetry"
-	"renovate-operator/internal/utils"
 	"sync"
 	"time"
 
@@ -121,9 +120,9 @@ func (e *discoveryAgent) WaitForDiscoveryJob(ctx context.Context, job *api.Renov
 
 	// 3. Extract discovered projects from stdout
 	existingDiscoveryJob, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
-		JobName:   utils.DiscoveryJobName(job),
-		JobType:   crdManager.DiscoveryJobType,
-		Namespace: job.Namespace,
+		JobType:         crdManager.DiscoveryJobType,
+		Namespace:       job.Namespace,
+		RenovateJobName: job.Name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get discovery job: %w", err)
@@ -165,10 +164,10 @@ func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job 
 
 	// if generation is not provided, get the latest job and return its status
 	existingDiscoveryJob, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
-		JobName:    utils.DiscoveryJobName(job),
-		JobType:    crdManager.DiscoveryJobType,
-		Namespace:  job.Namespace,
-		Generation: &generation,
+		JobType:         crdManager.DiscoveryJobType,
+		Namespace:       job.Namespace,
+		Generation:      &generation,
+		RenovateJobName: job.Name,
 	})
 	// retry getting the job if not found
 	if err != nil && errors.IsNotFound(err) {
@@ -181,10 +180,10 @@ func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job 
 				return api.JobStatusFailed, fmt.Errorf("discovery job not found: %w", err)
 			}
 			existingDiscoveryJob, err = crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
-				JobName:    utils.DiscoveryJobName(job),
-				JobType:    crdManager.DiscoveryJobType,
-				Namespace:  job.Namespace,
-				Generation: &generation,
+				JobType:         crdManager.DiscoveryJobType,
+				Namespace:       job.Namespace,
+				Generation:      &generation,
+				RenovateJobName: job.Name,
 			})
 		}
 	} else if err != nil {
@@ -223,9 +222,9 @@ func (e *discoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api
 
 	// Create the discovery job
 	generation, err := crdManager.CreateJobWithGeneration(ctx, e.client, discoveryJob, crdManager.JobSelector{
-		JobName:   utils.DiscoveryJobName(&renovateJob),
-		JobType:   crdManager.DiscoveryJobType,
-		Namespace: renovateJob.Namespace,
+		JobType:         crdManager.DiscoveryJobType,
+		Namespace:       renovateJob.Namespace,
+		RenovateJobName: renovateJob.Name,
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create discovery job: %w", err)

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -6,17 +6,13 @@ import (
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/config"
 	crdManager "renovate-operator/internal/crdManager"
-	"renovate-operator/internal/telemetry"
+	"renovate-operator/internal/types"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
-	"go.opentelemetry.io/otel/trace"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,124 +21,46 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-var discoveryTracer = otel.Tracer("renovate-operator/discovery")
-
 /*
 DiscoveryAgent is the interface for discovering projects for a RenovateJob CRD.
 */
 type DiscoveryAgent interface {
-	// Discover runs the discovery process for the given RenovateJob CRD and returns the list of discovered projects.
-	Discover(ctx context.Context, job *api.RenovateJob) ([]string, error)
-	// Only create and start the discovery job, do not wait for completion.
-	CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob) (string, error)
+	// CreateDiscoveryJob creates and starts a discovery job for the given RenovateJob.
+	// scheduleAfterCompletion controls whether ProcessDiscoveryJobResult will schedule all
+	// non-running projects once the job completes (true for cron, false for UI-triggered).
+	// Completion is handled reactively by the job controller via ProcessDiscoveryJobResult.
+	CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob, scheduleAfterCompletion bool) (string, error)
 	// GetDiscoveryJobStatus retrieves the current status of the discovery job for the given RenovateJob CRD.
 	GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error)
-	// WaitForDiscoveryJob waits for the discovery job to complete and returns the list of discovered projects.
-	WaitForDiscoveryJob(ctx context.Context, job *api.RenovateJob, generation string) ([]string, error)
+	// ProcessDiscoveryJobResult handles completion of a discovery k8s Job: extracts discovered projects,
+	// reconciles them into the RenovateJob CRD, schedules all projects, and optionally deletes the job.
+	// A nil k8sJob or a still-running job is a no-op.
+	ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobName string, namespace string) error
 }
 
 type discoveryAgent struct {
-	client client.Client
-	logger logr.Logger
-	scheme *runtime.Scheme
-	syncer map[string]*sync.RWMutex
+	client  client.Client
+	logger  logr.Logger
+	scheme  *runtime.Scheme
+	manager crdManager.RenovateJobManager
+	syncer  map[string]*sync.RWMutex
 	// allow tests to override how logs are extracted
 	getDiscoveredProjectsFromJobLogsFn func(ctx context.Context, c client.Client, job *batchv1.Job) ([]string, error)
 	// allow tests to override how status is checked
 	getDiscoveryJobStatusFn func(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error)
 }
 
-func NewDiscoveryAgent(scheme *runtime.Scheme, client client.Client, logger logr.Logger) DiscoveryAgent {
+func NewDiscoveryAgent(scheme *runtime.Scheme, client client.Client, logger logr.Logger, manager crdManager.RenovateJobManager) DiscoveryAgent {
 	da := &discoveryAgent{
-		client: client,
-		logger: logger,
-		scheme: scheme,
-		syncer: make(map[string]*sync.RWMutex),
+		client:  client,
+		logger:  logger,
+		scheme:  scheme,
+		manager: manager,
+		syncer:  make(map[string]*sync.RWMutex),
 	}
-	// default to the internal implementation
 	da.getDiscoveredProjectsFromJobLogsFn = da.getDiscoveredProjectsFromJobLogs
 	da.getDiscoveryJobStatusFn = da.getDiscoveryJobStatusInternal
 	return da
-}
-
-func (e *discoveryAgent) Discover(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-	name := job.Fullname()
-
-	ctx, span := discoveryTracer.Start(ctx, "discovery.run",
-		trace.WithAttributes(
-			semconv.K8SNamespaceName(job.Namespace),
-			semconv.CICDPipelineName(job.Name),
-		),
-	)
-	defer span.End()
-	ctx = telemetry.ContextWithTraceLogger(ctx, e.logger)
-
-	log.FromContext(ctx).V(2).Info("Discovering projects for RenovateJob", "job", name)
-	projects, err := e.discoverIntern(ctx, job)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return nil, err
-	}
-	span.AddEvent("discovery.complete", trace.WithAttributes(
-		attribute.Int("project.count", len(projects)),
-	))
-	return projects, nil
-}
-
-func (e *discoveryAgent) discoverIntern(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-	// 1. Create the discovery job - replaces existing job
-	generation, err := e.CreateDiscoveryJob(ctx, *job)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create or get discovery job: %w", err)
-	}
-
-	return e.WaitForDiscoveryJob(ctx, job, generation)
-}
-
-func (e *discoveryAgent) WaitForDiscoveryJob(ctx context.Context, job *api.RenovateJob, generation string) ([]string, error) {
-	// 2. Wait for discovery job completion
-	for {
-		status, err := e.getDiscoveryJobStatusFn(ctx, job, generation)
-
-		if err != nil {
-			return nil, fmt.Errorf("failed to get discovery job status: %w", err)
-		}
-
-		if status == api.JobStatusRunning {
-			time.Sleep(5 * time.Second)
-		} else if status == api.JobStatusCompleted {
-			break
-		} else if status == api.JobStatusFailed {
-			return nil, fmt.Errorf("discovery job failed")
-		}
-	}
-
-	// 3. Extract discovered projects from stdout
-	existingDiscoveryJob, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
-		JobType:         crdManager.DiscoveryJobType,
-		Namespace:       job.Namespace,
-		RenovateJobName: job.Name,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get discovery job: %w", err)
-	}
-	projects, err := e.getDiscoveredProjectsFromJobLogsFn(ctx, e.client, existingDiscoveryJob)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get discovered projects from job logs: %w", err)
-	}
-	log.FromContext(ctx).V(2).Info("Discovered projects", "count", len(projects), "job", job.Fullname())
-
-	// DELETE_SUCCESSFUL_JOBS applies to both executor and discovery jobs.
-	// Previously only executor jobs were deleted; discovery jobs accumulated
-	// indefinitely even when the setting was enabled.
-	if config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" {
-		if err := crdManager.DeleteJob(ctx, e.client, existingDiscoveryJob); err != nil {
-			log.FromContext(ctx).Error(err, "failed to delete successful discovery job", "job", job.Fullname())
-		}
-	}
-
-	return projects, nil
 }
 
 // GetDiscoveryJobStatus implements DiscoveryAgent.
@@ -152,7 +70,6 @@ func (e *discoveryAgent) GetDiscoveryJobStatus(ctx context.Context, job *api.Ren
 
 // getDiscoveryJobStatusInternal is the internal implementation of GetDiscoveryJobStatus.
 func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
-	// lock based on the renovatejob
 	name := job.Fullname()
 	lock := e.syncer[name]
 	if lock == nil {
@@ -162,14 +79,12 @@ func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job 
 	lock.RLock()
 	defer lock.RUnlock()
 
-	// if generation is not provided, get the latest job and return its status
 	existingDiscoveryJob, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
 		JobType:         crdManager.DiscoveryJobType,
 		Namespace:       job.Namespace,
 		Generation:      &generation,
 		RenovateJobName: job.Name,
 	})
-	// retry getting the job if not found
 	if err != nil && errors.IsNotFound(err) {
 		time.Sleep(1 * time.Second)
 
@@ -198,8 +113,70 @@ func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job 
 	}
 	return api.JobStatusRunning, nil
 }
-func (e *discoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob) (string, error) {
-	// lock based on the renovatejob
+
+// ProcessDiscoveryJobResult handles completion of a discovery k8s Job: extracts discovered
+// projects from its logs, reconciles them into the RenovateJob CRD, and optionally schedules
+// all non-running projects (controlled by the JOB_ANNOTATION_SCHEDULE_AFTER_DISCOVERY annotation).
+// A nil k8sJob or a still-running job is a no-op.
+func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobName string, namespace string) error {
+	if k8sJob == nil {
+		return nil
+	}
+
+	status, _, err := getJobStatus(k8sJob)
+	if err != nil {
+		return err
+	}
+	if status == api.JobStatusRunning {
+		return nil
+	}
+	if status == api.JobStatusFailed {
+		log.FromContext(ctx).Info("discovery job failed", "renovateJob", renovateJobName)
+		return nil
+	}
+
+	renovateJob, err := e.manager.GetRenovateJob(ctx, renovateJobName, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to load RenovateJob: %w", err)
+	}
+
+	projects, err := e.getDiscoveredProjectsFromJobLogsFn(ctx, e.client, k8sJob)
+	if err != nil {
+		// Pod may already be gone (operator restart replaying old jobs, or TTL cleanup).
+		// Skip reconciliation — the next scheduled discovery will correct any drift.
+		log.FromContext(ctx).V(1).Info("skipping discovery result: could not read job logs", "renovateJob", renovateJobName, "error", err)
+		return nil
+	}
+	log.FromContext(ctx).V(2).Info("Discovered projects", "count", len(projects), "job", renovateJob.Fullname())
+
+	if err := e.manager.ReconcileProjects(ctx, renovateJob, projects); err != nil {
+		return fmt.Errorf("failed to reconcile projects: %w", err)
+	}
+
+	if k8sJob.Annotations[crdManager.JOB_ANNOTATION_SCHEDULE_AFTER_DISCOVERY] == "true" {
+		isNotRunning := func(p api.ProjectStatus) bool {
+			return p.Status != api.JobStatusRunning
+		}
+		if err := e.manager.UpdateProjectStatusBatched(ctx, isNotRunning, crdManager.RenovateJobIdentifier{
+			Name:      renovateJobName,
+			Namespace: namespace,
+		}, &types.RenovateStatusUpdate{
+			Status: api.JobStatusScheduled,
+		}); err != nil {
+			return fmt.Errorf("failed to schedule projects: %w", err)
+		}
+	}
+
+	if config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" {
+		if err := crdManager.DeleteJob(ctx, e.client, k8sJob); err != nil {
+			log.FromContext(ctx).Error(err, "failed to delete successful discovery job", "job", renovateJob.Fullname())
+		}
+	}
+
+	return nil
+}
+
+func (e *discoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob, scheduleAfterCompletion bool) (string, error) {
 	name := renovateJob.Fullname()
 	lock := e.syncer[name]
 	if lock == nil {
@@ -216,11 +193,16 @@ func (e *discoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api
 	carrier := propagation.MapCarrier{}
 	otel.GetTextMapPropagator().Inject(ctx, carrier)
 	discoveryJob := newDiscoveryJob(&renovateJob, carrier.Get("traceparent"))
+	if scheduleAfterCompletion {
+		if discoveryJob.Annotations == nil {
+			discoveryJob.Annotations = make(map[string]string)
+		}
+		discoveryJob.Annotations[crdManager.JOB_ANNOTATION_SCHEDULE_AFTER_DISCOVERY] = "true"
+	}
 	if err := controllerutil.SetControllerReference(&renovateJob, discoveryJob, e.scheme); err != nil {
 		return "", fmt.Errorf("failed to set controller reference: %w", err)
 	}
 
-	// Create the discovery job
 	generation, err := crdManager.CreateJobWithGeneration(ctx, e.client, discoveryJob, crdManager.JobSelector{
 		JobType:         crdManager.DiscoveryJobType,
 		Namespace:       renovateJob.Namespace,

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -128,8 +128,10 @@ func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *
 	if status == api.JobStatusRunning {
 		return nil
 	}
+
 	if status == api.JobStatusFailed {
 		log.FromContext(ctx).Info("discovery job failed", "renovateJob", jobId.Name)
+		_ = crdManager.MarkJobProcessed(ctx, e.client, k8sJob)
 		return nil
 	}
 
@@ -160,6 +162,11 @@ func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *
 		}); err != nil {
 			return fmt.Errorf("failed to schedule projects: %w", err)
 		}
+	}
+
+	// Stamp before the optional delete: if deletion fails the annotation prevents re-processing.
+	if err := crdManager.MarkJobProcessed(ctx, e.client, k8sJob); err != nil {
+		log.FromContext(ctx).Error(err, "failed to mark discovery job as processed", "job", k8sJob.Name)
 	}
 
 	if config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" {

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -31,7 +31,7 @@ type DiscoveryAgent interface {
 	// Completion is handled reactively by the job controller via ProcessDiscoveryJobResult.
 	CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob, scheduleAfterCompletion bool) (string, error)
 	// GetDiscoveryJobStatus retrieves the current status of the discovery job for the given RenovateJob CRD.
-	GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error)
+	GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error)
 	// ProcessDiscoveryJobResult handles completion of a discovery k8s Job: extracts discovered projects,
 	// reconciles them into the RenovateJob CRD, schedules all projects, and optionally deletes the job.
 	// A nil k8sJob or a still-running job is a no-op.
@@ -47,7 +47,7 @@ type discoveryAgent struct {
 	// allow tests to override how logs are extracted
 	getDiscoveredProjectsFromJobLogsFn func(ctx context.Context, c client.Client, job *batchv1.Job) ([]string, error)
 	// allow tests to override how status is checked
-	getDiscoveryJobStatusFn func(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error)
+	getDiscoveryJobStatusFn func(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error)
 }
 
 func NewDiscoveryAgent(scheme *runtime.Scheme, client client.Client, logger logr.Logger, manager crdManager.RenovateJobManager) DiscoveryAgent {
@@ -64,12 +64,12 @@ func NewDiscoveryAgent(scheme *runtime.Scheme, client client.Client, logger logr
 }
 
 // GetDiscoveryJobStatus implements DiscoveryAgent.
-func (e *discoveryAgent) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
-	return e.getDiscoveryJobStatusFn(ctx, job, generation)
+func (e *discoveryAgent) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error) {
+	return e.getDiscoveryJobStatusFn(ctx, job)
 }
 
 // getDiscoveryJobStatusInternal is the internal implementation of GetDiscoveryJobStatus.
-func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
+func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error) {
 	name := job.Fullname()
 	lock := e.syncer[name]
 	if lock == nil {
@@ -82,7 +82,6 @@ func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job 
 	existingDiscoveryJob, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
 		JobType:         crdManager.DiscoveryJobType,
 		Namespace:       job.Namespace,
-		Generation:      &generation,
 		RenovateJobName: job.Name,
 	})
 	if err != nil && errors.IsNotFound(err) {
@@ -97,7 +96,6 @@ func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job 
 			existingDiscoveryJob, err = crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
 				JobType:         crdManager.DiscoveryJobType,
 				Namespace:       job.Namespace,
-				Generation:      &generation,
 				RenovateJobName: job.Name,
 			})
 		}

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -35,7 +35,7 @@ type DiscoveryAgent interface {
 	// ProcessDiscoveryJobResult handles completion of a discovery k8s Job: extracts discovered projects,
 	// reconciles them into the RenovateJob CRD, schedules all projects, and optionally deletes the job.
 	// A nil k8sJob or a still-running job is a no-op.
-	ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobName string, namespace string) error
+	ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, jobId crdManager.RenovateJobIdentifier) error
 }
 
 type discoveryAgent struct {
@@ -118,7 +118,7 @@ func (e *discoveryAgent) getDiscoveryJobStatusInternal(ctx context.Context, job 
 // projects from its logs, reconciles them into the RenovateJob CRD, and optionally schedules
 // all non-running projects (controlled by the JOB_ANNOTATION_SCHEDULE_AFTER_DISCOVERY annotation).
 // A nil k8sJob or a still-running job is a no-op.
-func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobName string, namespace string) error {
+func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, jobId crdManager.RenovateJobIdentifier) error {
 	if k8sJob == nil {
 		return nil
 	}
@@ -131,11 +131,11 @@ func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *
 		return nil
 	}
 	if status == api.JobStatusFailed {
-		log.FromContext(ctx).Info("discovery job failed", "renovateJob", renovateJobName)
+		log.FromContext(ctx).Info("discovery job failed", "renovateJob", jobId.Name)
 		return nil
 	}
 
-	renovateJob, err := e.manager.GetRenovateJob(ctx, renovateJobName, namespace)
+	renovateJob, err := e.manager.GetRenovateJob(ctx, jobId.Name, jobId.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to load RenovateJob: %w", err)
 	}
@@ -144,7 +144,7 @@ func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *
 	if err != nil {
 		// Pod may already be gone (operator restart replaying old jobs, or TTL cleanup).
 		// Skip reconciliation — the next scheduled discovery will correct any drift.
-		log.FromContext(ctx).V(1).Info("skipping discovery result: could not read job logs", "renovateJob", renovateJobName, "error", err)
+		log.FromContext(ctx).V(1).Info("skipping discovery result: could not read job logs", "renovateJob", jobId.Name, "error", err)
 		return nil
 	}
 	log.FromContext(ctx).V(2).Info("Discovered projects", "count", len(projects), "job", renovateJob.Fullname())
@@ -157,10 +157,7 @@ func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *
 		isNotRunning := func(p api.ProjectStatus) bool {
 			return p.Status != api.JobStatusRunning
 		}
-		if err := e.manager.UpdateProjectStatusBatched(ctx, isNotRunning, crdManager.RenovateJobIdentifier{
-			Name:      renovateJobName,
-			Namespace: namespace,
-		}, &types.RenovateStatusUpdate{
+		if err := e.manager.UpdateProjectStatusBatched(ctx, isNotRunning, jobId, &types.RenovateStatusUpdate{
 			Status: api.JobStatusScheduled,
 		}); err != nil {
 			return fmt.Errorf("failed to schedule projects: %w", err)

--- a/src/internal/renovate/discoveryAgent_test.go
+++ b/src/internal/renovate/discoveryAgent_test.go
@@ -2,19 +2,78 @@ package renovate
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/config"
 	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/types"
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+// fakeJobManager is a minimal RenovateJobManager for discoveryAgent tests.
+type fakeJobManager struct {
+	getJobFn                     func(ctx context.Context, name, namespace string) (*api.RenovateJob, error)
+	reconcileProjectsFn          func(ctx context.Context, job *api.RenovateJob, projects []string) error
+	updateProjectStatusBatchedFn func(ctx context.Context, fn func(p api.ProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error
+}
+
+func (f *fakeJobManager) GetRenovateJob(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+	if f.getJobFn != nil {
+		return f.getJobFn(ctx, name, namespace)
+	}
+	return &api.RenovateJob{}, nil
+}
+func (f *fakeJobManager) ReconcileProjects(ctx context.Context, job *api.RenovateJob, projects []string) error {
+	if f.reconcileProjectsFn != nil {
+		return f.reconcileProjectsFn(ctx, job, projects)
+	}
+	return nil
+}
+func (f *fakeJobManager) UpdateProjectStatusBatched(ctx context.Context, fn func(p api.ProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
+	if f.updateProjectStatusBatchedFn != nil {
+		return f.updateProjectStatusBatchedFn(ctx, fn, job, status)
+	}
+	return nil
+}
+func (f *fakeJobManager) ListRenovateJobs(ctx context.Context) ([]crdManager.RenovateJobIdentifier, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (f *fakeJobManager) ListRenovateJobsFull(ctx context.Context) ([]api.RenovateJob, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (f *fakeJobManager) GetProjectsForRenovateJob(ctx context.Context, job crdManager.RenovateJobIdentifier) ([]crdManager.RenovateProjectStatus, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (f *fakeJobManager) UpdateProjectStatus(ctx context.Context, project string, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
+	return fmt.Errorf("not implemented")
+}
+func (f *fakeJobManager) GetProjectsByStatus(ctx context.Context, job crdManager.RenovateJobIdentifier, status api.RenovateProjectStatus) ([]crdManager.RenovateProjectStatus, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (f *fakeJobManager) GetLogsForProject(ctx context.Context, job crdManager.RenovateJobIdentifier, project string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+func (f *fakeJobManager) IsWebhookTokenValid(ctx context.Context, job crdManager.RenovateJobIdentifier, token string) (bool, error) {
+	return true, nil
+}
+func (f *fakeJobManager) IsWebhookSignatureValid(ctx context.Context, job crdManager.RenovateJobIdentifier, signature string, body []byte) (bool, error) {
+	return true, nil
+}
+func (f *fakeJobManager) UpdateExecutionOptions(ctx context.Context, job crdManager.RenovateJobIdentifier, options *api.RenovateExecutionOptions) error {
+	return nil
+}
+func (f *fakeJobManager) CancelProjectJob(ctx context.Context, project string, job crdManager.RenovateJobIdentifier) error {
+	return nil
+}
 
 // minimal logger for tests
 var testLogger = logr.Discard()
@@ -58,7 +117,7 @@ func TestGetDiscoveryJobStatus(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(running, failed, succeeded).Build()
 
-	daIface := NewDiscoveryAgent(scheme, c, testLogger)
+	daIface := NewDiscoveryAgent(scheme, c, testLogger, nil)
 	da := daIface.(*discoveryAgent)
 
 	tests := []struct {
@@ -87,7 +146,7 @@ func TestGetDiscoveryJobStatus(t *testing.T) {
 	}
 }
 
-func TestCreateDiscoveryJobAndWait(t *testing.T) {
+func TestCreateDiscoveryJob(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := api.AddToScheme(scheme); err != nil {
 		t.Fatalf("failed to add api scheme: %v", err)
@@ -99,38 +158,106 @@ func TestCreateDiscoveryJobAndWait(t *testing.T) {
 		t.Fatalf("failed to add core scheme: %v", err)
 	}
 
-	// initialize minimal config used by newDiscoveryJob
 	_ = config.InitializeConfigModule([]config.ConfigItemDescription{
 		{Key: "JOB_TIMEOUT_SECONDS", Optional: true, Default: "1"},
 	})
 
-	// start with no jobs - enable status subresource for Job
 	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&batchv1.Job{}).Build()
+	da := NewDiscoveryAgent(scheme, c, testLogger, nil).(*discoveryAgent)
 
-	da := NewDiscoveryAgent(scheme, c, testLogger).(*discoveryAgent)
-
-	// override log extraction to return a deterministic list
-	da.getDiscoveredProjectsFromJobLogsFn = func(ctx context.Context, c client.Client, job *batchv1.Job) ([]string, error) {
-		return []string{"a", "b"}, nil
-	}
-
-	// override status check to return completed immediately
-	da.getDiscoveryJobStatusFn = func(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
-		// Return completed on first call to simulate job completion
-		return api.JobStatusCompleted, nil
-	}
-
-	// create a RenovateJob and run Discover -> should create the job and return discovered projects
 	rj := &api.RenovateJob{}
 	rj.Name = "job1"
 	rj.Namespace = "ns"
 
-	projects, err := da.Discover(context.Background(), rj)
+	generation, err := da.CreateDiscoveryJob(context.Background(), *rj, false)
 	if err != nil {
-		t.Fatalf("Discover returned error: %v", err)
+		t.Fatalf("CreateDiscoveryJob returned error: %v", err)
 	}
-	if len(projects) != 2 {
-		t.Fatalf("expected 2 projects, got %d", len(projects))
+	if generation == "" {
+		t.Fatalf("expected non-empty generation")
+	}
+
+	// verify a k8s Job was actually created
+	jobList := &batchv1.JobList{}
+	if err := c.List(context.Background(), jobList); err != nil {
+		t.Fatalf("listing jobs: %v", err)
+	}
+	if len(jobList.Items) != 1 {
+		t.Fatalf("expected 1 job created, got %d", len(jobList.Items))
+	}
+}
+
+func TestProcessDiscoveryJobResult(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := api.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add api scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add batch scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	var capturedProjects []string
+	mgr := &fakeJobManager{
+		getJobFn: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+			return &api.RenovateJob{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}, nil
+		},
+		reconcileProjectsFn: func(ctx context.Context, job *api.RenovateJob, projects []string) error {
+			capturedProjects = projects
+			return nil
+		},
+	}
+
+	da := NewDiscoveryAgent(scheme, c, testLogger, mgr).(*discoveryAgent)
+	da.getDiscoveredProjectsFromJobLogsFn = func(ctx context.Context, c client.Client, job *batchv1.Job) ([]string, error) {
+		return []string{"a", "b"}, nil
+	}
+
+	// succeeded k8s Job (getJobStatus checks Conditions, not Succeeded counter)
+	k8sJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job1-discovery-abc", Namespace: "ns"},
+		Status: batchv1.JobStatus{
+			Conditions: []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	if err := da.ProcessDiscoveryJobResult(context.Background(), k8sJob, "job1", "ns"); err != nil {
+		t.Fatalf("ProcessDiscoveryJobResult returned error: %v", err)
+	}
+	if len(capturedProjects) != 2 {
+		t.Fatalf("expected 2 projects passed to ReconcileProjects, got %d", len(capturedProjects))
+	}
+}
+
+func TestProcessDiscoveryJobResult_NilJob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	da := NewDiscoveryAgent(scheme, c, testLogger, nil).(*discoveryAgent)
+
+	if err := da.ProcessDiscoveryJobResult(context.Background(), nil, "job1", "ns"); err != nil {
+		t.Fatalf("expected nil error for nil job, got: %v", err)
+	}
+}
+
+func TestProcessDiscoveryJobResult_RunningJob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add batch scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	da := NewDiscoveryAgent(scheme, c, testLogger, nil).(*discoveryAgent)
+
+	runningJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "job1-discovery-abc", Namespace: "ns"},
+	}
+	if err := da.ProcessDiscoveryJobResult(context.Background(), runningJob, "job1", "ns"); err != nil {
+		t.Fatalf("expected nil error for running job, got: %v", err)
 	}
 }
 

--- a/src/internal/renovate/discoveryAgent_test.go
+++ b/src/internal/renovate/discoveryAgent_test.go
@@ -135,7 +135,7 @@ func TestGetDiscoveryJobStatus(t *testing.T) {
 			job := &api.RenovateJob{}
 			job.Name = tc.jobName
 			job.Namespace = "ns"
-			got, err := da.GetDiscoveryJobStatus(context.Background(), job, "")
+			got, err := da.GetDiscoveryJobStatus(context.Background(), job)
 			if err != nil {
 				t.Fatalf("GetDiscoveryJobStatus error: %v", err)
 			}

--- a/src/internal/renovate/discoveryAgent_test.go
+++ b/src/internal/renovate/discoveryAgent_test.go
@@ -227,7 +227,10 @@ func TestProcessDiscoveryJobResult(t *testing.T) {
 		},
 	}
 
-	if err := da.ProcessDiscoveryJobResult(context.Background(), k8sJob, "job1", "ns"); err != nil {
+	if err := da.ProcessDiscoveryJobResult(context.Background(), k8sJob, crdManager.RenovateJobIdentifier{
+		Namespace: "ns",
+		Name:      "job1",
+	}); err != nil {
 		t.Fatalf("ProcessDiscoveryJobResult returned error: %v", err)
 	}
 	if len(capturedProjects) != 2 {
@@ -240,7 +243,10 @@ func TestProcessDiscoveryJobResult_NilJob(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(scheme).Build()
 	da := NewDiscoveryAgent(scheme, c, testLogger, nil).(*discoveryAgent)
 
-	if err := da.ProcessDiscoveryJobResult(context.Background(), nil, "job1", "ns"); err != nil {
+	if err := da.ProcessDiscoveryJobResult(context.Background(), nil, crdManager.RenovateJobIdentifier{
+		Namespace: "ns",
+		Name:      "job1",
+	}); err != nil {
 		t.Fatalf("expected nil error for nil job, got: %v", err)
 	}
 }
@@ -256,7 +262,10 @@ func TestProcessDiscoveryJobResult_RunningJob(t *testing.T) {
 	runningJob := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: "job1-discovery-abc", Namespace: "ns"},
 	}
-	if err := da.ProcessDiscoveryJobResult(context.Background(), runningJob, "job1", "ns"); err != nil {
+	if err := da.ProcessDiscoveryJobResult(context.Background(), runningJob, crdManager.RenovateJobIdentifier{
+		Namespace: "ns",
+		Name:      "job1",
+	}); err != nil {
 		t.Fatalf("expected nil error for running job, got: %v", err)
 	}
 }

--- a/src/internal/renovate/discoveryAgent_test.go
+++ b/src/internal/renovate/discoveryAgent_test.go
@@ -33,8 +33,8 @@ func TestGetDiscoveryJobStatus(t *testing.T) {
 	running.Name = "job1-discovery-b6caabe5"
 	running.Namespace = "ns"
 	running.Labels = map[string]string{
-		crdManager.JOB_LABEL_NAME: "job1-discovery-b6caabe5",
-		crdManager.JOB_LABEL_TYPE: string(crdManager.DiscoveryJobType),
+		crdManager.JOB_LABEL_RENOVATEJOB: "job1",
+		crdManager.JOB_LABEL_TYPE:        string(crdManager.DiscoveryJobType),
 	}
 
 	// failed job
@@ -43,8 +43,8 @@ func TestGetDiscoveryJobStatus(t *testing.T) {
 	failed.Namespace = "ns"
 	failed.Status.Failed = 1
 	failed.Labels = map[string]string{
-		crdManager.JOB_LABEL_NAME: "job2-discovery-2e2a0d0f",
-		crdManager.JOB_LABEL_TYPE: string(crdManager.DiscoveryJobType),
+		crdManager.JOB_LABEL_RENOVATEJOB: "job2",
+		crdManager.JOB_LABEL_TYPE:        string(crdManager.DiscoveryJobType),
 	}
 	// succeeded job
 	succeeded := &batchv1.Job{}
@@ -52,8 +52,8 @@ func TestGetDiscoveryJobStatus(t *testing.T) {
 	succeeded.Namespace = "ns"
 	succeeded.Status.Succeeded = 1
 	succeeded.Labels = map[string]string{
-		crdManager.JOB_LABEL_NAME: "job3-discovery-b42e63e1",
-		crdManager.JOB_LABEL_TYPE: string(crdManager.DiscoveryJobType),
+		crdManager.JOB_LABEL_RENOVATEJOB: "job3",
+		crdManager.JOB_LABEL_TYPE:        string(crdManager.DiscoveryJobType),
 	}
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(running, failed, succeeded).Build()

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -166,9 +166,10 @@ func (e *renovateExecutor) reconcileRunning(ctx context.Context, renovateJobs []
 			}
 
 			k8sJob, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
-				JobName:   utils.ExecutorJobName(renovateJob, project.Name),
-				JobType:   crdManager.ExecutorJobType,
-				Namespace: renovateJob.Namespace,
+				JobType:         crdManager.ExecutorJobType,
+				Namespace:       renovateJob.Namespace,
+				RenovateJobName: renovateJob.Name,
+				Project:         project.Name,
 			})
 
 			var newStatus api.RenovateProjectStatus
@@ -325,9 +326,10 @@ func (e *renovateExecutor) dispatchScheduled(ctx context.Context, renovateJobs [
 		}
 
 		_, err := crdManager.CreateJobWithGeneration(ctx, e.client, k8sJob, crdManager.JobSelector{
-			JobName:   utils.ExecutorJobName(renovateJob, project.Name),
-			JobType:   crdManager.ExecutorJobType,
-			Namespace: renovateJob.Namespace,
+			JobType:         crdManager.ExecutorJobType,
+			Namespace:       renovateJob.Namespace,
+			RenovateJobName: renovateJob.Name,
+			Project:         project.Name,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -258,6 +258,12 @@ func (e *renovateExecutor) ProcessProjectJobResult(ctx context.Context, k8sJob *
 		return err
 	}
 
+	if k8sJob != nil {
+		if err := crdManager.MarkJobProcessed(ctx, e.client, k8sJob); err != nil {
+			log.FromContext(ctx).Error(err, "failed to mark executor job as processed", "job", k8sJob.Name)
+		}
+	}
+
 	if newStatus == api.JobStatusCompleted && config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" && k8sJob != nil {
 		if err := crdManager.DeleteJob(ctx, e.client, k8sJob); err != nil {
 			return err

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -150,9 +150,8 @@ func (e *renovateExecutor) execute(ctx context.Context, options executionOptions
 	return err
 }
 
-// reconcileRunning iterates over all Running projects across all RenovateJobs, checks their
-// Kubernetes Job status, updates finished ones, and returns the number of still-running projects
-// globally and per job (keyed by job fullname).
+// countRunningProjects returns the number of still-running projects globally and per job
+// (keyed by job fullname).
 func (e *renovateExecutor) countRunningProjects(renovateJobs []api.RenovateJob) (int, map[string]int, error) {
 	globalRunning := 0
 	perJobRunning := make(map[string]int, len(renovateJobs))
@@ -168,11 +167,8 @@ func (e *renovateExecutor) countRunningProjects(renovateJobs []api.RenovateJob) 
 			if project.Status != api.JobStatusRunning {
 				continue
 			}
-
-			if project.Status == api.JobStatusRunning {
-				globalRunning++
-				perJobRunning[key]++
-			}
+			globalRunning++
+			perJobRunning[key]++
 		}
 	}
 

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
-	"k8s.io/apimachinery/pkg/api/errors"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -43,6 +43,10 @@ It checks the status of each project and starts new jobs as needed based on the 
 type RenovateExecutor interface {
 	// Start begins the periodic execution of RenovateJob CRDs.
 	Start(ctx context.Context) error
+	// ProcessProjectJobResult handles the status transition of a single Running project given its
+	// k8s Job. A nil k8sJob means the job was not found and is treated as failed.
+	// Updates metrics, logs, and CRD status. Returns true if the project is still running.
+	ProcessProjectJobResult(ctx context.Context, k8sJob *batchv1.Job, project string, jobId crdManager.RenovateJobIdentifier) error
 }
 
 type renovateExecutor struct {
@@ -129,7 +133,7 @@ func (e *renovateExecutor) execute(ctx context.Context, options executionOptions
 
 	// Pass 1: check all currently running projects across all jobs, update their statuses,
 	// and count how many are still running globally and per job.
-	globalRunning, perJobRunning, err := e.reconcileRunning(ctx, renovateJobs)
+	globalRunning, perJobRunning, err := e.countRunningProjects(renovateJobs)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -149,7 +153,7 @@ func (e *renovateExecutor) execute(ctx context.Context, options executionOptions
 // reconcileRunning iterates over all Running projects across all RenovateJobs, checks their
 // Kubernetes Job status, updates finished ones, and returns the number of still-running projects
 // globally and per job (keyed by job fullname).
-func (e *renovateExecutor) reconcileRunning(ctx context.Context, renovateJobs []api.RenovateJob) (int, map[string]int, error) {
+func (e *renovateExecutor) countRunningProjects(renovateJobs []api.RenovateJob) (int, map[string]int, error) {
 	globalRunning := 0
 	perJobRunning := make(map[string]int, len(renovateJobs))
 
@@ -165,88 +169,106 @@ func (e *renovateExecutor) reconcileRunning(ctx context.Context, renovateJobs []
 				continue
 			}
 
-			k8sJob, err := crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
-				JobType:         crdManager.ExecutorJobType,
-				Namespace:       renovateJob.Namespace,
-				RenovateJobName: renovateJob.Name,
-				Project:         project.Name,
-			})
-
-			var newStatus api.RenovateProjectStatus
-			var durationStr string
-			if err != nil {
-				if errors.IsNotFound(err) {
-					newStatus = api.JobStatusFailed
-				} else {
-					return 0, nil, err
-				}
-			} else {
-				newStatus, durationStr, err = getJobStatus(k8sJob)
-				if err != nil {
-					return 0, nil, err
-				}
-			}
-
-			if newStatus == api.JobStatusRunning {
+			if project.Status == api.JobStatusRunning {
 				globalRunning++
 				perJobRunning[key]++
-				continue
-			}
-
-			// Job finished — collect metrics and update CRD status.
-			newProjectStatus := &types.RenovateStatusUpdate{
-				Status:   newStatus,
-				Duration: &durationStr,
-			}
-			hasIssues := false
-			if k8sJob != nil {
-				cp := clientProvider.StaticClientProvider()
-				if clientset, err := cp.K8sClientSet(); err == nil {
-					if logs, err := crdManager.GetLastJobLog(ctx, clientset, k8sJob); err == nil {
-						e.logStore.Save(renovateJob.Namespace, renovateJob.Name, project.Name, logs)
-						parseResult := parser.ParseRenovateLogs(logs)
-						hasIssues = parseResult.HasIssues
-						newProjectStatus.RenovateResultStatus = parseResult.RenovateResultStatus
-						newProjectStatus.PRActivity = parseResult.PRActivity
-						newProjectStatus.LogIssues = parseResult.LogIssues
-					} else {
-						log.FromContext(ctx).Error(err, "failed to get logs for metrics parsing", "project", project.Name)
-					}
-				} else {
-					log.FromContext(ctx).Error(err, "failed to create Kubernetes clientset for metrics parsing", "project", project.Name)
-				}
-			}
-
-			metricStore.SetRunFailed(renovateJob.Namespace, renovateJob.Name, project.Name, newStatus == api.JobStatusFailed)
-			metricStore.SetDependencyIssues(renovateJob.Namespace, renovateJob.Name, project.Name, hasIssues)
-			approvalsNeeded := 0
-			if newProjectStatus.PRActivity != nil {
-				approvalsNeeded = newProjectStatus.PRActivity.NeedsApproval
-			}
-			metricStore.SetApprovalsNeeded(renovateJob.Namespace, renovateJob.Name, project.Name, approvalsNeeded)
-			metricStore.CaptureRenovateProjectExecution(ctx, renovateJob.Namespace, renovateJob.Name, project.Name, newStatus)
-
-			if span := trace.SpanFromContext(ctx); span.IsRecording() {
-				span.AddEvent("project.completed", trace.WithAttributes(
-					semconv.K8SNamespaceName(renovateJob.Namespace),
-					semconv.K8SJobName(utils.ExecutorJobName(renovateJob, project.Name)),
-					metricStore.MapPipelineResult(newStatus),
-				))
-			}
-
-			if err := e.manager.UpdateProjectStatus(ctx, project.Name, jobId, newProjectStatus); err != nil {
-				return 0, nil, err
-			}
-
-			if newStatus == api.JobStatusCompleted && config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" && k8sJob != nil {
-				if err := crdManager.DeleteJob(ctx, e.client, k8sJob); err != nil {
-					return 0, nil, err
-				}
 			}
 		}
 	}
 
 	return globalRunning, perJobRunning, nil
+}
+
+// ProcessProjectJobResult handles the status transition of a single Running project given its
+// k8s Job. A nil k8sJob means the job was not found and is treated as failed.
+// Updates metrics, logs, and CRD status. Returns true if the project is still running.
+func (e *renovateExecutor) ProcessProjectJobResult(ctx context.Context, k8sJob *batchv1.Job, project string, jobId crdManager.RenovateJobIdentifier) error {
+	var newStatus api.RenovateProjectStatus
+	var durationStr string
+	if k8sJob == nil {
+		newStatus = api.JobStatusFailed
+	} else {
+		var err error
+		newStatus, durationStr, err = getJobStatus(k8sJob)
+		if err != nil {
+			return err
+		}
+	}
+
+	if newStatus == api.JobStatusRunning {
+		return nil
+	}
+
+	// Guard: only proceed if the project is still Running in the CRD.
+	// Without this, the job controller replays all existing Jobs on startup and
+	// tries to fetch logs for pods that are long gone.
+	renovateJob, err := e.manager.GetRenovateJob(ctx, jobId.Name, jobId.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to load RenovateJob for status check: %w", err)
+	}
+	projectIsRunning := false
+	for _, p := range renovateJob.Status.Projects {
+		if p.Name == project && p.Status == api.JobStatusRunning {
+			projectIsRunning = true
+			break
+		}
+	}
+	if !projectIsRunning {
+		return nil
+	}
+
+	// Job finished — collect metrics and update CRD status.
+	newProjectStatus := &types.RenovateStatusUpdate{
+		Status:   newStatus,
+		Duration: &durationStr,
+	}
+	hasIssues := false
+	if k8sJob != nil {
+		cp := clientProvider.StaticClientProvider()
+		if clientset, err := cp.K8sClientSet(); err == nil {
+			if logs, err := crdManager.GetLastJobLog(ctx, clientset, k8sJob); err == nil {
+				e.logStore.Save(jobId.Namespace, jobId.Name, project, logs)
+				parseResult := parser.ParseRenovateLogs(logs)
+				hasIssues = parseResult.HasIssues
+				newProjectStatus.RenovateResultStatus = parseResult.RenovateResultStatus
+				newProjectStatus.PRActivity = parseResult.PRActivity
+				newProjectStatus.LogIssues = parseResult.LogIssues
+			} else {
+				log.FromContext(ctx).Error(err, "failed to get logs for metrics parsing", "project", project)
+			}
+		} else {
+			log.FromContext(ctx).Error(err, "failed to create Kubernetes clientset for metrics parsing", "project", project)
+		}
+	}
+
+	metricStore.SetRunFailed(jobId.Namespace, jobId.Name, project, newStatus == api.JobStatusFailed)
+	metricStore.SetDependencyIssues(jobId.Namespace, jobId.Name, project, hasIssues)
+	approvalsNeeded := 0
+	if newProjectStatus.PRActivity != nil {
+		approvalsNeeded = newProjectStatus.PRActivity.NeedsApproval
+	}
+	metricStore.SetApprovalsNeeded(jobId.Namespace, jobId.Name, project, approvalsNeeded)
+	metricStore.CaptureRenovateProjectExecution(ctx, jobId.Namespace, jobId.Name, project, newStatus)
+
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		span.AddEvent("project.completed", trace.WithAttributes(
+			semconv.K8SNamespaceName(jobId.Namespace),
+			semconv.K8SJobName(k8sJob.GetName()),
+			metricStore.MapPipelineResult(newStatus),
+		))
+	}
+
+	if err := e.manager.UpdateProjectStatus(ctx, project, jobId, newProjectStatus); err != nil {
+		return err
+	}
+
+	if newStatus == api.JobStatusCompleted && config.GetValue("DELETE_SUCCESSFUL_JOBS") == "true" && k8sJob != nil {
+		if err := crdManager.DeleteJob(ctx, e.client, k8sJob); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // scheduledCandidate is a project ready to be dispatched together with its parent RenovateJob.

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -2,12 +2,10 @@ package renovate
 
 import (
 	"encoding/json"
-	"maps"
 	"os"
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/config"
 	"renovate-operator/github"
-	crdmanager "renovate-operator/internal/crdManager"
 	"renovate-operator/internal/utils"
 	"strconv"
 	"strings"
@@ -108,10 +106,9 @@ func newDiscoveryJob(job *api.RenovateJob, traceparent string) *batchv1.Job {
 	if job.Spec.Metadata != nil {
 		batchJob.Spec.Template.Annotations = job.Spec.Metadata.Annotations
 		batchJob.Annotations = job.Spec.Metadata.Annotations
+		batchJob.Labels = job.Spec.Metadata.Labels
+		batchJob.Spec.Template.Labels = job.Spec.Metadata.Labels
 	}
-	labels := getJobLabels(job.Spec.Metadata, crdmanager.DiscoveryJobType, jobName)
-	batchJob.Spec.Template.Labels = labels
-	batchJob.Labels = labels
 	return batchJob
 }
 
@@ -193,10 +190,9 @@ func newRenovateJob(job *api.RenovateJob, project string, traceparent string) *b
 	if job.Spec.Metadata != nil {
 		batchJob.Spec.Template.Annotations = job.Spec.Metadata.Annotations
 		batchJob.Annotations = job.Spec.Metadata.Annotations
+		batchJob.Labels = job.Spec.Metadata.Labels
+		batchJob.Spec.Template.Labels = job.Spec.Metadata.Labels
 	}
-	labels := getJobLabels(job.Spec.Metadata, crdmanager.ExecutorJobType, jobName)
-	batchJob.Labels = labels
-	batchJob.Spec.Template.Labels = labels
 	return batchJob
 }
 
@@ -335,17 +331,6 @@ func getJobTTLSecondsAfterFinished() *int32 {
 		return nil
 	}
 	return new(int32(val))
-}
-
-func getJobLabels(metadata *api.RenovateJobMetadata, jobType crdmanager.JobType, jobName string) map[string]string {
-	labels := map[string]string{
-		crdmanager.JOB_LABEL_TYPE: string(jobType),
-		crdmanager.JOB_LABEL_NAME: jobName,
-	}
-	if metadata != nil {
-		maps.Copy(labels, metadata.Labels)
-	}
-	return labels
 }
 
 // imagePullSecrets configured at the operator level via IMAGE_PULL_SECRETS env var

--- a/src/internal/renovate/jobDefinitions_test.go
+++ b/src/internal/renovate/jobDefinitions_test.go
@@ -618,18 +618,6 @@ func expectLabels(t *testing.T, job *batchv1.Job, expectedLabels map[string]stri
 			t.Fatalf("expected job label %s=%s, got %s", k, v, job.Labels[k])
 		}
 	}
-	defaultLabels := map[string]string{
-		"renovate-operator.mogenius.com/job-type": jobType,
-		"renovate-operator.mogenius.com/job-name": jobName,
-	}
-	for k, v := range defaultLabels {
-		if job.Spec.Template.Labels[k] != v {
-			t.Fatalf("expected default template label %s=%s, got %s", k, v, job.Spec.Template.Labels[k])
-		}
-		if job.Labels[k] != v {
-			t.Fatalf("expected default job label %s=%s, got %s", k, v, job.Labels[k])
-		}
-	}
 }
 
 func expectImage(t *testing.T, container *v1.Container, expectedImage string) {

--- a/src/internal/webhookSync/manager.go
+++ b/src/internal/webhookSync/manager.go
@@ -1,0 +1,243 @@
+package webhookSync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	api "renovate-operator/api/v1alpha1"
+	"renovate-operator/gitProviderClients/forgejoProvider"
+	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/utils"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const SyncStateAnnotation = "renovate-operator.mogenius.com/webhook-sync-managed-repos"
+
+type WebhookSyncManager interface {
+	// EnsureSyncer creates, updates, or removes the WebhookSyncer for a RenovateJob
+	// based on the webhook.forgejo.sync configuration.
+	EnsureSyncer(ctx context.Context, logger logr.Logger, renovateJob *api.RenovateJob)
+	// RunSync executes one webhook sync cycle for the given job, if a syncer is configured.
+	RunSync(ctx context.Context, logger logr.Logger, jobName, jobNamespace string)
+	// RemoveSyncer removes the syncer entry for the given job (called on RenovateJob deletion).
+	RemoveSyncer(name string)
+}
+
+type syncerEntry struct {
+	syncer      *WebhookSyncer
+	fingerprint string
+}
+
+type webhookSyncManager struct {
+	syncers    map[string]*syncerEntry
+	k8sClient  client.Client
+	jobManager crdManager.RenovateJobManager
+}
+
+func NewWebhookSyncManager(k8sClient client.Client, jobManager crdManager.RenovateJobManager) WebhookSyncManager {
+	return &webhookSyncManager{
+		syncers:    make(map[string]*syncerEntry),
+		k8sClient:  k8sClient,
+		jobManager: jobManager,
+	}
+}
+
+func (m *webhookSyncManager) RemoveSyncer(name string) {
+	delete(m.syncers, name)
+}
+
+func (m *webhookSyncManager) EnsureSyncer(ctx context.Context, logger logr.Logger, renovateJob *api.RenovateJob) {
+	name := renovateJob.Fullname()
+
+	if renovateJob.Spec.Webhook == nil || renovateJob.Spec.Webhook.Forgejo == nil ||
+		renovateJob.Spec.Webhook.Forgejo.Sync == nil || !renovateJob.Spec.Webhook.Forgejo.Sync.Enabled {
+		delete(m.syncers, name)
+		return
+	}
+
+	syncCfg := renovateJob.Spec.Webhook.Forgejo.Sync
+	_, providerEndpoint := utils.GetPlatformAndEndpoint(renovateJob.Spec.Provider)
+	fp := syncFingerprint(syncCfg, providerEndpoint, renovateJob.Spec.DiscoverTopics, renovateJob.Namespace, renovateJob.Name)
+
+	if entry, exists := m.syncers[name]; exists && entry.fingerprint == fp {
+		return
+	}
+
+	jobNamespace := renovateJob.Namespace
+
+	if syncCfg.TokenSecretRef == nil {
+		logger.Error(fmt.Errorf("tokenSecretRef is required when webhook sync is enabled"), "cannot initialize webhook syncer without a Forgejo API token")
+		return
+	}
+
+	forgejoToken, err := m.readSecretKey(ctx, syncCfg.TokenSecretRef, jobNamespace)
+	if err != nil {
+		logger.Error(err, "failed to read Forgejo API token for webhook sync")
+		return
+	}
+
+	var authToken string
+	if syncCfg.AuthTokenSecretRef != nil {
+		authToken, err = m.readSecretKey(ctx, syncCfg.AuthTokenSecretRef, jobNamespace)
+		if err != nil {
+			logger.Error(err, "failed to read auth token for webhook sync")
+			return
+		}
+	}
+
+	topic := syncCfg.Topic
+	if topic == "" && len(renovateJob.Spec.DiscoverTopics) > 0 {
+		topic = renovateJob.Spec.DiscoverTopics[0]
+	}
+
+	webhookURL := syncCfg.WebhookURL
+	parsed, err := url.Parse(webhookURL)
+	if err != nil {
+		logger.Error(err, "failed to parse webhookURL")
+		return
+	}
+	q := parsed.Query()
+	q.Set("namespace", renovateJob.Namespace)
+	q.Set("job", renovateJob.Name)
+	parsed.RawQuery = q.Encode()
+	webhookURL = parsed.String()
+
+	if providerEndpoint == "" {
+		logger.Error(fmt.Errorf("provider endpoint is required when webhook sync is enabled"), "cannot initialize webhook syncer without a Forgejo endpoint")
+		return
+	}
+
+	forgejoClient := forgejoProvider.NewClient(providerEndpoint, forgejoToken)
+	syncer := NewWebhookSyncer(
+		forgejoClient,
+		webhookURL,
+		authToken,
+		topic,
+		syncCfg.Events,
+		logger.WithName("webhook-sync"),
+	)
+
+	// Transfer managed repos state: prefer in-memory from old syncer,
+	// fall back to persisted annotation (covers operator restart).
+	if oldEntry, exists := m.syncers[name]; exists {
+		syncer.SetManagedRepos(oldEntry.syncer.ManagedRepos())
+	} else {
+		state := loadWebhookSyncState(renovateJob)
+		if len(state) > 0 {
+			syncer.SetManagedRepos(state)
+			logger.V(2).Info("restored webhook sync state from annotation", "repos", len(state))
+		}
+	}
+
+	m.syncers[name] = &syncerEntry{syncer: syncer, fingerprint: fp}
+}
+
+func (m *webhookSyncManager) RunSync(ctx context.Context, logger logr.Logger, jobName, jobNamespace string) {
+	name := jobName + "-" + jobNamespace
+	entry, ok := m.syncers[name]
+	if !ok {
+		return
+	}
+	state, err := entry.syncer.RunOnce(ctx)
+	if err != nil {
+		logger.Error(err, "webhook sync failed")
+	}
+	if state != nil {
+		m.saveWebhookSyncState(ctx, logger, jobName, jobNamespace, entry.syncer, state)
+	}
+}
+
+func syncFingerprint(cfg *api.RenovateWebhookForgejoSync, endpoint string, defaultTopic []string, namespace, jobName string) string {
+	topic := cfg.Topic
+	if topic == "" && len(defaultTopic) > 0 {
+		topic = defaultTopic[0]
+	}
+	tokenRef := ""
+	if cfg.TokenSecretRef != nil {
+		tokenRef = cfg.TokenSecretRef.Name + "/" + cfg.TokenSecretRef.Key
+	}
+	authRef := ""
+	if cfg.AuthTokenSecretRef != nil {
+		authRef = cfg.AuthTokenSecretRef.Name + "/" + cfg.AuthTokenSecretRef.Key
+	}
+	events := strings.Join(cfg.Events, ",")
+	return fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s", endpoint, cfg.WebhookURL, topic, events, tokenRef, authRef, namespace+"/"+jobName)
+}
+
+func loadWebhookSyncState(renovateJob *api.RenovateJob) map[string]int64 {
+	if renovateJob.Annotations == nil {
+		return nil
+	}
+	raw, ok := renovateJob.Annotations[SyncStateAnnotation]
+	if !ok || raw == "" {
+		return nil
+	}
+	var state map[string]int64
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return nil
+	}
+	return state
+}
+
+func (m *webhookSyncManager) saveWebhookSyncState(ctx context.Context, logger logr.Logger, jobName, jobNamespace string, syncer *WebhookSyncer, state map[string]int64) {
+	renovateJob, err := m.jobManager.GetRenovateJob(ctx, jobName, jobNamespace)
+	if err != nil {
+		logger.Error(err, "failed to fetch RenovateJob for saving webhook sync state")
+		return
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		logger.Error(err, "failed to marshal webhook sync state")
+		return
+	}
+
+	newVal := string(data)
+	if renovateJob.Annotations != nil && renovateJob.Annotations[SyncStateAnnotation] == newVal {
+		return
+	}
+
+	var previousState map[string]int64
+	if raw, ok := renovateJob.Annotations[SyncStateAnnotation]; ok && raw != "" {
+		if err := json.Unmarshal([]byte(raw), &previousState); err != nil {
+			previousState = nil
+		}
+	}
+
+	if renovateJob.Annotations == nil {
+		renovateJob.Annotations = make(map[string]string)
+	}
+	renovateJob.Annotations[SyncStateAnnotation] = newVal
+
+	if err := m.k8sClient.Update(ctx, renovateJob); err != nil {
+		logger.Error(err, "failed to save webhook sync state annotation, rolling back in-memory state to last persisted value")
+		if previousState != nil {
+			syncer.SetManagedRepos(previousState)
+		}
+	}
+}
+
+func (m *webhookSyncManager) readSecretKey(ctx context.Context, ref *api.RenovateSecretKeyReference, namespace string) (string, error) {
+	if ref == nil {
+		return "", fmt.Errorf("secret reference is nil")
+	}
+	secret := &corev1.Secret{}
+	err := m.k8sClient.Get(ctx, client.ObjectKey{
+		Name:      ref.Name,
+		Namespace: namespace,
+	}, secret)
+	if err != nil {
+		return "", fmt.Errorf("reading secret %s: %w", ref.Name, err)
+	}
+	data, ok := secret.Data[ref.Key]
+	if !ok {
+		return "", fmt.Errorf("key %s not found in secret %s", ref.Key, ref.Name)
+	}
+	return string(data), nil
+}

--- a/src/internal/webhookSync/manager.go
+++ b/src/internal/webhookSync/manager.go
@@ -24,7 +24,7 @@ type WebhookSyncManager interface {
 	// based on the webhook.forgejo.sync configuration.
 	EnsureSyncer(ctx context.Context, logger logr.Logger, renovateJob *api.RenovateJob)
 	// RunSync executes one webhook sync cycle for the given job, if a syncer is configured.
-	RunSync(ctx context.Context, logger logr.Logger, jobName, jobNamespace string)
+	RunSync(ctx context.Context, logger logr.Logger, jobId crdManager.RenovateJobIdentifier)
 	// RemoveSyncer removes the syncer entry for the given job (called on RenovateJob deletion).
 	RemoveSyncer(name string)
 }
@@ -138,8 +138,8 @@ func (m *webhookSyncManager) EnsureSyncer(ctx context.Context, logger logr.Logge
 	m.syncers[name] = &syncerEntry{syncer: syncer, fingerprint: fp}
 }
 
-func (m *webhookSyncManager) RunSync(ctx context.Context, logger logr.Logger, jobName, jobNamespace string) {
-	name := jobName + "-" + jobNamespace
+func (m *webhookSyncManager) RunSync(ctx context.Context, logger logr.Logger, jobId crdManager.RenovateJobIdentifier) {
+	name := jobId.Name + "-" + jobId.Namespace
 	entry, ok := m.syncers[name]
 	if !ok {
 		return
@@ -149,7 +149,7 @@ func (m *webhookSyncManager) RunSync(ctx context.Context, logger logr.Logger, jo
 		logger.Error(err, "webhook sync failed")
 	}
 	if state != nil {
-		m.saveWebhookSyncState(ctx, logger, jobName, jobNamespace, entry.syncer, state)
+		m.saveWebhookSyncState(ctx, logger, jobId.Name, jobId.Namespace, entry.syncer, state)
 	}
 }
 

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	api "renovate-operator/api/v1alpha1"
@@ -525,26 +524,11 @@ func (s *Server) runDiscoveryForProject(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	generation, err := s.discovery.CreateDiscoveryJob(ctx, *job)
-	if err != nil {
+	if _, err := s.discovery.CreateDiscoveryJob(ctx, *job, false); err != nil {
 		s.logger.Error(err, "Failed to start discovery for RenovateJob", "renovateJob", params.name, "namespace", params.namespace)
 		internalServerError(w, err, "failed to create discovery job")
 		return
 	}
-	go func() {
-		ctxBackground := context.Background()
-		projects, err := s.discovery.WaitForDiscoveryJob(ctxBackground, job, generation)
-		if err != nil {
-			s.logger.Error(err, "Discovery job failed for RenovateJob", "renovateJob", params.name, "namespace", params.namespace)
-			return
-		}
-
-		err = s.manager.ReconcileProjects(ctxBackground, job, projects)
-		if err != nil {
-			s.logger.Error(err, "failed to reconcile projects")
-			return
-		}
-	}()
 
 	writeSuccess(w, SuccessResult{Message: "discovery job started"})
 	s.logger.V(2).Info("Successfully started discovery for RenovateJob", "renovateJob", params.name, "namespace", params.namespace)

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -240,7 +240,7 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 	for i := range renovateJobs {
 		renovateJob := &renovateJobs[i]
 
-		discoveryStatus, err := s.discovery.GetDiscoveryJobStatus(r.Context(), renovateJob, "")
+		discoveryStatus, err := s.discovery.GetDiscoveryJobStatus(r.Context(), renovateJob)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				discoveryStatus = api.JobStatusScheduled
@@ -517,7 +517,7 @@ func (s *Server) runDiscoveryForProject(w http.ResponseWriter, r *http.Request) 
 
 	ctx := r.Context()
 	// discovery mus only run once
-	status, err := s.discovery.GetDiscoveryJobStatus(ctx, job, "")
+	status, err := s.discovery.GetDiscoveryJobStatus(ctx, job)
 	if err == nil && status == api.JobStatusRunning {
 		// discovery job is already running
 		writeSuccess(w, SuccessResult{Message: "discovery job is already running"})
@@ -589,7 +589,7 @@ func (s *Server) discoveryStatusForProject(w http.ResponseWriter, r *http.Reques
 		internalServerError(w, nil, "failed to get renovate job")
 		return
 	}
-	status, err := s.discovery.GetDiscoveryJobStatus(ctx, job, "")
+	status, err := s.discovery.GetDiscoveryJobStatus(ctx, job)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			status = api.JobStatusScheduled

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -121,13 +121,13 @@ func (m *mockRenovateJobManager) CancelProjectJob(ctx context.Context, project s
 
 // Mock DiscoveryAgent
 type mockDiscoveryAgent struct {
-	getDiscoveryJobStatusFunc func(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error)
+	getDiscoveryJobStatusFunc func(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error)
 	createDiscoveryJobFunc    func(ctx context.Context, renovateJob api.RenovateJob) error
 }
 
-func (m *mockDiscoveryAgent) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
+func (m *mockDiscoveryAgent) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error) {
 	if m.getDiscoveryJobStatusFunc != nil {
-		return m.getDiscoveryJobStatusFunc(ctx, job, generation)
+		return m.getDiscoveryJobStatusFunc(ctx, job)
 	}
 	return api.JobStatusScheduled, nil
 }
@@ -327,7 +327,7 @@ func TestDiscoveryStatusForProject_Success(t *testing.T) {
 	}
 
 	mockDiscovery := &mockDiscoveryAgent{
-		getDiscoveryJobStatusFunc: func(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
+		getDiscoveryJobStatusFunc: func(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error) {
 			return api.JobStatusRunning, nil
 		},
 	}
@@ -373,7 +373,7 @@ func TestDiscoveryStatusForProject_NotFound(t *testing.T) {
 	}
 
 	mockDiscovery := &mockDiscoveryAgent{
-		getDiscoveryJobStatusFunc: func(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
+		getDiscoveryJobStatusFunc: func(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error) {
 			return "", k8serrors.NewNotFound(schema.GroupResource{}, "job1")
 		},
 	}
@@ -420,7 +420,7 @@ func TestRunDiscoveryForProject_AlreadyRunning(t *testing.T) {
 	}
 
 	mockDiscovery := &mockDiscoveryAgent{
-		getDiscoveryJobStatusFunc: func(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
+		getDiscoveryJobStatusFunc: func(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error) {
 			return api.JobStatusRunning, nil
 		},
 	}

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -139,7 +139,7 @@ func (m *mockDiscoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob
 	return "", nil
 }
 
-func (m *mockDiscoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobName string, namespace string) error {
+func (m *mockDiscoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, jobId crdmanager.RenovateJobIdentifier) error {
 	return nil
 }
 

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -122,11 +123,6 @@ func (m *mockRenovateJobManager) CancelProjectJob(ctx context.Context, project s
 type mockDiscoveryAgent struct {
 	getDiscoveryJobStatusFunc func(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error)
 	createDiscoveryJobFunc    func(ctx context.Context, renovateJob api.RenovateJob) error
-	waitForDiscoveryJobFunc   func(ctx context.Context, job *api.RenovateJob, generation string) ([]string, error)
-}
-
-func (m *mockDiscoveryAgent) Discover(ctx context.Context, job *api.RenovateJob) ([]string, error) {
-	return nil, nil
 }
 
 func (m *mockDiscoveryAgent) GetDiscoveryJobStatus(ctx context.Context, job *api.RenovateJob, generation string) (api.RenovateProjectStatus, error) {
@@ -136,18 +132,15 @@ func (m *mockDiscoveryAgent) GetDiscoveryJobStatus(ctx context.Context, job *api
 	return api.JobStatusScheduled, nil
 }
 
-func (m *mockDiscoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob) (string, error) {
+func (m *mockDiscoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api.RenovateJob, scheduleAfterCompletion bool) (string, error) {
 	if m.createDiscoveryJobFunc != nil {
 		return "", m.createDiscoveryJobFunc(ctx, renovateJob)
 	}
 	return "", nil
 }
 
-func (m *mockDiscoveryAgent) WaitForDiscoveryJob(ctx context.Context, job *api.RenovateJob, generation string) ([]string, error) {
-	if m.waitForDiscoveryJobFunc != nil {
-		return m.waitForDiscoveryJobFunc(ctx, job, generation)
-	}
-	return []string{}, nil
+func (m *mockDiscoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *batchv1.Job, renovateJobName string, namespace string) error {
+	return nil
 }
 
 func TestGetRenovateJobs_Success(t *testing.T) {


### PR DESCRIPTION
This branch replaces the operator's polling-based job tracking with a reactive, event-driven reconciler pattern. The key changes:

**New `JobReconciler`** — a Kubernetes controller watching `batchv1.Job` resources. When a discovery or executor job completes, it fires `ProcessDiscoveryJobResult` / `ProcessProjectJobResult` immediately, rather than waiting for the next executor tick (every 10 s).

**Discovery goes async** — `DiscoveryAgent.Discover()` (create job → poll → wait → return results) is removed. Now the cron just calls `CreateDiscoveryJob()` and returns. Completion is handled reactively by `JobReconciler`, including project reconciliation, scheduling, and webhook sync.

**Executor loop simplified** — `reconcileRunning()` no longer walks every running project and hits the k8s API for each one. That logic is extracted to `ProcessProjectJobResult()` and triggered on the reconcile event. The executor loop now only counts running projects (no API calls) and dispatches new ones.

**WebhookSync extracted** — the `webhookSyncers` map and all its lifecycle code is pulled out of `RenovateJobReconciler` into a dedicated `WebhookSyncManager` interface.

**Orphan recovery** — `resetOrphanedRunning()` is called on every RenovateJob reconcile to detect projects stuck in `Running` state whose k8s Job no longer exists (e.g. operator was down during completion) and marks them `Failed`.