### PR TITLE
fix(helm): trim service account name helper

### DIFF
--- a/charts/renovate-operator/templates/_helpers.tpl
+++ b/charts/renovate-operator/templates/_helpers.tpl
@@ -10,13 +10,13 @@
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (ternary .Values.image.tag .Chart.AppVersion (empty .Values.image.tag)) }}
 {{- end }}
 
-{{ define "renovate-operator.serviceAccountName" }}
-{{- if .Values.serviceAccount.name }}
-{{ .Values.serviceAccount.name }}
-{{- else }}
-{{- include "renovate-operator.fullname" . }}
-{{- end }}
-{{- end }}
+{{- define "renovate-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{- include "renovate-operator.fullname" . -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Returns the effective auth redirect URL.

--- a/charts/renovate-operator/unittests/deployment/deployment.yaml
+++ b/charts/renovate-operator/unittests/deployment/deployment.yaml
@@ -8,6 +8,15 @@ release:
 templates:
 - templates/deployment.yaml
 tests:
+- it: Uses explicit service account name
+  set:
+    serviceAccount:
+      name: custom-service-account
+  asserts:
+  - equal:
+      path: spec.template.spec.serviceAccountName
+      value: custom-service-account
+
 - it: Test default valkey credential secret
   set:
     valkey:


### PR DESCRIPTION
## Summary

Fixes the Helm chart helper used to render `.Values.serviceAccount.name` so it no longer emits extra newlines when an explicit service account name is configured.

## Root cause

`renovate-operator.serviceAccountName` did not trim whitespace in the branch that returns `.Values.serviceAccount.name`. Because the helper is used inline in multiple templates, Helm could render invalid YAML such as:

```yaml
name:
custom-service-account
```

This affects resources that call the helper inline, including `serviceaccount.yaml`, `deployment.yaml`, `clusterrolebinding.yaml`, and `rolebinding.yaml`.

## Changes

- Make the `renovate-operator.serviceAccountName` helper whitespace-trimming in all branches.
- Add a Helm unittest assertion for an explicit `serviceAccount.name` value.

## Validation

- `helm dependency build ./charts/renovate-operator`
- `helm template renovate-operator ./charts/renovate-operator --namespace renovate-operator -f <values-with-serviceAccount.name>`
- Parsed the rendered manifest as YAML.
- `helm unittest ./charts/renovate-operator/ --file "unittests/**/*.yaml"`
- `git diff --check`
