### PR TITLE
fix(jobManager): trim project label selector if it is too long

### DIFF
--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -100,7 +100,7 @@ func GetJobsByLabel(ctx context.Context, client crclient.Client, selector JobSel
 		JOB_LABEL_RENOVATEJOB: selector.RenovateJobName,
 	}
 	if selector.JobType == ExecutorJobType && selector.Project != "" {
-		matcher[JOB_LABEL_PROJECT] = utils.KubernetesCompatibleName(selector.Project)
+		matcher[JOB_LABEL_PROJECT] = utils.KubernetesCompatibleProjectName(selector.Project)
 	}
 
 	if selector.Generation != nil && *selector.Generation != "" {
@@ -149,7 +149,7 @@ func CreateJobWithGeneration(ctx context.Context, client crclient.Client, job *b
 	job.Labels[JOB_LABEL_RENOVATEJOB] = selector.RenovateJobName
 
 	if selector.JobType == ExecutorJobType {
-		job.Labels[JOB_LABEL_PROJECT] = utils.KubernetesCompatibleName(selector.Project)
+		job.Labels[JOB_LABEL_PROJECT] = utils.KubernetesCompatibleProjectName(selector.Project)
 		if job.Annotations == nil {
 			job.Annotations = make(map[string]string)
 		}

--- a/src/internal/utils/jobNames.go
+++ b/src/internal/utils/jobNames.go
@@ -30,6 +30,20 @@ func ExecutorJobName(in *api.RenovateJob, project string) string {
 	return fullName + "-" + hashStr
 }
 
+func KubernetesCompatibleProjectName(project string) string {
+	cleanNamed := KubernetesCompatibleName(project)
+	if len(cleanNamed) <= 63 {
+		return cleanNamed
+	}
+
+	// Generate hash of the full name
+	hash := sha256.Sum256([]byte(cleanNamed))
+	hashStr := fmt.Sprintf("%x", hash[:4]) // Use first 4 bytes (8 hex chars)
+
+	cleanNamed = cleanNamed[:54]
+	return cleanNamed + "-" + hashStr
+}
+
 func KubernetesCompatibleName(name string) string {
 	name = strings.ToLower(name) // Ensure lowercase for consistency
 	name = invalidChars.ReplaceAllString(name, "-")


### PR DESCRIPTION
fixes #436

this should be non breaking as this label is only used for job selection on reading logs