### PR TITLE
fix(ui): set Cache-Control headers on static assets

### DIFF
--- a/src/ui/ui.go
+++ b/src/ui/ui.go
@@ -14,27 +14,15 @@ func (s *Server) registerUiRoutes(router *mux.Router) {
 	router.PathPrefix("/").Handler(cacheControl(http.FileServer(http.Dir("./static/"))))
 }
 
-// vendoredAssets are version-pinned third-party bundles served under stable
-// filenames. They change only when their pin is bumped (which ships a new
-// image), so they can be cached. Everything else the UI serves is app-authored
-// and changes every deploy, so it must be revalidated to avoid a browser
-// running a stale index.html against changed scripts.
 var vendoredAssets = map[string]struct{}{
 	"/js/babel.min.js":        {},
 	"/js/react-bundle.esm.js": {},
 	"/js/tailwind.min.js":     {},
 }
 
-// cacheControl caches the large vendored bundles for a day while forcing
-// revalidation of app-authored files. ("no-cache" still allows cheap 304
-// revalidation via Last-Modified.) Content-hashed filenames would let the
-// vendored bundles be cached immutably, but they aren't hashed today, so a
-// day caps how long a pin bump can serve stale.
 func cacheControl(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := vendoredAssets[r.URL.Path]; ok {
-			// Defer the long-lived header to WriteHeader so a transient
-			// non-200 (e.g. a missing bundle) isn't cached for a day.
 			next.ServeHTTP(&longCacheWriter{ResponseWriter: w}, r)
 			return
 		}
@@ -43,8 +31,7 @@ func cacheControl(next http.Handler) http.Handler {
 	})
 }
 
-// longCacheWriter sets the day-long Cache-Control header only on successful
-// (200) or revalidated (304) responses, so error responses stay uncached.
+// wrap the request writer to only write cache headers if request was successful
 type longCacheWriter struct {
 	http.ResponseWriter
 	wroteHeader bool

--- a/src/ui/ui.go
+++ b/src/ui/ui.go
@@ -8,7 +8,35 @@ import (
 
 func (s *Server) registerUiRoutes(router *mux.Router) {
 	router.HandleFunc("/logs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-cache")
 		http.ServeFile(w, r, "./static/pages/logs.html")
 	}).Methods("GET")
-	router.PathPrefix("/").Handler(http.FileServer(http.Dir("./static/")))
+	router.PathPrefix("/").Handler(cacheControl(http.FileServer(http.Dir("./static/"))))
+}
+
+// vendoredAssets are version-pinned third-party bundles served under stable
+// filenames. They change only when their pin is bumped (which ships a new
+// image), so they can be cached. Everything else the UI serves is app-authored
+// and changes every deploy, so it must be revalidated to avoid a browser
+// running a stale index.html against changed scripts.
+var vendoredAssets = map[string]bool{
+	"/js/babel.min.js":        true,
+	"/js/react-bundle.esm.js": true,
+	"/js/tailwind.min.js":     true,
+}
+
+// cacheControl caches the large vendored bundles for a day while forcing
+// revalidation of app-authored files. ("no-cache" still allows cheap 304
+// revalidation via Last-Modified.) Content-hashed filenames would let the
+// vendored bundles be cached immutably, but they aren't hashed today, so a
+// day caps how long a pin bump can serve stale.
+func cacheControl(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if vendoredAssets[r.URL.Path] {
+			w.Header().Set("Cache-Control", "public, max-age=86400")
+		} else {
+			w.Header().Set("Cache-Control", "no-cache")
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/src/ui/ui.go
+++ b/src/ui/ui.go
@@ -19,10 +19,10 @@ func (s *Server) registerUiRoutes(router *mux.Router) {
 // image), so they can be cached. Everything else the UI serves is app-authored
 // and changes every deploy, so it must be revalidated to avoid a browser
 // running a stale index.html against changed scripts.
-var vendoredAssets = map[string]bool{
-	"/js/babel.min.js":        true,
-	"/js/react-bundle.esm.js": true,
-	"/js/tailwind.min.js":     true,
+var vendoredAssets = map[string]struct{}{
+	"/js/babel.min.js":        {},
+	"/js/react-bundle.esm.js": {},
+	"/js/tailwind.min.js":     {},
 }
 
 // cacheControl caches the large vendored bundles for a day while forcing
@@ -32,11 +32,35 @@ var vendoredAssets = map[string]bool{
 // day caps how long a pin bump can serve stale.
 func cacheControl(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if vendoredAssets[r.URL.Path] {
-			w.Header().Set("Cache-Control", "public, max-age=86400")
-		} else {
-			w.Header().Set("Cache-Control", "no-cache")
+		if _, ok := vendoredAssets[r.URL.Path]; ok {
+			// Defer the long-lived header to WriteHeader so a transient
+			// non-200 (e.g. a missing bundle) isn't cached for a day.
+			next.ServeHTTP(&longCacheWriter{ResponseWriter: w}, r)
+			return
 		}
+		w.Header().Set("Cache-Control", "no-cache")
 		next.ServeHTTP(w, r)
 	})
+}
+
+// longCacheWriter sets the day-long Cache-Control header only on successful
+// (200) or revalidated (304) responses, so error responses stay uncached.
+type longCacheWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *longCacheWriter) WriteHeader(status int) {
+	w.wroteHeader = true
+	if status == http.StatusOK || status == http.StatusNotModified {
+		w.Header().Set("Cache-Control", "public, max-age=86400")
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *longCacheWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
 }


### PR DESCRIPTION
## Summary

The UI's static files are served by a plain `http.FileServer` (`src/ui/ui.go`) with no `Cache-Control` or `ETag` — only `Last-Modified`. Browsers then apply heuristic caching to `index.html` and the scripts, so after a deploy a browser can keep running a **stale `index.html` against changed assets**. In practice this surfaces as confusing console errors from a mismatched cached page, e.g.:

```
Uncaught SyntaxError: export declarations may only appear at top level of a module  (babel.min.js)
Uncaught ReferenceError: StatBadge is not defined
```

even though the deployed files are correct.

## Change

Tiered cache policy in `registerUiRoutes`:

- **`no-cache`** (revalidate every load, cheap 304 via `Last-Modified`) for app-authored files that change each deploy: `index.html`, `/logs`, `/components/*.js`, `/js/babel-config.js`, `/js/theme-utils.js`, `/css/*`.
- **`public, max-age=86400`** for the large version-pinned vendored bundles `/js/babel.min.js`, `/js/react-bundle.esm.js`, `/js/tailwind.min.js` — they only change when their pin is bumped (which ships a new image), so there's no need to revalidate ~3.4MB on every load. The 1-day cap bounds staleness after a rare pin bump.

A follow-up could content-hash the vendored bundles to cache them `immutable`, but they aren't hashed today.