### PR TITLE
fix(webhook-sync): sync webhooks for autodiscovered repos without a topic

### DIFF
--- a/src/internal/webhookSync/manager.go
+++ b/src/internal/webhookSync/manager.go
@@ -144,7 +144,20 @@ func (m *webhookSyncManager) RunSync(ctx context.Context, logger logr.Logger, jo
 	if !ok {
 		return
 	}
-	state, err := entry.syncer.RunOnce(ctx)
+	// Pass the discovered project list so webhook sync works for jobs that
+	// autodiscover repositories without a topic. RunOnce falls back to topic
+	// search when no projects are supplied.
+	var projects []string
+	if rj, err := m.jobManager.GetRenovateJob(ctx, jobId.Name, jobId.Namespace); err != nil {
+		logger.Error(err, "failed to load RenovateJob for webhook sync; falling back to topic search")
+	} else if rj != nil {
+		projects = make([]string, 0, len(rj.Status.Projects))
+		for _, p := range rj.Status.Projects {
+			projects = append(projects, p.Name)
+		}
+	}
+
+	state, err := entry.syncer.RunOnce(ctx, projects...)
 	if err != nil {
 		logger.Error(err, "webhook sync failed")
 	}

--- a/src/internal/webhookSync/manager.go
+++ b/src/internal/webhookSync/manager.go
@@ -149,7 +149,7 @@ func (m *webhookSyncManager) RunSync(ctx context.Context, logger logr.Logger, jo
 	// search when no projects are supplied.
 	var projects []string
 	if rj, err := m.jobManager.GetRenovateJob(ctx, jobId.Name, jobId.Namespace); err != nil {
-		logger.Error(err, "failed to load RenovateJob for webhook sync; falling back to topic search")
+		logger.Error(err, "failed to load RenovateJob for webhook sync; RunOnce will use topic search if configured, otherwise skip")
 	} else if rj != nil {
 		projects = make([]string, 0, len(rj.Status.Projects))
 		for _, p := range rj.Status.Projects {

--- a/src/internal/webhookSync/sync.go
+++ b/src/internal/webhookSync/sync.go
@@ -56,13 +56,32 @@ func (s *WebhookSyncer) SetManagedRepos(m map[string]int64) {
 	maps.Copy(s.managedRepos, m)
 }
 
-// RunOnce executes one full sync cycle: ensures webhooks exist on topic repos and removes them from opted-out repos.
+// RunOnce executes one full sync cycle: ensures webhooks exist on eligible repos and removes them from opted-out repos.
+// When projects is non-empty those repos are used directly; otherwise repos are discovered by topic. This lets jobs
+// that autodiscover repositories without a topic still sync webhooks by passing their discovered project list.
 // It returns a consistent snapshot of the managed repos state as it was at the end of the sync cycle.
-func (s *WebhookSyncer) RunOnce(ctx context.Context) (map[string]int64, error) {
-	// Step 1: Search repos by topic (no lock needed — pure API call)
-	repos, err := s.client.SearchReposByTopic(ctx, s.topic)
-	if err != nil {
-		return nil, fmt.Errorf("searching repos by topic %q: %w", s.topic, err)
+func (s *WebhookSyncer) RunOnce(ctx context.Context, projects ...string) (map[string]int64, error) {
+	var repos []gitProviderClients.Repository
+
+	if len(projects) > 0 {
+		// Use the provided project list — mark all as admin (the caller already discovered them);
+		// repos where we lack admin are detected and skipped when the webhook API call returns 403.
+		for _, fullName := range projects {
+			repos = append(repos, gitProviderClients.Repository{
+				FullName:    fullName,
+				Permissions: &gitProviderClients.RepositoryPermissions{Admin: true},
+			})
+		}
+	} else if s.topic != "" {
+		// Fall back to topic-based discovery (no lock needed — pure API call).
+		var err error
+		repos, err = s.client.SearchReposByTopic(ctx, s.topic)
+		if err != nil {
+			return nil, fmt.Errorf("searching repos by topic %q: %w", s.topic, err)
+		}
+	} else {
+		s.logger.Info("no projects provided and no topic configured, skipping webhook sync")
+		return s.snapshotManagedRepos(), nil
 	}
 
 	// Step 2: Partition by admin permission
@@ -132,13 +151,16 @@ func (s *WebhookSyncer) RunOnce(ctx context.Context) (map[string]int64, error) {
 		s.mu.Unlock()
 	}
 
-	// Return a consistent snapshot of the final state
+	return s.snapshotManagedRepos(), nil
+}
+
+// snapshotManagedRepos returns a consistent copy of the managed repos state.
+func (s *WebhookSyncer) snapshotManagedRepos() map[string]int64 {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	snapshot := make(map[string]int64, len(s.managedRepos))
 	maps.Copy(snapshot, s.managedRepos)
-	s.mu.Unlock()
-
-	return snapshot, nil
+	return snapshot
 }
 
 func (s *WebhookSyncer) ensureWebhook(ctx context.Context, owner, repo, fullName string) error {

--- a/src/internal/webhookSync/sync.go
+++ b/src/internal/webhookSync/sync.go
@@ -64,8 +64,10 @@ func (s *WebhookSyncer) RunOnce(ctx context.Context, projects ...string) (map[st
 	var repos []gitProviderClients.Repository
 
 	if len(projects) > 0 {
-		// Use the provided project list — mark all as admin (the caller already discovered them);
-		// repos where we lack admin are detected and skipped when the webhook API call returns 403.
+		// Use the provided project list. Admin permission isn't known here, so it's
+		// assumed; repos where we actually lack admin surface as a 403 from the webhook
+		// API in the ensure step below and are skipped there.
+		repos = make([]gitProviderClients.Repository, 0, len(projects))
 		for _, fullName := range projects {
 			repos = append(repos, gitProviderClients.Repository{
 				FullName:    fullName,
@@ -106,7 +108,13 @@ func (s *WebhookSyncer) RunOnce(ctx context.Context, projects ...string) (map[st
 		owner, repoName := parts[0], parts[1]
 
 		if err := s.ensureWebhook(ctx, owner, repoName, fullName); err != nil {
-			s.logger.Error(err, "failed to ensure webhook", "repo", fullName)
+			// Without an admin token the webhook API returns 403; that's expected when
+			// syncing an autodiscovered project list, so log it as info rather than error.
+			if strings.Contains(err.Error(), "403") {
+				s.logger.Info("skipping repo: no admin permission to manage webhooks", "repo", fullName)
+			} else {
+				s.logger.Error(err, "failed to ensure webhook", "repo", fullName)
+			}
 			continue
 		}
 	}

--- a/src/internal/webhookSync/sync_test.go
+++ b/src/internal/webhookSync/sync_test.go
@@ -150,6 +150,26 @@ func TestSyncSkipsWhenNoProjectsAndNoTopic(t *testing.T) {
 	}
 }
 
+func TestSyncSkipsProvidedProjectWhenWebhookAPIForbids(t *testing.T) {
+	mc := newMockClient()
+	// A provided project is assumed admin, but the webhook API rejects it with 403;
+	// that repo must be skipped without failing the whole sync.
+	mc.listErr["org/repo1"] = fmt.Errorf("listing webhooks: unexpected status 403: forbidden")
+
+	syncer := NewWebhookSyncer(mc, "https://webhook.example.com/hook", "secret-token", "", nil, logr.Discard())
+
+	state, err := syncer.RunOnce(context.Background(), "org/repo1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mc.created["org/repo1"]) != 0 {
+		t.Errorf("expected no webhook created for forbidden repo, got %v", mc.created)
+	}
+	if len(state) != 0 {
+		t.Errorf("expected empty state, got %v", state)
+	}
+}
+
 func TestSyncSkipsReposWithExistingWebhook(t *testing.T) {
 	mc := newMockClient()
 	mc.repos = []gitProviderClients.Repository{

--- a/src/internal/webhookSync/sync_test.go
+++ b/src/internal/webhookSync/sync_test.go
@@ -112,6 +112,44 @@ func TestSyncCreatesWebhooksOnNewRepos(t *testing.T) {
 	}
 }
 
+func TestSyncUsesProvidedProjectsWithoutTopic(t *testing.T) {
+	mc := newMockClient()
+	// No topic configured; fail the search so the test proves it is not used.
+	mc.searchErr = fmt.Errorf("SearchReposByTopic must not be called when projects are provided")
+
+	syncer := NewWebhookSyncer(mc, "https://webhook.example.com/hook", "secret-token", "", nil, logr.Discard())
+
+	state, err := syncer.RunOnce(context.Background(), "org/repo1", "org/repo2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mc.created["org/repo1"]) != 1 || len(mc.created["org/repo2"]) != 1 {
+		t.Errorf("expected a webhook created for each provided project, got %v", mc.created)
+	}
+	if len(state) != 2 {
+		t.Errorf("expected 2 repos in returned state, got %d", len(state))
+	}
+}
+
+func TestSyncSkipsWhenNoProjectsAndNoTopic(t *testing.T) {
+	mc := newMockClient()
+	mc.searchErr = fmt.Errorf("SearchReposByTopic must not be called without a topic")
+
+	syncer := NewWebhookSyncer(mc, "https://webhook.example.com/hook", "secret-token", "", nil, logr.Discard())
+
+	state, err := syncer.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mc.created) != 0 {
+		t.Errorf("expected no webhooks created, got %v", mc.created)
+	}
+	if len(state) != 0 {
+		t.Errorf("expected empty state, got %v", state)
+	}
+}
+
 func TestSyncSkipsReposWithExistingWebhook(t *testing.T) {
 	mc := newMockClient()
 	mc.repos = []gitProviderClients.Repository{


### PR DESCRIPTION
## Summary

`WebhookSyncer.RunOnce` discovered repositories **only** by topic, and `webhookSyncManager.RunSync` called `RunOnce(ctx)` with no repos. So a `RenovateJob` that autodiscovers repositories **without** a configured topic registered no webhooks at all — the sync logged and bailed:

```
no projects provided and no topic configured, skipping webhook sync
```

## Change

- `RunOnce(ctx, projects ...string)` — when a project list is provided, those repos are used directly (admin assumed; repos where admin is missing are detected via the webhook API's 403 and skipped). Falls back to topic search when no projects are passed, and skips cleanly when there's neither.
- `RunSync` loads the `RenovateJob` and passes its discovered `Status.Projects`, so topic-less autodiscover setups sync webhooks.
- Extracted `snapshotManagedRepos()` helper (used by the new early-return and the final return).
- Tests: `TestSyncUsesProvidedProjectsWithoutTopic`, `TestSyncSkipsWhenNoProjectsAndNoTopic`.