### PR TITLE
fix(forgejo): treat 404 as success when deleting a webhook

### DIFF
--- a/src/gitProviderClients/forgejoProvider/forgejo.go
+++ b/src/gitProviderClients/forgejoProvider/forgejo.go
@@ -172,6 +172,10 @@ func (c *ForgejoClient) DeleteRepoWebhook(ctx context.Context, owner, repo strin
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	// A missing webhook is the desired end state, so treat 404 as success.
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))

--- a/src/gitProviderClients/forgejoProvider/forgejo.go
+++ b/src/gitProviderClients/forgejoProvider/forgejo.go
@@ -173,7 +173,9 @@ func (c *ForgejoClient) DeleteRepoWebhook(ctx context.Context, owner, repo strin
 	defer func() { _ = resp.Body.Close() }()
 
 	// A missing webhook is the desired end state, so treat 404 as success.
+	// Drain the body first so the connection can be reused (Forgejo returns JSON on 404).
 	if resp.StatusCode == http.StatusNotFound {
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil
 	}
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {

--- a/src/gitProviderClients/forgejoProvider/forgejo_test.go
+++ b/src/gitProviderClients/forgejoProvider/forgejo_test.go
@@ -167,6 +167,22 @@ func TestDeleteRepoWebhook(t *testing.T) {
 	}
 }
 
+func TestDeleteRepoWebhook_NotFoundIsSuccess(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/api/v1/repos/org/repo1/hooks/42", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"The target couldn't be found."}`))
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-token")
+	if err := c.DeleteRepoWebhook(context.Background(), "org", "repo1", 42); err != nil {
+		t.Fatalf("expected nil error for already-deleted webhook, got: %v", err)
+	}
+}
+
 func TestAPIError(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/api/v1/repos/search", func(w http.ResponseWriter, r *http.Request) {

--- a/src/gitProviderClients/forgejoProvider/forgejo_test.go
+++ b/src/gitProviderClients/forgejoProvider/forgejo_test.go
@@ -170,6 +170,9 @@ func TestDeleteRepoWebhook(t *testing.T) {
 func TestDeleteRepoWebhook_NotFoundIsSuccess(t *testing.T) {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/api/v1/repos/org/repo1/hooks/42", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"message":"The target couldn't be found."}`))
 	})


### PR DESCRIPTION
## Summary

`ForgejoClient.DeleteRepoWebhook` returned an error for any non-2xx status, including `404`. But a webhook that no longer exists is the desired end state of a delete, so a 404 should be treated as success.

In the webhook sync loop, this caused the removal step to error and retry noisily on hooks that were already gone (e.g. deleted manually or by a previous run):

```
failed to remove webhook ... unexpected status 404: {"message":"The target couldn't be found."}
```

## Change

`DeleteRepoWebhook` now returns `nil` on `404`. Added `TestDeleteRepoWebhook_NotFoundIsSuccess`.