### PR TITLE
fix(helm): add missing patch permission for jobs resources

### DIFF
--- a/charts/renovate-operator/templates/clusterrole/clusterrole.yaml
+++ b/charts/renovate-operator/templates/clusterrole/clusterrole.yaml
@@ -17,7 +17,7 @@ rules:
   # Allow create, get, list, update, delete on jobs
   - apiGroups: ["batch"]
     resources: ["jobs"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
 
   # Allow log access from pods
   - apiGroups: [""]


### PR DESCRIPTION
```
{"level":"error","ts":"2026-06-17T08:57:20Z","logger":"job-controller","msg":"failed to mark executor job as processed","controller":"job","controllerGroup":"batch","controllerKind":"Job","Job":{"name":"forgejo-homelab-homelab-ansible-playbooks-56fd097b2xgtk","namespace":"renovate-operator"},"namespace":"renovate-operator","name":"forgejo-homelab-homelab-ansible-playbooks-56fd097b2xgtk","reconcileID":"9a6524c3-f2a6-471f-8b49-a3b3543daa27","job":"forgejo-homelab-homelab-ansible-playbooks-56fd097b2xgtk","error":"jobs.batch \"forgejo-homelab-homelab-ansible-playbooks-56fd097b2xgtk\" is forbidden: User \"system:serviceaccount:renovate-operator:renovate-operator-renovate-operator\" cannot patch resource \"jobs\" in API group \"batch\" in the namespace \"renovate-operator\"","stacktrace":"renovate-operator/internal/renovate.(*renovateExecutor).ProcessProjectJobResult\n\trenovate-operator/internal/renovate/executor.go:258\nrenovate-operator/controllers.(*JobReconciler).Reconcile\n\trenovate-operator/controllers/job_controller.go:79\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:221\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:478\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\tsigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312"}
```