### PR TITLE
feat(operator): expose pending-approval duration as a metric

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -4287,6 +4287,11 @@ spec:
                 items:
                   description: Status of a single project within a RenovateJob
                   properties:
+                    approvalsNeededSince:
+                      description: ApprovalsNeededSince is when this project's current
+                        streak of pending approvals began, cleared once none are pending.
+                      format: date-time
+                      type: string
                     duration:
                       type: string
                     lastRun:

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -218,6 +218,8 @@ type ProjectStatus struct {
 	RenovateResultStatus *string               `json:"renovateResultStatus,omitempty"`
 	PRActivity           *PRActivity           `json:"prActivity,omitempty"`
 	LogIssues            *LogIssues            `json:"logIssues,omitempty"`
+	// ApprovalsNeededSince is when this project's current streak of pending approvals began, cleared once none are pending.
+	ApprovalsNeededSince *metav1.Time `json:"approvalsNeededSince,omitempty"`
 }
 
 type RenovateProjectStatus string
@@ -321,6 +323,9 @@ func (in *ProjectStatus) DeepCopyInto(out *ProjectStatus) {
 			out.LogIssues.Issues = make([]LogIssue, len(in.LogIssues.Issues))
 			copy(out.LogIssues.Issues, in.LogIssues.Issues)
 		}
+	}
+	if in.ApprovalsNeededSince != nil {
+		out.ApprovalsNeededSince = in.ApprovalsNeededSince.DeepCopy()
 	}
 }
 

--- a/src/controllers/renovatejob_controller.go
+++ b/src/controllers/renovatejob_controller.go
@@ -7,6 +7,7 @@ import (
 	"renovate-operator/internal/renovate"
 	"renovate-operator/internal/telemetry"
 	"renovate-operator/internal/types"
+	"renovate-operator/metricStore"
 	"renovate-operator/scheduler"
 	"strings"
 	"time"
@@ -64,6 +65,7 @@ func (r *RenovateJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		// renovatejob object read without problem -> create the schedule
 		r.ensureWebhookCleanupFinalizer(ctx, logger, renovateJob)
+		metricStore.RehydrateMetrics(renovateJob.Namespace, renovateJob.Name, renovateJob.Status.Projects)
 		r.resetOrphanedRunning(ctx, renovateJob)
 		createScheduler(logger, renovateJob, r)
 		if err := r.GithubApp.EnsureToken(ctx, renovateJob); err != nil {

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -28,6 +28,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
 	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -199,14 +200,14 @@ func (e *renovateExecutor) ProcessProjectJobResult(ctx context.Context, k8sJob *
 	if err != nil {
 		return fmt.Errorf("failed to load RenovateJob for status check: %w", err)
 	}
-	projectIsRunning := false
-	for _, p := range renovateJob.Status.Projects {
-		if p.Name == project && p.Status == api.JobStatusRunning {
-			projectIsRunning = true
+	var currentStatus *api.ProjectStatus
+	for i := range renovateJob.Status.Projects {
+		if renovateJob.Status.Projects[i].Name == project {
+			currentStatus = &renovateJob.Status.Projects[i]
 			break
 		}
 	}
-	if !projectIsRunning {
+	if currentStatus == nil || currentStatus.Status != api.JobStatusRunning {
 		return nil
 	}
 
@@ -236,6 +237,15 @@ func (e *renovateExecutor) ProcessProjectJobResult(ctx context.Context, k8sJob *
 		approvalsNeeded = newProjectStatus.PRActivity.NeedsApproval
 	}
 	metricStore.SetApprovalsNeeded(jobId.Namespace, jobId.Name, project, approvalsNeeded)
+	if newProjectStatus.PRActivity != nil {
+		since := utils.NextApprovalsNeededSince(currentStatus.ApprovalsNeededSince, approvalsNeeded, metav1.Now())
+		newProjectStatus.ApprovalsNeededSince = since
+		if since != nil {
+			metricStore.SetApprovalsNeededSince(jobId.Namespace, jobId.Name, project, since.Time)
+		} else {
+			metricStore.ClearApprovalsNeededSince(jobId.Namespace, jobId.Name, project)
+		}
+	}
 	metricStore.CaptureRenovateProjectExecution(ctx, jobId.Namespace, jobId.Name, project, newStatus)
 
 	if span := trace.SpanFromContext(ctx); span.IsRecording() {

--- a/src/internal/types/renovateStatusUpdate.go
+++ b/src/internal/types/renovateStatusUpdate.go
@@ -14,4 +14,5 @@ type RenovateStatusUpdate struct {
 	LogIssues            *api.LogIssues
 	LastRun              *v1.Time
 	Duration             *string
+	ApprovalsNeededSince *v1.Time
 }

--- a/src/internal/utils/projectStatus.go
+++ b/src/internal/utils/projectStatus.go
@@ -34,7 +34,7 @@ func validateProjectStatusScheduled(projectStatus *api.ProjectStatus, desiredSta
 		}
 	}
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
-	updatePRActivity(projectStatus, desiredStatus.PRActivity)
+	updatePRActivity(projectStatus, desiredStatus)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
 	return projectStatus
 }
@@ -47,7 +47,7 @@ func validateProjectStatusRunning(projectStatus *api.ProjectStatus, desiredStatu
 	}
 	projectStatus.Duration = nil
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
-	updatePRActivity(projectStatus, desiredStatus.PRActivity)
+	updatePRActivity(projectStatus, desiredStatus)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
 	return projectStatus
 }
@@ -61,7 +61,7 @@ func validateProjectStatusCompleted(projectStatus *api.ProjectStatus, desiredSta
 	}
 	projectStatus.Duration = desiredStatus.Duration
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
-	updatePRActivity(projectStatus, desiredStatus.PRActivity)
+	updatePRActivity(projectStatus, desiredStatus)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
 	return projectStatus
 }
@@ -75,7 +75,7 @@ func validateProjectStatusFailed(projectStatus *api.ProjectStatus, desiredStatus
 	}
 	projectStatus.Duration = desiredStatus.Duration
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
-	updatePRActivity(projectStatus, desiredStatus.PRActivity)
+	updatePRActivity(projectStatus, desiredStatus)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
 	return projectStatus
 }
@@ -89,7 +89,7 @@ func validateProjectStatusCancelled(projectStatus *api.ProjectStatus, desiredSta
 	}
 	projectStatus.Duration = desiredStatus.Duration
 	updateRenovateResultStatus(projectStatus, desiredStatus.RenovateResultStatus)
-	updatePRActivity(projectStatus, desiredStatus.PRActivity)
+	updatePRActivity(projectStatus, desiredStatus)
 	updateLogIssues(projectStatus, desiredStatus.LogIssues)
 	return projectStatus
 }
@@ -100,10 +100,24 @@ func updateRenovateResultStatus(projectStatus *api.ProjectStatus, status *string
 	}
 }
 
-func updatePRActivity(projectStatus *api.ProjectStatus, activity *api.PRActivity) {
-	if activity != nil {
-		projectStatus.PRActivity = activity
+func updatePRActivity(projectStatus *api.ProjectStatus, desiredStatus *types.RenovateStatusUpdate) {
+	if desiredStatus.PRActivity == nil {
+		return
 	}
+	projectStatus.PRActivity = desiredStatus.PRActivity
+	projectStatus.ApprovalsNeededSince = desiredStatus.ApprovalsNeededSince
+}
+
+// NextApprovalsNeededSince returns the start of the current pending-approval streak:
+// the previous timestamp while approvals remain, a fresh now when a streak begins, or nil when none are pending.
+func NextApprovalsNeededSince(prev *v1.Time, needsApproval int, now v1.Time) *v1.Time {
+	if needsApproval <= 0 {
+		return nil
+	}
+	if prev != nil {
+		return prev
+	}
+	return &now
 }
 
 func updateLogIssues(projectStatus *api.ProjectStatus, issues *api.LogIssues) {

--- a/src/internal/utils/projectStatus_test.go
+++ b/src/internal/utils/projectStatus_test.go
@@ -2,9 +2,12 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/internal/types"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetUpdateStatusForProject(t *testing.T) {
@@ -61,6 +64,29 @@ func TestGetUpdateStatusForProject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNextApprovalsNeededSince(t *testing.T) {
+	now := v1.Now()
+	earlier := v1.NewTime(time.Now().Add(-72 * time.Hour))
+
+	t.Run("stamps now when a streak begins", func(t *testing.T) {
+		if got := NextApprovalsNeededSince(nil, 2, now); got == nil || !got.Equal(&now) {
+			t.Fatalf("expected %v, got %v", now, got)
+		}
+	})
+
+	t.Run("preserves the original timestamp while approvals remain", func(t *testing.T) {
+		if got := NextApprovalsNeededSince(&earlier, 1, now); got == nil || !got.Equal(&earlier) {
+			t.Fatalf("expected %v, got %v", earlier, got)
+		}
+	})
+
+	t.Run("clears when no approvals are pending", func(t *testing.T) {
+		if got := NextApprovalsNeededSince(&earlier, 0, now); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
 }
 
 func TestGetUpdateStatusForProject_Priority(t *testing.T) {

--- a/src/metricStore/metrics.go
+++ b/src/metricStore/metrics.go
@@ -53,6 +53,13 @@ var (
 			Help: "Number of dependency updates awaiting approval after the last Renovate run",
 		},
 		[]string{"renovate_namespace", "renovate_job", "project"})
+
+	approvalsNeededSince = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_approvals_needed_since_seconds",
+			Help: "Unix timestamp at which the current streak of pending approvals began for a project; absent when none are pending",
+		},
+		[]string{"renovate_namespace", "renovate_job", "project"})
 )
 
 // OTel metrics — no-ops when OTel is not configured.
@@ -75,6 +82,7 @@ func Register(registry ctrlmetrics.RegistererGatherer) {
 	registry.MustRegister(runFailed)
 	registry.MustRegister(dependencyIssues)
 	registry.MustRegister(approvalsNeeded)
+	registry.MustRegister(approvalsNeededSince)
 }
 
 func ObserveExecutorLoopDuration(ctx context.Context, duration time.Duration) {
@@ -138,11 +146,39 @@ func SetApprovalsNeeded(namespace, job, project string, count int) {
 	approvalsNeeded.WithLabelValues(namespace, job, project).Set(float64(count))
 }
 
+// SetApprovalsNeededSince records when the current streak of pending approvals began for a project.
+func SetApprovalsNeededSince(namespace, job, project string, since time.Time) {
+	approvalsNeededSince.WithLabelValues(namespace, job, project).Set(float64(since.Unix()))
+}
+
+// ClearApprovalsNeededSince removes the pending-approval timestamp for a project.
+func ClearApprovalsNeededSince(namespace, job, project string) {
+	approvalsNeededSince.DeleteLabelValues(namespace, job, project)
+}
+
+// RehydrateMetrics re-emits per-project gauges from durable CRD status,
+// restoring state lost when the operator restarts before the next scheduled run.
+func RehydrateMetrics(namespace, job string, projects []api.ProjectStatus) {
+	for i := range projects {
+		p := projects[i]
+		SetRunFailed(namespace, job, p.Name, p.Status == api.JobStatusFailed)
+		if p.PRActivity != nil {
+			SetApprovalsNeeded(namespace, job, p.Name, p.PRActivity.NeedsApproval)
+		}
+		if p.ApprovalsNeededSince != nil {
+			SetApprovalsNeededSince(namespace, job, p.Name, p.ApprovalsNeededSince.Time)
+		} else {
+			ClearApprovalsNeededSince(namespace, job, p.Name)
+		}
+	}
+}
+
 // DeleteProjectMetrics removes all metrics for a project that was removed from discovery
 func DeleteProjectMetrics(namespace, job, project string) {
 	runFailed.DeleteLabelValues(namespace, job, project)
 	dependencyIssues.DeleteLabelValues(namespace, job, project)
 	approvalsNeeded.DeleteLabelValues(namespace, job, project)
+	approvalsNeededSince.DeleteLabelValues(namespace, job, project)
 	// Note: projectRuns counter has an additional "status" label, so we delete both possible values
 	projectRuns.DeleteLabelValues(namespace, job, project, "completed")
 	projectRuns.DeleteLabelValues(namespace, job, project, "failed")


### PR DESCRIPTION
## Problem

`renovate_operator_approvals_needed` only reports the current count, with no notion of *how long* approvals have been pending. Because the gauge carries `pod`/`instance` labels and the operator restarts regularly, no single series is long-lived, so duration-based alerting via `min_over_time`/`for` can't reliably express "pending for N days".

## Change

- Persist `ApprovalsNeededSince` in the project status. It is set when approvals first appear, preserved while they remain, and cleared once none are pending. Living in the CRD status, it survives operator restarts.
- Expose it as a gauge `renovate_operator_approvals_needed_since_seconds` (Unix timestamp), emitted after a successful status update and re-hydrated from the durable status on reconcile so it is restored after a restart.

This lets consumers alert on duration directly, e.g.:

```promql
time() - max by (project) (renovate_operator_approvals_needed_since_seconds) > 518400
```

## Notes

- New CRD field is optional; existing resources are unaffected.
- Unit tests cover the set/preserve/clear transitions.
