### PR TITLE
feat(ui): reflect selected dashboard filter in URL

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -504,15 +504,32 @@
           pending: "Pending",
           withIssues: "With Issues",
         };
+        const STAT_FILTER_PARAM = "filter";
 
         const [selectedStatFilter, setSelectedStatFilter] = useState(() => {
           try {
+            const fromUrl = new URLSearchParams(window.location.search).get(STAT_FILTER_PARAM);
+            if (fromUrl && STAT_FILTER_LABELS[fromUrl]) {
+              return fromUrl;
+            }
             const stored = localStorage.getItem('selectedStatFilter');
             return stored && STAT_FILTER_LABELS[stored] ? stored : null;
           } catch {
             return null;
           }
         });
+
+        useEffect(() => {
+          try {
+            const url = new URL(window.location.href);
+            if (selectedStatFilter) {
+              url.searchParams.set(STAT_FILTER_PARAM, selectedStatFilter);
+            } else {
+              url.searchParams.delete(STAT_FILTER_PARAM);
+            }
+            window.history.replaceState(null, "", url.pathname + url.search + url.hash);
+          } catch {}
+        }, [selectedStatFilter]);
 
         const persistStatFilter = (value) => {
           try {


### PR DESCRIPTION
## Why

Today, when you filter the dashboard down to the projects you care about — say, everything that's **Failed** or has **Open PRs** — that view lives only in your browser. You can't send it to a teammate. Copy the URL into Slack and the recipient just gets the full, unfiltered dashboard and has to re-find the filter themselves.

This change makes filtered views **shareable**: the filter you pick is now part of the URL. "Here are all the failing repos" becomes a link you can paste anywhere, and it opens exactly the view you saw.

## What changes for users

- **Shareable links** — pick a filter and the URL updates to match (e.g. `?filter=failed`). Share it and the other person lands on the same filtered view.
- **Bookmarkable** — bookmark "Open PRs" and jump straight to it next time.
- **No surprises** — selecting **All** returns to the clean base URL. Your last-used filter is still remembered locally as before, so nothing regresses for existing users.

## How it works

- On load, the filter is read from the `?filter=` query param (validated against known filters; a bogus value safely falls back to **All**). If the URL has no filter, it falls back to the remembered `localStorage` value.
- The active filter is mirrored into the URL via `history.replaceState` whenever it changes — `?filter=<key>` for a filter, or no param at all for **All**. Using `replaceState` means the back button isn't cluttered with filter steps.

Purely client-side — filtering already happens in the browser, so no backend changes were needed. This follows the same URL-param pattern the logs page already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)