### PR TITLE
feat(helm): allow to add labels to service monitor

### DIFF
--- a/charts/renovate-operator/templates/serviceMonitor.yaml
+++ b/charts/renovate-operator/templates/serviceMonitor.yaml
@@ -4,6 +4,10 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "renovate-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.metrics.serviceMonitor.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
   - path: /metrics

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -317,6 +317,7 @@ metrics:
     enabled: false
     # -- scrape interval for the ServiceMonitor, defaults to Prometheus global scrape interval
     interval: ~
+    labels: {}
   dashboard:
     # -- whether to create a Grafana dashboard for the operator metrics
     enabled: false


### PR DESCRIPTION
# Summary

This PR allows adding labels to the service monitor. Labels can be added by updating the `.Values.metrics.serviceMonitor.labels` key

When no labels are defined (default behavior), there are no changes to the service monitor object. Therefore, this change is backwards compatible.