### PR TITLE
feat(metrics): expand with additional metrics

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -4377,6 +4377,12 @@ spec:
                       type: integer
                     renovateResultStatus:
                       type: string
+                    scheduledAt:
+                      description: |-
+                        ScheduledAt records when the project most recently entered the Scheduled
+                        state, used to measure queue wait time when it is dispatched.
+                      format: date-time
+                      type: string
                     status:
                       type: string
                   required:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -9,24 +9,107 @@ metrics:
     enabled: true
 ```
 
-## Exported Metrics
+All counters and histograms are also emitted via OpenTelemetry when an OTel meter is
+configured (`OTEL_EXPORTER_OTLP_ENDPOINT`), using the dotted equivalent of each name
+(e.g. `renovate_operator.job.duration`) and the same label dimensions. Gauges are
+Prometheus-only.
 
-| Name                                       | Type    | Description                                                              | Labels                                                    |
-|--------------------------------------------|---------|--------------------------------------------------------------------------|-----------------------------------------------------------|
-| renovate_operator_project_executions_total | Counter | Total number of executed Renovate projects                               | `renovate_namespace`, `renovate_job`, `project`, `status` |
-| renovate_operator_run_failed               | Gauge   | Whether the last Renovate run for this project failed (1=failed, 0=success) | `renovate_namespace`, `renovate_job`, `project`           |
-| renovate_operator_dependency_issues        | Gauge   | Whether the last Renovate run had WARN/ERROR log entries (1=issues, 0=clean) | `renovate_namespace`, `renovate_job`, `project`           |
+In addition to the metrics below, the operator exposes controller-runtime's built-in
+metrics for free (`controller_runtime_reconcile_*`, workqueue depth/latency,
+`leader_election_master_status`).
+
+## Execution and job lifecycle
+
+| Name                                          | Type      | Description                                                                 | Labels                                                    |
+|-----------------------------------------------|-----------|-----------------------------------------------------------------------------|-----------------------------------------------------------|
+| renovate_operator_executor_loop_duration_seconds | Histogram | Duration of a single executor loop tick                                  | (none)                                                    |
+| renovate_operator_project_executions_total    | Counter   | Total number of executed Renovate projects                                  | `renovate_namespace`, `renovate_job`, `project`, `status` |
+| renovate_operator_jobs_dispatched_total       | Counter   | Kubernetes Jobs launched by the operator                                    | `renovate_namespace`, `renovate_job`, `kind`              |
+| renovate_operator_job_duration_seconds        | Histogram | Wall-clock duration of a Renovate Kubernetes Job                            | `renovate_namespace`, `renovate_job`, `kind`, `status`    |
+| renovate_operator_project_queue_wait_seconds  | Histogram | Time a project spent in Scheduled before being dispatched                   | `renovate_namespace`, `renovate_job`                      |
+| renovate_operator_job_failures_total          | Counter   | Job failures by mode (`timeout`/`backoff_exceeded`/`job_not_found`/`pod_error`/`unknown`) | `renovate_namespace`, `renovate_job`, `kind`, `reason` |
+| renovate_operator_run_failed                  | Gauge     | Whether the last run for this project failed (1=failed, 0=success)          | `renovate_namespace`, `renovate_job`, `project`           |
+| renovate_operator_last_execution_duration_seconds | Gauge | Duration of the most recent run for this project                            | `renovate_namespace`, `renovate_job`, `project`           |
+
+`kind` is `executor` or `discovery`.
+
+## Saturation and queue depth
+
+| Name                                          | Type  | Description                                              | Labels                               |
+|-----------------------------------------------|-------|----------------------------------------------------------|--------------------------------------|
+| renovate_operator_projects_scheduled          | Gauge | Projects currently in Scheduled (queue depth) per job    | `renovate_namespace`, `renovate_job` |
+| renovate_operator_projects_running            | Gauge | Projects currently Running (in-flight) per job           | `renovate_namespace`, `renovate_job` |
+| renovate_operator_global_running_projects     | Gauge | Total Running projects across all jobs                   | (none)                               |
+| renovate_operator_global_parallelism_limit    | Gauge | Configured global parallelism limit (0 = unlimited)      | (none)                               |
+
+## Discovery
+
+| Name                                          | Type    | Description                                            | Labels                                          |
+|-----------------------------------------------|---------|--------------------------------------------------------|-------------------------------------------------|
+| renovate_operator_discovery_jobs_total        | Counter | Discovery Jobs completed by status                     | `renovate_namespace`, `renovate_job`, `status`  |
+| renovate_operator_discovered_repositories     | Gauge   | Repositories seen by the last discovery run            | `renovate_namespace`, `renovate_job`            |
+| renovate_operator_repositories_filtered_total | Counter | Repositories dropped by filters (`fork`/`pending_deletion`) | `renovate_namespace`, `renovate_job`, `reason` |
+
+## Scheduler
+
+| Name                                                   | Type    | Description                                      | Labels                                          |
+|--------------------------------------------------------|---------|--------------------------------------------------|-------------------------------------------------|
+| renovate_operator_schedule_runs_total                  | Counter | Cron schedule firings executed by result (`success`/`error`) | `renovate_namespace`, `renovate_job`, `result` |
+| renovate_operator_schedule_next_run_timestamp_seconds  | Gauge   | Unix timestamp of the next planned scheduled run | `renovate_namespace`, `renovate_job`            |
+
+## Results and outcomes
+
+| Name                                              | Type    | Description                                                | Labels                                          |
+|---------------------------------------------------|---------|------------------------------------------------------------|-------------------------------------------------|
+| renovate_operator_open_pull_requests              | Gauge   | Open Renovate-managed pull requests after the last run     | `renovate_namespace`, `renovate_job`, `project` |
+| renovate_operator_pull_requests_awaiting_approval | Gauge   | Pull requests awaiting human approval after the last run   | `renovate_namespace`, `renovate_job`, `project` |
+| renovate_operator_pull_requests_created_total     | Counter | Pull requests created                                      | `renovate_namespace`, `renovate_job`            |
+| renovate_operator_pull_requests_merged_total      | Counter | Pull requests automerged (updates that landed)             | `renovate_namespace`, `renovate_job`            |
+| renovate_operator_pull_requests_updated_total     | Counter | Pull requests updated                                      | `renovate_namespace`, `renovate_job`            |
+| renovate_operator_repositories_by_status          | Gauge   | Repositories per Renovate result status (coverage). `status` is a bounded enum: `disabled`, `no_config`, `onboarding`, `onboarding_closed`, `unknown`, `other` | `renovate_namespace`, `renovate_job`, `status`  |
+| renovate_operator_approvals_needed                | Gauge   | Dependency updates awaiting approval after the last run    | `renovate_namespace`, `renovate_job`, `project` |
+
+## Log quality
+
+| Name                                  | Type  | Description                                                                  | Labels                                                  |
+|---------------------------------------|-------|------------------------------------------------------------------------------|---------------------------------------------------------|
+| renovate_operator_log_issues          | Gauge | WARN/ERROR log entry counts in the last run, by `level` (`warn`/`error`)     | `renovate_namespace`, `renovate_job`, `project`, `level`|
+| renovate_operator_dependency_issues   | Gauge | Whether the last run had WARN/ERROR log entries (1=issues, 0=clean)          | `renovate_namespace`, `renovate_job`, `project`         |
+
+## Webhook integrity
+
+| Name                                                            | Type    | Description                                                  | Labels                       |
+|-----------------------------------------------------------------|---------|--------------------------------------------------------------|------------------------------|
+| renovate_operator_webhook_requests_total                        | Counter | Webhook requests by `provider` and `result` (`accepted`/`rejected`/`ignored`) | `provider`, `result` |
+| renovate_operator_webhook_signature_verification_failures_total | Counter | Webhook HMAC signature verification failures                 | `provider`                   |
+| renovate_operator_webhook_auth_failures_total                   | Counter | Webhook auth failures by `error_type` (`no_matching_job`/`auth_failed`/`secret_error`) | `provider`, `error_type` |
+| renovate_operator_webhook_payload_decode_failures_total         | Counter | Webhook payloads that failed to decode                       | `provider`                   |
+
+`provider` is one of `github`, `gitlab`, `forgejo`, `schedule`.
+
+## Credentials
+
+| Name                                             | Type    | Description                                                                 | Labels       |
+|--------------------------------------------------|---------|-----------------------------------------------------------------------------|--------------|
+| renovate_operator_secret_resolution_errors_total | Counter | Kubernetes Secret resolution errors (`not_found`/`key_missing`/`api_error`) | `error_type` |
+
+Security metric labels are deliberately bounded enums; user identifiers, IP addresses,
+and raw request paths are never used as label values.
 
 ## Dependency Issues Detection
 
-The `renovate_operator_dependency_issues` metric detects issues by parsing Renovate's JSON log output. This includes:
+The `renovate_operator_dependency_issues` and `renovate_operator_log_issues` metrics
+detect issues by parsing Renovate's JSON log output. This includes:
 
 - Configuration validation warnings
 - Dependency lookup failures
 - Rate limiting issues
 - Invalid `renovate.json` configuration
 
-**Important**: This metric requires Renovate to output logs in JSON format. The operator sets `RENOVATE_LOG_FORMAT=json` by default for all Renovate jobs. If you override this via `extraEnv` in your RenovateJob spec, the `renovate_operator_dependency_issues` metric will not function correctly and will always report 0.
+**Important**: These metrics require Renovate to output logs in JSON format. The operator
+sets `RENOVATE_LOG_FORMAT=json` by default for all Renovate jobs. If you override this via
+`extraEnv` in your RenovateJob spec, these metrics will not function correctly and will
+always report 0.
 
 ## Example Prometheus Alerting Rules
 
@@ -51,4 +134,44 @@ groups:
         annotations:
           summary: "Renovate detected dependency issues for {{ $labels.project }}"
           description: "The last Renovate run for project {{ $labels.project }} in job {{ $labels.renovate_job }} had warnings or errors. Check the Dependency Dashboard or Renovate logs for details."
+
+      # SRE: runs taking dangerously close to the 30m default job timeout.
+      - alert: RenovateJobDurationHigh
+        expr: histogram_quantile(0.95, sum(rate(renovate_operator_job_duration_seconds_bucket[1h])) by (le, renovate_job)) > 1500
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Renovate job p95 duration is high for {{ $labels.renovate_job }}"
+          description: "p95 job duration is approaching the 1800s (JOB_TIMEOUT_SECONDS) default."
+
+      # SRE: automerge has flatlined while the open-PR backlog keeps growing.
+      - alert: RenovateAutomergeStalled
+        expr: sum(rate(renovate_operator_pull_requests_merged_total[6h])) == 0 and sum(renovate_operator_open_pull_requests) > 0
+        for: 6h
+        labels:
+          severity: warning
+        annotations:
+          summary: "No Renovate PRs merged in 6h while open PRs exist"
+          description: "Automerge may be broken or gated; the dependency-update backlog is not draining."
+
+      # SRE: a schedule that should have fired is overdue (leader stall / requeue failure).
+      - alert: RenovateScheduleMissed
+        expr: time() - renovate_operator_schedule_next_run_timestamp_seconds > 3600
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Renovate schedule overdue for {{ $labels.renovate_job }}"
+          description: "The next planned run is more than an hour in the past."
+
+      # SecOps: sustained webhook HMAC signature failures - forged or misconfigured webhooks.
+      - alert: RenovateWebhookSignatureFailures
+        expr: sum(rate(renovate_operator_webhook_signature_verification_failures_total[10m])) by (provider) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Renovate webhook signature failures from {{ $labels.provider }}"
+          description: "HMAC signature verification is failing; investigate forged or misconfigured webhooks."
 ```

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -208,14 +208,17 @@ type LogIssues struct {
 Status of a single project within a RenovateJob
 */
 type ProjectStatus struct {
-	Name                 string                `json:"name"`
-	LastRun              metav1.Time           `json:"lastRun"`
-	Duration             *string               `json:"duration,omitempty"`
-	Status               RenovateProjectStatus `json:"status"`
-	Priority             int32                 `json:"priority,omitempty"`
-	RenovateResultStatus *string               `json:"renovateResultStatus,omitempty"`
-	PRActivity           *PRActivity           `json:"prActivity,omitempty"`
-	LogIssues            *LogIssues            `json:"logIssues,omitempty"`
+	Name     string                `json:"name"`
+	LastRun  metav1.Time           `json:"lastRun"`
+	Duration *string               `json:"duration,omitempty"`
+	Status   RenovateProjectStatus `json:"status"`
+	Priority int32                 `json:"priority,omitempty"`
+	// ScheduledAt records when the project most recently entered the Scheduled
+	// state, used to measure queue wait time when it is dispatched.
+	ScheduledAt          *metav1.Time `json:"scheduledAt,omitempty"`
+	RenovateResultStatus *string      `json:"renovateResultStatus,omitempty"`
+	PRActivity           *PRActivity  `json:"prActivity,omitempty"`
+	LogIssues            *LogIssues   `json:"logIssues,omitempty"`
 }
 
 type RenovateProjectStatus string
@@ -298,6 +301,9 @@ func (in *RenovateJob) DeepCopyObject() runtime.Object {
 // DeepCopyInto deep copies a ProjectStatus into out.
 func (in *ProjectStatus) DeepCopyInto(out *ProjectStatus) {
 	*out = *in
+	if in.ScheduledAt != nil {
+		out.ScheduledAt = in.ScheduledAt.DeepCopy()
+	}
 	if in.Duration != nil {
 		out.Duration = new(string)
 		*out.Duration = *in.Duration

--- a/src/controllers/renovatejob_controller.go
+++ b/src/controllers/renovatejob_controller.go
@@ -74,8 +74,7 @@ func (r *RenovateJobReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	} else if errors.IsNotFound(err) {
 		// renovatejob cannot be found -> delete the schedule
 		// the github app token secret is owned by the RenovateJob and cleaned up by Kubernetes GC
-		name := req.Name + "-" + req.Namespace
-		r.Scheduler.RemoveSchedule(name)
+		r.Scheduler.RemoveSchedule(req.Namespace, req.Name)
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	} else {
 		span.RecordError(err)
@@ -159,7 +158,7 @@ func createScheduler(logger logr.Logger, renovateJob *api.RenovateJob, reconcile
 
 	// adding the schedule if it does not exist
 	// if the expression is different it will be updated
-	err := reconciler.Scheduler.AddScheduleReplaceExisting(expr, name, f)
+	err := reconciler.Scheduler.AddScheduleReplaceExisting(expr, renovateJob.Namespace, renovateJob.Name, f)
 	if err != nil {
 		logger.Error(err, "Failed to add schedule for RenovateJob")
 		return

--- a/src/controllers/renovatejob_controller_test.go
+++ b/src/controllers/renovatejob_controller_test.go
@@ -142,24 +142,24 @@ type fakeScheduler struct {
 	addErr       error
 }
 
-func (f *fakeScheduler) AddScheduleReplaceExisting(expr string, name string, fct func()) error {
+func (f *fakeScheduler) AddScheduleReplaceExisting(expr string, namespace, job string, fct func()) error {
 	f.addedExpr = expr
-	f.addedName = name
+	f.addedName = job + "-" + namespace
 	f.addCalled = true
 	f.storedFn = fct
 	return f.addErr
 }
-func (f *fakeScheduler) RemoveSchedule(name string) {
-	f.removedNames = append(f.removedNames, name)
+func (f *fakeScheduler) RemoveSchedule(namespace, job string) {
+	f.removedNames = append(f.removedNames, job+"-"+namespace)
 	f.removeCalled = true
 }
 
 // implement remaining methods of scheduler.Scheduler as no-ops for tests
 func (f *fakeScheduler) Start() {}
 func (f *fakeScheduler) Stop()  {}
-func (f *fakeScheduler) AddSchedule(expr string, name string, fn func()) error {
+func (f *fakeScheduler) AddSchedule(expr string, namespace, job string, fn func()) error {
 	// behave like AddScheduleReplaceExisting for tests
-	return f.AddScheduleReplaceExisting(expr, name, fn)
+	return f.AddScheduleReplaceExisting(expr, namespace, job, fn)
 }
 func (f *fakeScheduler) GetNextRunOnSchedule(schedule, key string) time.Time { return time.Time{} }
 

--- a/src/gitProviderClients/projectFilter.go
+++ b/src/gitProviderClients/projectFilter.go
@@ -7,6 +7,14 @@ import (
 	"github.com/go-logr/logr"
 )
 
+// FilterStats reports how many repositories were dropped by each criterion so
+// callers (which know the namespace/job labels) can record the
+// repositories_filtered metric.
+type FilterStats struct {
+	ForksRemoved   int
+	PendingRemoved int
+}
+
 // FilterProjects filters out repositories that should be skipped during
 // discovery according to the enabled criteria:
 //   - skipForks excludes forked repositories
@@ -17,9 +25,9 @@ import (
 // so enabling both criteria does not double the number of requests. On API
 // errors for individual repos, the repo is kept (fail-open) to avoid
 // accidentally excluding valid projects.
-func FilterProjects(ctx context.Context, providerClient GitProviderClient, logger logr.Logger, projects []string, skipForks, skipPendingDeletion bool) ([]string, error) {
+func FilterProjects(ctx context.Context, providerClient GitProviderClient, logger logr.Logger, projects []string, skipForks, skipPendingDeletion bool) ([]string, FilterStats, error) {
 	if len(projects) == 0 || (!skipForks && !skipPendingDeletion) {
-		return projects, nil
+		return projects, FilterStats{}, nil
 	}
 
 	const maxConcurrency = 10
@@ -51,6 +59,8 @@ func FilterProjects(ctx context.Context, providerClient GitProviderClient, logge
 	var forksRemoved, pendingRemoved int
 	for _, r := range results {
 		if r.err != nil {
+			// Fail-open: keep the repo when its metadata could not be fetched,
+			// rather than risk excluding a valid project.
 			logger.V(1).Info("Failed to fetch repository info, keeping it", "project", r.project, "error", r.err)
 			filtered = append(filtered, r.project)
 			continue
@@ -71,5 +81,5 @@ func FilterProjects(ctx context.Context, providerClient GitProviderClient, logge
 	if forksRemoved > 0 || pendingRemoved > 0 {
 		logger.Info("Filtered discovered repositories", "forks", forksRemoved, "pendingDeletion", pendingRemoved, "remaining", len(filtered))
 	}
-	return filtered, nil
+	return filtered, FilterStats{ForksRemoved: forksRemoved, PendingRemoved: pendingRemoved}, nil
 }

--- a/src/gitProviderClients/projectFilter_test.go
+++ b/src/gitProviderClients/projectFilter_test.go
@@ -80,7 +80,7 @@ func TestFilterProjects(t *testing.T) {
 			}
 
 			logger := logr.Logger{}
-			result, err := FilterProjects(context.Background(), client, logger, tt.projects, tt.skipForks, tt.skipPendingDeletion)
+			result, _, err := FilterProjects(context.Background(), client, logger, tt.projects, tt.skipForks, tt.skipPendingDeletion)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/src/internal/crdManager/renovateJobManager.go
+++ b/src/internal/crdManager/renovateJobManager.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -283,12 +284,14 @@ func (r *renovateJobManager) ReconcileProjects(ctx context.Context, renovateJob 
 		if err != nil {
 			r.logger.Error(err, "Failed to create git provider client for project filtering")
 		} else {
-			newProjects, err := gitProviderClients.FilterProjects(ctx, providerClient, r.logger, projects, renovateJob.Spec.SkipForks, renovateJob.Spec.SkipPendingDeletion)
+			newProjects, stats, err := gitProviderClients.FilterProjects(ctx, providerClient, r.logger, projects, renovateJob.Spec.SkipForks, renovateJob.Spec.SkipPendingDeletion)
 			if err != nil {
 				r.logger.Error(err, "Failed to filter discovered repositories")
 			} else {
 				r.logger.V(2).Info("Filtered discovered repositories", "remaining", len(newProjects))
 				projects = newProjects
+				metricStore.AddRepositoriesFiltered(ctx, renovateJob.Namespace, renovateJob.Name, "fork", stats.ForksRemoved)
+				metricStore.AddRepositoriesFiltered(ctx, renovateJob.Namespace, renovateJob.Name, "pending_deletion", stats.PendingRemoved)
 			}
 		}
 	}
@@ -329,10 +332,12 @@ func (r *renovateJobManager) ReconcileProjects(ctx context.Context, renovateJob 
 				newProjects = append(newProjects, crdProject)
 			} else {
 				// add new project to the list
+				now := v1.Now()
 				newProjects = append(newProjects, api.ProjectStatus{
-					Name:    project,
-					Status:  api.JobStatusScheduled,
-					LastRun: v1.Now(),
+					Name:        project,
+					Status:      api.JobStatusScheduled,
+					LastRun:     now,
+					ScheduledAt: &now,
 				})
 			}
 		}
@@ -523,11 +528,17 @@ func (r *renovateJobManager) getRenovateJobTokens(ctx context.Context, job *api.
 		Namespace: job.Namespace,
 	}, secret)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			metricStore.IncSecretResolutionError(ctx, "not_found")
+		} else {
+			metricStore.IncSecretResolutionError(ctx, "api_error")
+		}
 		return nil, err
 	}
 
 	authData, exists := secret.Data[job.Spec.Webhook.Authentication.SecretRef.Key]
 	if !exists {
+		metricStore.IncSecretResolutionError(ctx, "key_missing")
 		return nil, fmt.Errorf("secret key %s not found in secret %s", job.Spec.Webhook.Authentication.SecretRef.Key, job.Spec.Webhook.Authentication.SecretRef.Name)
 	}
 

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -8,6 +8,7 @@ import (
 	crdManager "renovate-operator/internal/crdManager"
 	"renovate-operator/internal/podLogs"
 	"renovate-operator/internal/types"
+	"renovate-operator/metricStore"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -103,7 +104,7 @@ func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *
 		return nil
 	}
 
-	status, _, err := getJobStatus(k8sJob)
+	status, _, _, err := getJobStatus(k8sJob)
 	if err != nil {
 		return err
 	}
@@ -113,6 +114,7 @@ func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *
 
 	if status == api.JobStatusFailed {
 		log.FromContext(ctx).Info("discovery job failed", "renovateJob", jobId.Name)
+		metricStore.IncDiscoveryJob(ctx, jobId.Namespace, jobId.Name, "failed")
 		_ = crdManager.MarkJobProcessed(ctx, e.client, k8sJob)
 		return nil
 	}
@@ -135,6 +137,9 @@ func (e *discoveryAgent) ProcessDiscoveryJobResult(ctx context.Context, k8sJob *
 		return nil
 	}
 	log.FromContext(ctx).V(2).Info("Discovered projects", "count", len(projects), "job", renovateJob.Fullname())
+
+	metricStore.IncDiscoveryJob(ctx, jobId.Namespace, jobId.Name, "completed")
+	metricStore.SetDiscoveredRepositories(jobId.Namespace, jobId.Name, len(projects))
 
 	removedProjects, err := e.manager.ReconcileProjects(ctx, renovateJob, projects)
 	if err != nil {
@@ -230,5 +235,8 @@ func (e *discoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api
 	if err != nil {
 		return "", fmt.Errorf("failed to create discovery job: %w", err)
 	}
+
+	metricStore.IncJobDispatched(ctx, renovateJob.Namespace, renovateJob.Name, "discovery")
+
 	return generation, nil
 }

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -133,6 +133,8 @@ func (e *renovateExecutor) execute(ctx context.Context, options executionOptions
 	span.SetAttributes(attribute.Int("renovate_operator.jobs.count", len(renovateJobs)))
 	log.FromContext(ctx).V(2).Info("Executing renovate executor loop for jobs", "count", len(renovateJobs))
 
+	metricStore.SetGlobalParallelismLimit(options.globalParallelism)
+
 	// Pass 1: check all currently running projects across all jobs, update their statuses,
 	// and count how many are still running globally and per job.
 	globalRunning, perJobRunning := e.countRunningProjects(renovateJobs)
@@ -148,10 +150,14 @@ func (e *renovateExecutor) execute(ctx context.Context, options executionOptions
 }
 
 // countRunningProjects returns the number of still-running projects globally and per job
-// (keyed by job fullname).
+// (keyed by job fullname). It also emits per-tick saturation gauges (running/scheduled
+// per job, global running) and the repositories-by-status gauge aggregated per job.
 func (e *renovateExecutor) countRunningProjects(renovateJobs []api.RenovateJob) (int, map[string]int) {
 	globalRunning := 0
 	perJobRunning := make(map[string]int, len(renovateJobs))
+
+	// Clear stale repositories_by_status series before repopulating for every job this tick.
+	metricStore.ResetRepositoriesByStatus()
 
 	for i := range renovateJobs {
 		renovateJob := &renovateJobs[i]
@@ -159,15 +165,33 @@ func (e *renovateExecutor) countRunningProjects(renovateJobs []api.RenovateJob) 
 		key := jobId.Fullname()
 		perJobRunning[key] = 0
 
+		scheduled := 0
+		byResultStatus := make(map[string]int)
 		for j := range renovateJob.Status.Projects {
 			project := &renovateJob.Status.Projects[j]
-			if project.Status != api.JobStatusRunning {
-				continue
+			if project.RenovateResultStatus != nil {
+				byResultStatus[metricStore.NormalizeRepositoryStatus(*project.RenovateResultStatus)]++
 			}
-			globalRunning++
-			perJobRunning[key]++
+			switch project.Status {
+			case api.JobStatusRunning:
+				globalRunning++
+				perJobRunning[key]++
+			case api.JobStatusScheduled:
+				scheduled++
+			}
+		}
+
+		// Saturation gauges (set 0 when none so stale values are cleared).
+		metricStore.SetProjectsRunning(renovateJob.Namespace, renovateJob.Name, perJobRunning[key])
+		metricStore.SetProjectsScheduled(renovateJob.Namespace, renovateJob.Name, scheduled)
+
+		// repositories_by_status aggregated at the job level by persisted Renovate result.
+		for status, count := range byResultStatus {
+			metricStore.SetRepositoriesByStatus(renovateJob.Namespace, renovateJob.Name, status, count)
 		}
 	}
+
+	metricStore.SetGlobalRunningProjects(globalRunning)
 
 	return globalRunning, perJobRunning
 }
@@ -178,11 +202,12 @@ func (e *renovateExecutor) countRunningProjects(renovateJobs []api.RenovateJob) 
 func (e *renovateExecutor) ProcessProjectJobResult(ctx context.Context, k8sJob *batchv1.Job, project string, jobId crdManager.RenovateJobIdentifier) error {
 	var newStatus api.RenovateProjectStatus
 	var durationStr string
+	var duration time.Duration
 	if k8sJob == nil {
 		newStatus = api.JobStatusFailed
 	} else {
 		var err error
-		newStatus, durationStr, err = getJobStatus(k8sJob)
+		newStatus, durationStr, duration, err = getJobStatus(k8sJob)
 		if err != nil {
 			return err
 		}
@@ -237,6 +262,37 @@ func (e *renovateExecutor) ProcessProjectJobResult(ctx context.Context, k8sJob *
 	}
 	metricStore.SetApprovalsNeeded(jobId.Namespace, jobId.Name, project, approvalsNeeded)
 	metricStore.CaptureRenovateProjectExecution(ctx, jobId.Namespace, jobId.Name, project, newStatus)
+
+	// Execution duration (Group A/E). Only emit when the k8s Job reported a StartTime.
+	if k8sJob != nil && k8sJob.Status.StartTime != nil {
+		seconds := duration.Seconds()
+		metricStore.ObserveJobDuration(ctx, jobId.Namespace, jobId.Name, "executor", newStatus, seconds)
+		metricStore.SetLastExecutionDuration(jobId.Namespace, jobId.Name, project, seconds)
+	}
+
+	// Failure breakdown by reason (Group A).
+	if newStatus == api.JobStatusFailed {
+		metricStore.IncJobFailure(ctx, jobId.Namespace, jobId.Name, "executor", jobFailureReason(k8sJob))
+	}
+
+	// Log issue counts (Group L).
+	if newProjectStatus.LogIssues != nil {
+		metricStore.SetLogIssues(jobId.Namespace, jobId.Name, project, "warn", newProjectStatus.LogIssues.WarnCount)
+		metricStore.SetLogIssues(jobId.Namespace, jobId.Name, project, "error", newProjectStatus.LogIssues.ErrorCount)
+	}
+
+	// Pull request activity (Group E/L).
+	if pr := newProjectStatus.PRActivity; pr != nil {
+		metricStore.AddPullRequestsCreated(ctx, jobId.Namespace, jobId.Name, pr.Created)
+		metricStore.AddPullRequestsMerged(ctx, jobId.Namespace, jobId.Name, pr.Automerged)
+		metricStore.AddPullRequestsUpdated(ctx, jobId.Namespace, jobId.Name, pr.Updated)
+		metricStore.SetPullRequestsAwaitingApproval(jobId.Namespace, jobId.Name, project, pr.NeedsApproval)
+		// Open managed PRs: automerged ones are closed, so exclude them.
+		metricStore.SetOpenPullRequests(jobId.Namespace, jobId.Name, project, pr.Created+pr.Updated+pr.NeedsApproval+pr.Unchanged)
+	} else {
+		metricStore.SetPullRequestsAwaitingApproval(jobId.Namespace, jobId.Name, project, 0)
+		metricStore.SetOpenPullRequests(jobId.Namespace, jobId.Name, project, 0)
+	}
 
 	if span := trace.SpanFromContext(ctx); span.IsRecording() {
 		span.AddEvent("project.completed", trace.WithAttributes(
@@ -362,6 +418,13 @@ func (e *renovateExecutor) dispatchScheduled(ctx context.Context, renovateJobs [
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)
+		}
+
+		metricStore.IncJobDispatched(ctx, renovateJob.Namespace, renovateJob.Name, "executor")
+
+		// Queue wait: time the project spent in Scheduled before this dispatch.
+		if project.ScheduledAt != nil {
+			metricStore.ObserveQueueWait(ctx, renovateJob.Namespace, renovateJob.Name, time.Since(project.ScheduledAt.Time).Seconds())
 		}
 
 		if span := trace.SpanFromContext(ctx); span.IsRecording() {

--- a/src/internal/renovate/jobHelper.go
+++ b/src/internal/renovate/jobHelper.go
@@ -11,10 +11,11 @@ import (
 )
 
 // get the renovateprojectstatus from an executing kubernetes job
-// Also returns a human readable duration string
-func getJobStatus(job *batchv1.Job) (api.RenovateProjectStatus, string, error) {
+// Also returns a human readable duration string and the numeric duration.
+// The numeric duration is zero when the job has no StartTime yet.
+func getJobStatus(job *batchv1.Job) (api.RenovateProjectStatus, string, time.Duration, error) {
 	if job == nil {
-		return api.JobStatusFailed, "", nil
+		return api.JobStatusFailed, "", 0, nil
 	}
 
 	var status api.RenovateProjectStatus
@@ -34,17 +35,42 @@ func getJobStatus(job *batchv1.Job) (api.RenovateProjectStatus, string, error) {
 
 	// Calculate duration
 	var durationStr string
+	var duration time.Duration
 	if job.Status.StartTime != nil {
 		var endTime = job.Status.CompletionTime
 		if endTime == nil {
 			// If not completed, use current time
 			endTime = &v1.Time{Time: time.Now()}
 		}
-		duration := endTime.Sub(job.Status.StartTime.Time)
+		duration = endTime.Sub(job.Status.StartTime.Time)
 		durationStr = humanDuration(duration)
 	}
 
-	return status, durationStr, nil
+	return status, durationStr, duration, nil
+}
+
+// jobFailureReason derives a coarse failure reason for the job_failures metric from the
+// k8s Job's JobFailed condition. A nil job means the job was not found.
+// Returns one of: timeout, backoff_exceeded, job_not_found, pod_error, unknown.
+func jobFailureReason(job *batchv1.Job) string {
+	if job == nil {
+		return "job_not_found"
+	}
+	for _, condition := range job.Status.Conditions {
+		if condition.Type != batchv1.JobFailed || condition.Status != corev1.ConditionTrue {
+			continue
+		}
+		switch condition.Reason {
+		case "DeadlineExceeded":
+			return "timeout"
+		case "BackoffLimitExceeded":
+			return "backoff_exceeded"
+		case "PodFailurePolicy":
+			return "pod_error"
+		}
+		return "unknown"
+	}
+	return "unknown"
 }
 
 // humanDuration returns a human readable duration string

--- a/src/internal/renovate/jobHelper_test.go
+++ b/src/internal/renovate/jobHelper_test.go
@@ -152,7 +152,7 @@ func TestGetJobStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status, duration, err := getJobStatus(tt.job)
+			status, durationStr, _, err := getJobStatus(tt.job)
 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -160,7 +160,7 @@ func TestGetJobStatus(t *testing.T) {
 			if status != tt.expectedStatus {
 				t.Errorf("expected status %v, got %v", tt.expectedStatus, status)
 			}
-			if tt.expectDuration && duration == "" {
+			if tt.expectDuration && durationStr == "" {
 				t.Errorf("expected a duration, got empty string")
 			}
 		})

--- a/src/internal/utils/projectStatus.go
+++ b/src/internal/utils/projectStatus.go
@@ -29,6 +29,8 @@ func validateProjectStatusScheduled(projectStatus *api.ProjectStatus, desiredSta
 	// cannot schedule a project that is currently running
 	if projectStatus.Status != api.JobStatusRunning {
 		projectStatus.Status = api.JobStatusScheduled
+		now := v1.Now()
+		projectStatus.ScheduledAt = &now
 		if desiredStatus.Priority > projectStatus.Priority {
 			projectStatus.Priority = desiredStatus.Priority
 		}

--- a/src/metricStore/metrics.go
+++ b/src/metricStore/metrics.go
@@ -16,7 +16,22 @@ import (
 
 var otelMeter = otel.Meter("renovate-operator/metrics")
 
-// Prometheus metrics
+// Label-key constants shared between Prometheus label names and OTel attribute keys so
+// the two emission paths expose identical dimensions.
+const (
+	labelNamespace = "renovate_namespace"
+	labelJob       = "renovate_job"
+	labelProject   = "project"
+	labelStatus    = "status"
+	labelKind      = "kind"
+	labelReason    = "reason"
+	labelResult    = "result"
+	labelLevel     = "level"
+	labelProvider  = "provider"
+	labelErrorType = "error_type"
+)
+
+// Prometheus metrics — existing.
 var (
 	executorLoopDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
@@ -31,31 +46,239 @@ var (
 			Name: "renovate_operator_project_executions_total",
 			Help: "Total number of executed Renovate projects",
 		},
-		[]string{"renovate_namespace", "renovate_job", "project", "status"})
+		[]string{labelNamespace, labelJob, labelProject, labelStatus})
 
 	runFailed = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "renovate_operator_run_failed",
 			Help: "Whether the last Renovate run for this project failed (1=failed, 0=success)",
 		},
-		[]string{"renovate_namespace", "renovate_job", "project"})
+		[]string{labelNamespace, labelJob, labelProject})
 
 	dependencyIssues = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "renovate_operator_dependency_issues",
 			Help: "Whether the last Renovate run had WARN/ERROR log entries (1=issues found, 0=clean)",
 		},
-		[]string{"renovate_namespace", "renovate_job", "project"})
+		[]string{labelNamespace, labelJob, labelProject})
 
 	approvalsNeeded = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "renovate_operator_approvals_needed",
 			Help: "Number of dependency updates awaiting approval after the last Renovate run",
 		},
-		[]string{"renovate_namespace", "renovate_job", "project"})
+		[]string{labelNamespace, labelJob, labelProject})
 )
 
-// OTel metrics — no-ops when OTel is not configured.
+// Prometheus metrics — SRE: job lifecycle & latency (Group A).
+var (
+	jobsDispatched = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_jobs_dispatched_total",
+			Help: "Total number of Kubernetes Jobs launched by the operator",
+		},
+		[]string{labelNamespace, labelJob, labelKind})
+
+	jobDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "renovate_operator_job_duration_seconds",
+			Help:    "Wall-clock duration of a Renovate Kubernetes Job in seconds",
+			Buckets: []float64{10, 30, 60, 120, 300, 600, 1200, 1800, 3600},
+		},
+		[]string{labelNamespace, labelJob, labelKind, labelStatus})
+
+	queueWait = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "renovate_operator_project_queue_wait_seconds",
+			Help:    "Time a project spent in Scheduled before being dispatched, in seconds",
+			Buckets: []float64{1, 5, 15, 30, 60, 300, 900, 3600},
+		},
+		[]string{labelNamespace, labelJob})
+
+	jobFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_job_failures_total",
+			Help: "Total Renovate Job failures by failure mode",
+		},
+		[]string{labelNamespace, labelJob, labelKind, labelReason})
+)
+
+// Prometheus metrics — SRE: saturation & queue depth (Group B).
+var (
+	projectsScheduled = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_projects_scheduled",
+			Help: "Number of projects currently in Scheduled state (queue depth) per job",
+		},
+		[]string{labelNamespace, labelJob})
+
+	projectsRunning = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_projects_running",
+			Help: "Number of projects currently Running (in-flight) per job",
+		},
+		[]string{labelNamespace, labelJob})
+
+	globalRunningProjects = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_global_running_projects",
+			Help: "Total number of Running projects across all jobs",
+		})
+
+	globalParallelismLimit = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_global_parallelism_limit",
+			Help: "Configured global parallelism limit (0 = unlimited)",
+		})
+)
+
+// Prometheus metrics — SRE: discovery (Group C).
+var (
+	discoveryJobs = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_discovery_jobs_total",
+			Help: "Total discovery Jobs completed by status",
+		},
+		[]string{labelNamespace, labelJob, labelStatus})
+
+	discoveredRepositories = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_discovered_repositories",
+			Help: "Number of repositories seen by the last discovery run",
+		},
+		[]string{labelNamespace, labelJob})
+
+	repositoriesFiltered = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_repositories_filtered_total",
+			Help: "Total repositories dropped by discovery filters by reason",
+		},
+		[]string{labelNamespace, labelJob, labelReason})
+)
+
+// Prometheus metrics — SRE: scheduler (Group D).
+var (
+	scheduleRuns = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_schedule_runs_total",
+			Help: "Total cron schedule firings executed by result",
+		},
+		[]string{labelNamespace, labelJob, labelResult})
+
+	scheduleNextRun = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_schedule_next_run_timestamp_seconds",
+			Help: "Unix timestamp of the next planned scheduled run",
+		},
+		[]string{labelNamespace, labelJob})
+)
+
+// Prometheus metrics — SRE: log quality (Group E).
+var (
+	logIssues = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_log_issues",
+			Help: "Count of WARN/ERROR log entries in the last run, by level",
+		},
+		[]string{labelNamespace, labelJob, labelProject, labelLevel})
+)
+
+// Prometheus metrics — Results & outcomes (Group L).
+var (
+	openPullRequests = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_open_pull_requests",
+			Help: "Number of open Renovate-managed pull requests after the last run",
+		},
+		[]string{labelNamespace, labelJob, labelProject})
+
+	pullRequestsAwaitingApproval = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_pull_requests_awaiting_approval",
+			Help: "Number of pull requests awaiting human approval after the last run",
+		},
+		[]string{labelNamespace, labelJob, labelProject})
+
+	repositoriesByStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_repositories_by_status",
+			Help: "Number of repositories per Renovate result status (coverage)",
+		},
+		[]string{labelNamespace, labelJob, labelStatus})
+
+	pullRequestsCreated = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_pull_requests_created_total",
+			Help: "Total Renovate pull requests created",
+		},
+		[]string{labelNamespace, labelJob})
+
+	pullRequestsMerged = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_pull_requests_merged_total",
+			Help: "Total Renovate pull requests automerged (updates that landed)",
+		},
+		[]string{labelNamespace, labelJob})
+
+	pullRequestsUpdated = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_pull_requests_updated_total",
+			Help: "Total Renovate pull requests updated",
+		},
+		[]string{labelNamespace, labelJob})
+
+	lastExecutionDuration = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "renovate_operator_last_execution_duration_seconds",
+			Help: "Duration of the most recent Renovate run for this project, in seconds",
+		},
+		[]string{labelNamespace, labelJob, labelProject})
+)
+
+// Prometheus metrics — SecOps: webhook integrity (Group H).
+var (
+	webhookRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_webhook_requests_total",
+			Help: "Total webhook requests by provider and outcome",
+		},
+		[]string{labelProvider, labelResult})
+
+	webhookSignatureFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_webhook_signature_verification_failures_total",
+			Help: "Total webhook HMAC signature verification failures by provider",
+		},
+		[]string{labelProvider})
+
+	webhookAuthFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_webhook_auth_failures_total",
+			Help: "Total webhook authentication failures by provider and error type",
+		},
+		[]string{labelProvider, labelErrorType})
+
+	webhookPayloadDecodeFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_webhook_payload_decode_failures_total",
+			Help: "Total webhook payloads that failed to decode by provider",
+		},
+		[]string{labelProvider})
+)
+
+// Prometheus metrics — SecOps: credential resolution (Group I).
+var (
+	secretResolutionErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "renovate_operator_secret_resolution_errors_total",
+			Help: "Total Kubernetes Secret resolution errors by error type",
+		},
+		[]string{labelErrorType})
+)
+
+// OTel metrics — no-ops when OTel is not configured. Mirrors the Prometheus
+// counters/histograms above. Gauges are intentionally Prometheus-only, matching the
+// existing run_failed/dependency_issues/approvals_needed convention.
 var (
 	otelExecutorLoopDuration, _ = otelMeter.Float64Histogram(
 		"renovate_operator.executor.loop.duration",
@@ -67,30 +290,101 @@ var (
 		metric.WithUnit("{execution}"),
 		metric.WithDescription("Total executed Renovate project runs"),
 	)
+
+	otelJobsDispatched, _    = otelMeter.Int64Counter("renovate_operator.jobs.dispatched", metric.WithDescription("Kubernetes Jobs launched"))
+	otelJobDuration, _       = otelMeter.Float64Histogram("renovate_operator.job.duration", metric.WithUnit("s"), metric.WithDescription("Renovate Job wall-clock duration"))
+	otelQueueWait, _         = otelMeter.Float64Histogram("renovate_operator.project.queue_wait", metric.WithUnit("s"), metric.WithDescription("Time a project waited in Scheduled"))
+	otelJobFailures, _       = otelMeter.Int64Counter("renovate_operator.job.failures", metric.WithDescription("Renovate Job failures by mode"))
+	otelDiscoveryJobs, _     = otelMeter.Int64Counter("renovate_operator.discovery.jobs", metric.WithDescription("Discovery Jobs by status"))
+	otelReposFiltered, _     = otelMeter.Int64Counter("renovate_operator.repositories.filtered", metric.WithDescription("Repositories dropped by filters"))
+	otelScheduleRuns, _      = otelMeter.Int64Counter("renovate_operator.schedule.runs", metric.WithDescription("Cron schedule firings by result"))
+	otelPRsCreated, _        = otelMeter.Int64Counter("renovate_operator.pull_requests.created", metric.WithDescription("Pull requests created"))
+	otelPRsMerged, _         = otelMeter.Int64Counter("renovate_operator.pull_requests.merged", metric.WithDescription("Pull requests automerged"))
+	otelPRsUpdated, _        = otelMeter.Int64Counter("renovate_operator.pull_requests.updated", metric.WithDescription("Pull requests updated"))
+	otelWebhookRequests, _   = otelMeter.Int64Counter("renovate_operator.webhook.requests", metric.WithDescription("Webhook requests by outcome"))
+	otelWebhookSigFail, _    = otelMeter.Int64Counter("renovate_operator.webhook.signature_verification.failures", metric.WithDescription("Webhook signature failures"))
+	otelWebhookAuthFail, _   = otelMeter.Int64Counter("renovate_operator.webhook.auth.failures", metric.WithDescription("Webhook auth failures"))
+	otelWebhookDecodeFail, _ = otelMeter.Int64Counter("renovate_operator.webhook.payload_decode.failures", metric.WithDescription("Webhook payload decode failures"))
+	otelSecretResolErrors, _ = otelMeter.Int64Counter("renovate_operator.secret.resolution.errors", metric.WithDescription("Secret resolution errors"))
 )
 
 func Register(registry ctrlmetrics.RegistererGatherer) {
-	registry.MustRegister(executorLoopDuration)
-	registry.MustRegister(projectRuns)
-	registry.MustRegister(runFailed)
-	registry.MustRegister(dependencyIssues)
-	registry.MustRegister(approvalsNeeded)
+	registry.MustRegister(
+		// existing
+		executorLoopDuration,
+		projectRuns,
+		runFailed,
+		dependencyIssues,
+		approvalsNeeded,
+		// Group A
+		jobsDispatched,
+		jobDuration,
+		queueWait,
+		jobFailures,
+		// Group B
+		projectsScheduled,
+		projectsRunning,
+		globalRunningProjects,
+		globalParallelismLimit,
+		// Group C
+		discoveryJobs,
+		discoveredRepositories,
+		repositoriesFiltered,
+		// Group D
+		scheduleRuns,
+		scheduleNextRun,
+		// Group E
+		logIssues,
+		// Group L
+		openPullRequests,
+		pullRequestsAwaitingApproval,
+		repositoriesByStatus,
+		pullRequestsCreated,
+		pullRequestsMerged,
+		pullRequestsUpdated,
+		lastExecutionDuration,
+		// Group H
+		webhookRequests,
+		webhookSignatureFailures,
+		webhookAuthFailures,
+		webhookPayloadDecodeFailures,
+		// Group I
+		secretResolutionErrors,
+	)
 }
 
-func ObserveExecutorLoopDuration(ctx context.Context, duration time.Duration) {
-	executorLoopDuration.Observe(duration.Seconds())
-	if otelExecutorLoopDuration.Enabled(ctx) {
-		otelExecutorLoopDuration.Record(ctx, duration.Seconds())
+// addOtel records an OTel counter increment when an OTel meter is configured.
+func addOtel(ctx context.Context, c metric.Int64Counter, n int64, attrs ...attribute.KeyValue) {
+	if c.Enabled(ctx) {
+		c.Add(ctx, n, metric.WithAttributes(attrs...))
 	}
 }
 
+// recordOtel records an OTel histogram observation when an OTel meter is configured.
+func recordOtel(ctx context.Context, h metric.Float64Histogram, v float64, attrs ...attribute.KeyValue) {
+	if h.Enabled(ctx) {
+		h.Record(ctx, v, metric.WithAttributes(attrs...))
+	}
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1.0
+	}
+	return 0.0
+}
+
+// ---------------------------------------------------------------------------
+// Existing helpers
+// ---------------------------------------------------------------------------
+
+func ObserveExecutorLoopDuration(ctx context.Context, duration time.Duration) {
+	executorLoopDuration.Observe(duration.Seconds())
+	recordOtel(ctx, otelExecutorLoopDuration, duration.Seconds())
+}
+
 func CaptureRenovateProjectExecution(ctx context.Context, namespace, job, project string, status api.RenovateProjectStatus) {
-	projectRuns.WithLabelValues(
-		namespace,
-		job,
-		project,
-		string(status),
-	).Inc()
+	projectRuns.WithLabelValues(namespace, job, project, string(status)).Inc()
 	if otelProjectExecutions.Enabled(ctx) {
 		otelProjectExecutions.Add(ctx, 1,
 			metric.WithAttributes(
@@ -117,20 +411,12 @@ func MapPipelineResult(status api.RenovateProjectStatus) attribute.KeyValue {
 
 // SetRunFailed sets the run_failed gauge for a project
 func SetRunFailed(namespace, job, project string, failed bool) {
-	value := 0.0
-	if failed {
-		value = 1.0
-	}
-	runFailed.WithLabelValues(namespace, job, project).Set(value)
+	runFailed.WithLabelValues(namespace, job, project).Set(boolToFloat(failed))
 }
 
 // SetDependencyIssues sets the dependency_issues gauge for a project
 func SetDependencyIssues(namespace, job, project string, hasIssues bool) {
-	value := 0.0
-	if hasIssues {
-		value = 1.0
-	}
-	dependencyIssues.WithLabelValues(namespace, job, project).Set(value)
+	dependencyIssues.WithLabelValues(namespace, job, project).Set(boolToFloat(hasIssues))
 }
 
 // SetApprovalsNeeded sets the count of dependency updates awaiting approval for a project.
@@ -138,11 +424,239 @@ func SetApprovalsNeeded(namespace, job, project string, count int) {
 	approvalsNeeded.WithLabelValues(namespace, job, project).Set(float64(count))
 }
 
-// DeleteProjectMetrics removes all metrics for a project that was removed from discovery
+// ---------------------------------------------------------------------------
+// Group A — job lifecycle & latency
+// ---------------------------------------------------------------------------
+
+// IncJobDispatched counts a Kubernetes Job launch. kind is "executor" or "discovery".
+func IncJobDispatched(ctx context.Context, namespace, job, kind string) {
+	jobsDispatched.WithLabelValues(namespace, job, kind).Inc()
+	addOtel(ctx, otelJobsDispatched, 1,
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job), attribute.String(labelKind, kind))
+}
+
+// ObserveJobDuration records the wall-clock duration of a finished Renovate Job.
+func ObserveJobDuration(ctx context.Context, namespace, job, kind string, status api.RenovateProjectStatus, seconds float64) {
+	jobDuration.WithLabelValues(namespace, job, kind, string(status)).Observe(seconds)
+	recordOtel(ctx, otelJobDuration, seconds,
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job),
+		attribute.String(labelKind, kind), attribute.String(labelStatus, string(status)))
+}
+
+// ObserveQueueWait records how long a project waited in Scheduled before dispatch.
+func ObserveQueueWait(ctx context.Context, namespace, job string, seconds float64) {
+	queueWait.WithLabelValues(namespace, job).Observe(seconds)
+	recordOtel(ctx, otelQueueWait, seconds,
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job))
+}
+
+// IncJobFailure counts a Job failure by mode (timeout/backoff_exceeded/job_not_found/pod_error/unknown).
+func IncJobFailure(ctx context.Context, namespace, job, kind, reason string) {
+	jobFailures.WithLabelValues(namespace, job, kind, reason).Inc()
+	addOtel(ctx, otelJobFailures, 1,
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job),
+		attribute.String(labelKind, kind), attribute.String(labelReason, reason))
+}
+
+// ---------------------------------------------------------------------------
+// Group B — saturation & queue depth (gauges, Prometheus-only)
+// ---------------------------------------------------------------------------
+
+func SetProjectsScheduled(namespace, job string, count int) {
+	projectsScheduled.WithLabelValues(namespace, job).Set(float64(count))
+}
+
+func SetProjectsRunning(namespace, job string, count int) {
+	projectsRunning.WithLabelValues(namespace, job).Set(float64(count))
+}
+
+func SetGlobalRunningProjects(count int) {
+	globalRunningProjects.Set(float64(count))
+}
+
+func SetGlobalParallelismLimit(limit int) {
+	globalParallelismLimit.Set(float64(limit))
+}
+
+// ---------------------------------------------------------------------------
+// Group C — discovery
+// ---------------------------------------------------------------------------
+
+// IncDiscoveryJob counts a finished discovery Job. status is "completed" or "failed".
+func IncDiscoveryJob(ctx context.Context, namespace, job, status string) {
+	discoveryJobs.WithLabelValues(namespace, job, status).Inc()
+	addOtel(ctx, otelDiscoveryJobs, 1,
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job), attribute.String(labelStatus, status))
+}
+
+func SetDiscoveredRepositories(namespace, job string, count int) {
+	discoveredRepositories.WithLabelValues(namespace, job).Set(float64(count))
+}
+
+// AddRepositoriesFiltered counts repositories dropped by a filter. reason is "fork" or "pending_deletion".
+func AddRepositoriesFiltered(ctx context.Context, namespace, job, reason string, count int) {
+	if count <= 0 {
+		return
+	}
+	repositoriesFiltered.WithLabelValues(namespace, job, reason).Add(float64(count))
+	addOtel(ctx, otelReposFiltered, int64(count),
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job), attribute.String(labelReason, reason))
+}
+
+// ---------------------------------------------------------------------------
+// Group D — scheduler
+// ---------------------------------------------------------------------------
+
+// IncScheduleRun counts a cron firing. result is "success" or "error".
+func IncScheduleRun(ctx context.Context, namespace, job, result string) {
+	scheduleRuns.WithLabelValues(namespace, job, result).Inc()
+	addOtel(ctx, otelScheduleRuns, 1,
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job), attribute.String(labelResult, result))
+}
+
+// SetScheduleNextRun sets the Unix timestamp (seconds) of the next planned run.
+func SetScheduleNextRun(namespace, job string, unixSeconds float64) {
+	scheduleNextRun.WithLabelValues(namespace, job).Set(unixSeconds)
+}
+
+// ---------------------------------------------------------------------------
+// Group E — log quality (gauge, Prometheus-only)
+// ---------------------------------------------------------------------------
+
+// SetLogIssues sets the count of log entries for a level ("warn" or "error").
+func SetLogIssues(namespace, job, project, level string, count int) {
+	logIssues.WithLabelValues(namespace, job, project, level).Set(float64(count))
+}
+
+// ---------------------------------------------------------------------------
+// Group L — results & outcomes
+// ---------------------------------------------------------------------------
+
+func SetOpenPullRequests(namespace, job, project string, count int) {
+	openPullRequests.WithLabelValues(namespace, job, project).Set(float64(count))
+}
+
+func SetPullRequestsAwaitingApproval(namespace, job, project string, count int) {
+	pullRequestsAwaitingApproval.WithLabelValues(namespace, job, project).Set(float64(count))
+}
+
+// SetRepositoriesByStatus sets the count of repositories for a job in a given Renovate
+// result status. The status label must be a bounded value from NormalizeRepositoryStatus:
+// disabled, no_config, onboarding, onboarding_closed, unknown, or other.
+func SetRepositoriesByStatus(namespace, job, status string, count int) {
+	repositoriesByStatus.WithLabelValues(namespace, job, status).Set(float64(count))
+}
+
+// ResetRepositoriesByStatus clears every repositories_by_status series. The executor
+// repopulates the gauge for all jobs on each tick, so resetting first prevents stale
+// values lingering for statuses that fall to zero (or for deleted jobs).
+func ResetRepositoriesByStatus() {
+	repositoriesByStatus.Reset()
+}
+
+// NormalizeRepositoryStatus maps a raw Renovate result status (as produced by the log
+// parser, which may emit friendly strings or an arbitrary finished.Result) to a bounded
+// label value, keeping the repositories_by_status metric's cardinality fixed.
+func NormalizeRepositoryStatus(raw string) string {
+	switch raw {
+	case "Disabled":
+		return "disabled"
+	case "No Config":
+		return "no_config"
+	case "Onboarding":
+		return "onboarding"
+	case "Onboarding Closed":
+		return "onboarding_closed"
+	case "Unknown", "":
+		return "unknown"
+	default:
+		return "other"
+	}
+}
+
+func AddPullRequestsCreated(ctx context.Context, namespace, job string, count int) {
+	if count <= 0 {
+		return
+	}
+	pullRequestsCreated.WithLabelValues(namespace, job).Add(float64(count))
+	addOtel(ctx, otelPRsCreated, int64(count),
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job))
+}
+
+func AddPullRequestsMerged(ctx context.Context, namespace, job string, count int) {
+	if count <= 0 {
+		return
+	}
+	pullRequestsMerged.WithLabelValues(namespace, job).Add(float64(count))
+	addOtel(ctx, otelPRsMerged, int64(count),
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job))
+}
+
+func AddPullRequestsUpdated(ctx context.Context, namespace, job string, count int) {
+	if count <= 0 {
+		return
+	}
+	pullRequestsUpdated.WithLabelValues(namespace, job).Add(float64(count))
+	addOtel(ctx, otelPRsUpdated, int64(count),
+		attribute.String(labelNamespace, namespace), attribute.String(labelJob, job))
+}
+
+// SetLastExecutionDuration sets the most-recent run duration for a project, in seconds.
+func SetLastExecutionDuration(namespace, job, project string, seconds float64) {
+	lastExecutionDuration.WithLabelValues(namespace, job, project).Set(seconds)
+}
+
+// ---------------------------------------------------------------------------
+// Group H — webhook integrity
+// ---------------------------------------------------------------------------
+
+// IncWebhookRequest counts a webhook request. provider is github/gitlab/forgejo/schedule;
+// result is accepted/rejected/ignored.
+func IncWebhookRequest(ctx context.Context, provider, result string) {
+	webhookRequests.WithLabelValues(provider, result).Inc()
+	addOtel(ctx, otelWebhookRequests, 1, attribute.String(labelProvider, provider), attribute.String(labelResult, result))
+}
+
+func IncWebhookSignatureFailure(ctx context.Context, provider string) {
+	webhookSignatureFailures.WithLabelValues(provider).Inc()
+	addOtel(ctx, otelWebhookSigFail, 1, attribute.String(labelProvider, provider))
+}
+
+// IncWebhookAuthFailure counts a webhook auth failure. errorType is no_matching_job/auth_failed/secret_error.
+func IncWebhookAuthFailure(ctx context.Context, provider, errorType string) {
+	webhookAuthFailures.WithLabelValues(provider, errorType).Inc()
+	addOtel(ctx, otelWebhookAuthFail, 1, attribute.String(labelProvider, provider), attribute.String(labelErrorType, errorType))
+}
+
+func IncWebhookPayloadDecodeFailure(ctx context.Context, provider string) {
+	webhookPayloadDecodeFailures.WithLabelValues(provider).Inc()
+	addOtel(ctx, otelWebhookDecodeFail, 1, attribute.String(labelProvider, provider))
+}
+
+// ---------------------------------------------------------------------------
+// Group I — credential resolution
+// ---------------------------------------------------------------------------
+
+// IncSecretResolutionError counts a Secret resolution error. errorType is not_found/key_missing/api_error.
+func IncSecretResolutionError(ctx context.Context, errorType string) {
+	secretResolutionErrors.WithLabelValues(errorType).Inc()
+	addOtel(ctx, otelSecretResolErrors, 1, attribute.String(labelErrorType, errorType))
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+// DeleteProjectMetrics removes all per-project metrics for a project that was removed from discovery.
 func DeleteProjectMetrics(namespace, job, project string) {
 	runFailed.DeleteLabelValues(namespace, job, project)
 	dependencyIssues.DeleteLabelValues(namespace, job, project)
 	approvalsNeeded.DeleteLabelValues(namespace, job, project)
+	openPullRequests.DeleteLabelValues(namespace, job, project)
+	pullRequestsAwaitingApproval.DeleteLabelValues(namespace, job, project)
+	lastExecutionDuration.DeleteLabelValues(namespace, job, project)
+	logIssues.DeleteLabelValues(namespace, job, project, "warn")
+	logIssues.DeleteLabelValues(namespace, job, project, "error")
 	// Note: projectRuns counter has an additional "status" label, so we delete both possible values
 	projectRuns.DeleteLabelValues(namespace, job, project, "completed")
 	projectRuns.DeleteLabelValues(namespace, job, project, "failed")

--- a/src/metricStore/metrics_test.go
+++ b/src/metricStore/metrics_test.go
@@ -142,3 +142,153 @@ func TestDeleteProjectMetrics(t *testing.T) {
 		t.Errorf("projectRuns metric count should decrease after deletion: before=%d, after=%d", projectRunsCountBefore, projectRunsCountAfter)
 	}
 }
+
+func TestIncJobDispatched(t *testing.T) {
+	ctx := context.Background()
+	IncJobDispatched(ctx, "ns", "job", "executor")
+	IncJobDispatched(ctx, "ns", "job", "executor")
+	IncJobDispatched(ctx, "ns", "job", "discovery")
+
+	if v := testutil.ToFloat64(jobsDispatched.WithLabelValues("ns", "job", "executor")); v != 2.0 {
+		t.Errorf("jobsDispatched{executor} = %v, want 2", v)
+	}
+	if v := testutil.ToFloat64(jobsDispatched.WithLabelValues("ns", "job", "discovery")); v != 1.0 {
+		t.Errorf("jobsDispatched{discovery} = %v, want 1", v)
+	}
+
+	jobsDispatched.DeleteLabelValues("ns", "job", "executor")
+	jobsDispatched.DeleteLabelValues("ns", "job", "discovery")
+}
+
+func TestObserveJobDuration(t *testing.T) {
+	ctx := context.Background()
+	ObserveJobDuration(ctx, "ns", "job", "executor", api.JobStatusCompleted, 42.0)
+
+	// A HistogramVec exposes a _count series; one observation means count == 1.
+	if c := testutil.CollectAndCount(jobDuration); c == 0 {
+		t.Errorf("jobDuration should have at least one series after observation, got %d", c)
+	}
+	jobDuration.DeleteLabelValues("ns", "job", "executor", string(api.JobStatusCompleted))
+}
+
+func TestSetSaturationGauges(t *testing.T) {
+	SetProjectsScheduled("ns", "job", 5)
+	SetProjectsRunning("ns", "job", 3)
+	SetGlobalRunningProjects(8)
+	SetGlobalParallelismLimit(10)
+
+	if v := testutil.ToFloat64(projectsScheduled.WithLabelValues("ns", "job")); v != 5.0 {
+		t.Errorf("projectsScheduled = %v, want 5", v)
+	}
+	if v := testutil.ToFloat64(projectsRunning.WithLabelValues("ns", "job")); v != 3.0 {
+		t.Errorf("projectsRunning = %v, want 3", v)
+	}
+	if v := testutil.ToFloat64(globalRunningProjects); v != 8.0 {
+		t.Errorf("globalRunningProjects = %v, want 8", v)
+	}
+	if v := testutil.ToFloat64(globalParallelismLimit); v != 10.0 {
+		t.Errorf("globalParallelismLimit = %v, want 10", v)
+	}
+
+	projectsScheduled.DeleteLabelValues("ns", "job")
+	projectsRunning.DeleteLabelValues("ns", "job")
+}
+
+func TestPullRequestCounters(t *testing.T) {
+	ctx := context.Background()
+	AddPullRequestsCreated(ctx, "ns", "job", 3)
+	AddPullRequestsMerged(ctx, "ns", "job", 2)
+	AddPullRequestsUpdated(ctx, "ns", "job", 1)
+	// count<=0 must be a no-op
+	AddPullRequestsCreated(ctx, "ns", "job", 0)
+
+	if v := testutil.ToFloat64(pullRequestsCreated.WithLabelValues("ns", "job")); v != 3.0 {
+		t.Errorf("pullRequestsCreated = %v, want 3", v)
+	}
+	if v := testutil.ToFloat64(pullRequestsMerged.WithLabelValues("ns", "job")); v != 2.0 {
+		t.Errorf("pullRequestsMerged = %v, want 2", v)
+	}
+	if v := testutil.ToFloat64(pullRequestsUpdated.WithLabelValues("ns", "job")); v != 1.0 {
+		t.Errorf("pullRequestsUpdated = %v, want 1", v)
+	}
+
+	pullRequestsCreated.DeleteLabelValues("ns", "job")
+	pullRequestsMerged.DeleteLabelValues("ns", "job")
+	pullRequestsUpdated.DeleteLabelValues("ns", "job")
+}
+
+func TestSecOpsCounters(t *testing.T) {
+	ctx := context.Background()
+	IncWebhookSignatureFailure(ctx, "github")
+	IncWebhookSignatureFailure(ctx, "github")
+	IncSecretResolutionError(ctx, "not_found")
+
+	if v := testutil.ToFloat64(webhookSignatureFailures.WithLabelValues("github")); v != 2.0 {
+		t.Errorf("webhookSignatureFailures{github} = %v, want 2", v)
+	}
+	if v := testutil.ToFloat64(secretResolutionErrors.WithLabelValues("not_found")); v != 1.0 {
+		t.Errorf("secretResolutionErrors{not_found} = %v, want 1", v)
+	}
+
+	webhookSignatureFailures.DeleteLabelValues("github")
+	secretResolutionErrors.DeleteLabelValues("not_found")
+}
+
+func TestNormalizeRepositoryStatus(t *testing.T) {
+	tests := map[string]string{
+		"Disabled":            "disabled",
+		"No Config":           "no_config",
+		"Onboarding":          "onboarding",
+		"Onboarding Closed":   "onboarding_closed",
+		"Unknown":             "unknown",
+		"":                    "unknown",
+		"done":                "other",
+		"disabled-no-config":  "other",
+		"something-brand-new": "other",
+	}
+	for raw, want := range tests {
+		if got := NormalizeRepositoryStatus(raw); got != want {
+			t.Errorf("NormalizeRepositoryStatus(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestResetRepositoriesByStatus(t *testing.T) {
+	SetRepositoriesByStatus("ns", "job", "disabled", 3)
+	SetRepositoriesByStatus("ns", "job", "unknown", 1)
+	if testutil.CollectAndCount(repositoriesByStatus) == 0 {
+		t.Fatal("repositoriesByStatus should have series before reset")
+	}
+
+	ResetRepositoriesByStatus()
+
+	if v := testutil.CollectAndCount(repositoriesByStatus); v != 0 {
+		t.Errorf("repositoriesByStatus should be empty after reset, got %d series", v)
+	}
+}
+
+func TestDeleteProjectMetricsRemovesNewSeries(t *testing.T) {
+	ns, job, proj := "del2-ns", "del2-job", "del2-proj"
+
+	SetOpenPullRequests(ns, job, proj, 4)
+	SetPullRequestsAwaitingApproval(ns, job, proj, 2)
+	SetLastExecutionDuration(ns, job, proj, 12.5)
+	SetLogIssues(ns, job, proj, "warn", 1)
+	SetLogIssues(ns, job, proj, "error", 1)
+
+	if testutil.CollectAndCount(openPullRequests) == 0 {
+		t.Fatal("openPullRequests should exist before deletion")
+	}
+
+	DeleteProjectMetrics(ns, job, proj)
+
+	if v := testutil.CollectAndCount(openPullRequests); v != 0 {
+		t.Errorf("openPullRequests should be empty after deletion, got %d series", v)
+	}
+	if v := testutil.CollectAndCount(lastExecutionDuration); v != 0 {
+		t.Errorf("lastExecutionDuration should be empty after deletion, got %d series", v)
+	}
+	if v := testutil.CollectAndCount(logIssues); v != 0 {
+		t.Errorf("logIssues should be empty after deletion, got %d series", v)
+	}
+}

--- a/src/scheduler/scheduler.go
+++ b/src/scheduler/scheduler.go
@@ -1,7 +1,9 @@
 package scheduler
 
 import (
+	"context"
 	"renovate-operator/health"
+	"renovate-operator/metricStore"
 	"sync"
 	"time"
 
@@ -18,12 +20,13 @@ type Scheduler interface {
 	Start()
 	// Stops the scheduler.
 	Stop()
-	// Adds a new schedule with the given cron expression, name, and function to execute.
-	AddSchedule(expr string, name string, fn func()) error
-	// Adds a new schedule, replacing any existing schedule with the same name.
-	AddScheduleReplaceExisting(expr string, name string, fn func()) error
-	// Removes a schedule by name.
-	RemoveSchedule(name string)
+	// Adds a new schedule for the given RenovateJob (namespace/job identify it and
+	// label its metrics) with the given cron expression and function to execute.
+	AddSchedule(expr string, namespace, job string, fn func()) error
+	// Adds a new schedule, replacing any existing schedule for the same RenovateJob.
+	AddScheduleReplaceExisting(expr string, namespace, job string, fn func()) error
+	// Removes a schedule for the given RenovateJob.
+	RemoveSchedule(namespace, job string)
 	// Gets the next run time for a cron schedule expression.
 	// key is used as a seed for Jenkins-style H expressions; pass an empty string for plain cron.
 	GetNextRunOnSchedule(schedule, key string) time.Time
@@ -72,15 +75,23 @@ func (s *scheduler) Stop() {
 	s.cronManager.Stop()
 }
 
+// scheduleName builds the internal schedule key from a RenovateJob's namespace and
+// name. It matches RenovateJob.Fullname() ("${name}-${namespace}") so the health-map
+// key and cron registration are unchanged from earlier behavior.
+func scheduleName(namespace, job string) string {
+	return job + "-" + namespace
+}
+
 // Adds a new schedule, does NOT cleanly remove existing ones with the same name
-func (s *scheduler) AddSchedule(expr string, name string, fn func()) error {
+func (s *scheduler) AddSchedule(expr string, namespace, job string, fn func()) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	name := scheduleName(namespace, job)
 	sched, err := s.hashParser.ParseWithHashKey(expr, name)
 	if err != nil {
 		return err
 	}
-	id, err := s.cronManager.ScheduleJob(sched, cron.FuncJob(s.execute(name, expr, fn)))
+	id, err := s.cronManager.ScheduleJob(sched, cron.FuncJob(s.execute(name, expr, namespace, job, fn)))
 	if err != nil {
 		return err
 	}
@@ -88,21 +99,27 @@ func (s *scheduler) AddSchedule(expr string, name string, fn func()) error {
 		entryId:  id,
 		schedule: expr,
 	}
+	nextRun := s.GetNextRunOnSchedule(expr, name)
 	// setting health status
 	s.health.SetSchedulerHealth(func(e *health.SchedulerHealth) *health.SchedulerHealth {
 		e.Scheduler[name] = health.SingleSchedulerHealth{
 			Name:      name,
-			NextRun:   s.GetNextRunOnSchedule(expr, name),
+			NextRun:   nextRun,
 			Schedule:  expr,
 			IsRunning: true,
 		}
 		return e
 	})
+	// emit next planned run metric (Group D); AddScheduleReplaceExisting delegates here.
+	if !nextRun.IsZero() {
+		metricStore.SetScheduleNextRun(namespace, job, float64(nextRun.Unix()))
+	}
 	return nil
 }
 
 // Adds a new schedule, if one with the same name already exists, it will be replaced
-func (s *scheduler) AddScheduleReplaceExisting(expr string, name string, fn func()) error {
+func (s *scheduler) AddScheduleReplaceExisting(expr string, namespace, job string, fn func()) error {
+	name := scheduleName(namespace, job)
 	s.mu.Lock()
 	entry, exists := s.entries[name]
 	s.mu.Unlock()
@@ -112,13 +129,14 @@ func (s *scheduler) AddScheduleReplaceExisting(expr string, name string, fn func
 			return nil // Schedule already exists with the same expression
 		}
 		// If the schedule exists but with a different expression, remove it first
-		s.RemoveSchedule(name)
+		s.RemoveSchedule(namespace, job)
 	}
-	return s.AddSchedule(expr, name, fn)
+	return s.AddSchedule(expr, namespace, job, fn)
 }
-func (s *scheduler) RemoveSchedule(name string) {
+func (s *scheduler) RemoveSchedule(namespace, job string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	name := scheduleName(namespace, job)
 	if entry, ok := s.entries[name]; ok {
 		s.cronManager.Remove(entry.entryId)
 		delete(s.entries, name)
@@ -138,9 +156,16 @@ func (s *scheduler) GetNextRunOnSchedule(schedule, key string) time.Time {
 	return sched.Next(time.Now())
 }
 
-// execute the cron expression while also adapting the health status in this time
-func (s *scheduler) execute(key string, schedule string, fn func()) func() {
+// execute the cron expression while also adapting the health status in this time.
+// key is the internal schedule/health key; ns and job are the RenovateJob's
+// namespace and name, used as metric labels.
+func (s *scheduler) execute(key string, schedule string, ns, job string, fn func()) func() {
 	return func() {
+		// The scheduled function is a bare func() with no error return, so the only
+		// failure signal available without changing the public Scheduler signature is
+		// a panic. Treat a panic as an "error" run and everything else as "success".
+		ctx := context.Background()
+
 		s.health.SetSchedulerHealth(func(e *health.SchedulerHealth) *health.SchedulerHealth {
 			e.Scheduler[key] = health.SingleSchedulerHealth{
 				Name:      key,
@@ -151,17 +176,29 @@ func (s *scheduler) execute(key string, schedule string, fn func()) func() {
 			return e
 		})
 
+		nextRun := s.GetNextRunOnSchedule(schedule, key)
 		defer s.health.SetSchedulerHealth(func(e *health.SchedulerHealth) *health.SchedulerHealth {
 			e.Scheduler[key] = health.SingleSchedulerHealth{
 				Name:      key,
-				NextRun:   s.GetNextRunOnSchedule(schedule, key),
+				NextRun:   nextRun,
 				Schedule:  schedule,
 				IsRunning: false,
 			}
 			return e
 		})
+		// refresh next planned run metric (Group D) as the schedule fires.
+		if !nextRun.IsZero() {
+			metricStore.SetScheduleNextRun(ns, job, float64(nextRun.Unix()))
+		}
 
 		s.logger.Info("executing schedule", "schedule", key)
+		defer func() {
+			if r := recover(); r != nil {
+				metricStore.IncScheduleRun(ctx, ns, job, "error")
+				panic(r) // preserve existing panic-propagation behavior
+			}
+			metricStore.IncScheduleRun(ctx, ns, job, "success")
+		}()
 		fn()
 		s.logger.Info("schedule executed", "schedule", key)
 	}

--- a/src/scheduler/scheduler_test.go
+++ b/src/scheduler/scheduler_test.go
@@ -40,7 +40,7 @@ func TestAddSchedule(t *testing.T) {
 	s.Start()
 	defer s.Stop()
 
-	err := s.AddSchedule("* * * * *", "test-schedule", func() {})
+	err := s.AddSchedule("* * * * *", "schedule", "test", func() {})
 
 	if err != nil {
 		t.Fatalf("AddSchedule returned error: %v", err)
@@ -59,7 +59,7 @@ func TestAddScheduleInvalidCron(t *testing.T) {
 	s.Start()
 	defer s.Stop()
 
-	err := s.AddSchedule("invalid-cron", "test-invalid", func() {})
+	err := s.AddSchedule("invalid-cron", "invalid", "test", func() {})
 	if err == nil {
 		t.Error("AddSchedule should return error for invalid cron expression")
 	}
@@ -72,19 +72,19 @@ func TestAddScheduleReplaceExisting(t *testing.T) {
 	defer s.Stop()
 
 	// Add initial schedule
-	err := s.AddSchedule("* * * * *", "test-replace", func() {})
+	err := s.AddSchedule("* * * * *", "replace", "test", func() {})
 	if err != nil {
 		t.Fatalf("AddSchedule returned error: %v", err)
 	}
 
 	// Replace with same schedule - should not error
-	err = s.AddScheduleReplaceExisting("* * * * *", "test-replace", func() {})
+	err = s.AddScheduleReplaceExisting("* * * * *", "replace", "test", func() {})
 	if err != nil {
 		t.Fatalf("AddScheduleReplaceExisting returned error for same schedule: %v", err)
 	}
 
 	// Replace with different schedule
-	err = s.AddScheduleReplaceExisting("*/2 * * * *", "test-replace", func() {})
+	err = s.AddScheduleReplaceExisting("*/2 * * * *", "replace", "test", func() {})
 	if err != nil {
 		t.Fatalf("AddScheduleReplaceExisting returned error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestRemoveSchedule(t *testing.T) {
 	defer s.Stop()
 
 	// Add a schedule
-	err := s.AddSchedule("* * * * *", "test-remove", func() {})
+	err := s.AddSchedule("* * * * *", "remove", "test", func() {})
 	if err != nil {
 		t.Fatalf("AddSchedule returned error: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestRemoveSchedule(t *testing.T) {
 	}
 
 	// Remove the schedule
-	s.RemoveSchedule("test-remove")
+	s.RemoveSchedule("remove", "test")
 
 	// Verify schedule was removed
 	hc = h.GetHealth()
@@ -130,7 +130,7 @@ func TestRemoveSchedule(t *testing.T) {
 	}
 
 	// Removing non-existent schedule should not panic
-	s.RemoveSchedule("non-existent")
+	s.RemoveSchedule("existent", "non")
 }
 
 func TestGetNextRun(t *testing.T) {
@@ -140,7 +140,7 @@ func TestGetNextRun(t *testing.T) {
 	defer s.Stop()
 
 	// Add a schedule
-	err := s.AddSchedule("* * * * *", "test-next", func() {})
+	err := s.AddSchedule("* * * * *", "next", "test", func() {})
 	if err != nil {
 		t.Fatalf("AddSchedule returned error: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestScheduleExecution(t *testing.T) {
 	defer s.Stop()
 
 	// Schedule every minute (cron uses 5 fields by default)
-	err := s.AddSchedule("* * * * *", "test-exec", func() {})
+	err := s.AddSchedule("* * * * *", "exec", "test", func() {})
 
 	if err != nil {
 		t.Fatalf("AddSchedule returned error: %v", err)
@@ -197,7 +197,7 @@ func TestAddScheduleHashedCron(t *testing.T) {
 			s.Start()
 			defer s.Stop()
 
-			err := s.AddSchedule(tt.expr, "my-job-default", func() {})
+			err := s.AddSchedule(tt.expr, "default", "my-job", func() {})
 			if err != nil {
 				t.Fatalf("AddSchedule(%q) returned unexpected error: %v", tt.expr, err)
 			}
@@ -305,11 +305,11 @@ func TestAddScheduleReplaceExistingHashedCronSameExprNotReAdded(t *testing.T) {
 	callCount := 0
 	add := func() { callCount++ }
 
-	if err := s.AddSchedule("H H * * *", "hashed-job", add); err != nil {
+	if err := s.AddSchedule("H H * * *", "default", "hashed-job", add); err != nil {
 		t.Fatalf("AddSchedule: %v", err)
 	}
 	// same expression + same name — must be a no-op
-	if err := s.AddScheduleReplaceExisting("H H * * *", "hashed-job", add); err != nil {
+	if err := s.AddScheduleReplaceExisting("H H * * *", "default", "hashed-job", add); err != nil {
 		t.Fatalf("AddScheduleReplaceExisting: %v", err)
 	}
 

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -474,13 +474,13 @@ func TestRunDiscoveryForProject_AlreadyRunning(t *testing.T) {
 // Additional mock types needed for authorization tests
 type mockScheduler struct{}
 
-func (m *mockScheduler) Start()                                                {}
-func (m *mockScheduler) Stop()                                                 {}
-func (m *mockScheduler) AddSchedule(expr string, name string, fn func()) error { return nil }
-func (m *mockScheduler) AddScheduleReplaceExisting(expr string, name string, fn func()) error {
+func (m *mockScheduler) Start()                                                          {}
+func (m *mockScheduler) Stop()                                                           {}
+func (m *mockScheduler) AddSchedule(expr string, namespace, job string, fn func()) error { return nil }
+func (m *mockScheduler) AddScheduleReplaceExisting(expr string, namespace, job string, fn func()) error {
 	return nil
 }
-func (m *mockScheduler) RemoveSchedule(name string) {}
+func (m *mockScheduler) RemoveSchedule(namespace, job string) {}
 func (m *mockScheduler) GetNextRunOnSchedule(schedule, key string) time.Time {
 	return time.Now().Add(24 * time.Hour)
 }

--- a/src/webhook/forgejo.go
+++ b/src/webhook/forgejo.go
@@ -7,6 +7,7 @@ import (
 
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/internal/types"
+	"renovate-operator/metricStore"
 )
 
 // Forgejo webhook types and handler.
@@ -63,20 +64,27 @@ type ForgejoUser struct {
 }
 
 func (s *Server) forgejoWebhook(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	const provider = "forgejo"
+
 	event := r.Header.Get("X-Forgejo-Event")
 	if event == "" {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing X-Forgejo-Event header"})
 		return
 	}
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read request body"})
 		return
 	}
 
 	var payload ForgejoEvent
 	if err := json.Unmarshal(body, &payload); err != nil {
+		metricStore.IncWebhookPayloadDecodeFailure(ctx, provider)
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.logger.Error(err, "failed to decode Forgejo webhook payload. Not processing.")
 		s.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to decode payload"})
 		return
@@ -84,6 +92,7 @@ func (s *Server) forgejoWebhook(w http.ResponseWriter, r *http.Request) {
 
 	valid, reason := isValidForgejoEvent(event, &payload)
 	if !valid {
+		metricStore.IncWebhookRequest(ctx, provider, "ignored")
 		s.logger.Info("ignoring Forgejo webhook event", "event", event, "repository", payload.Repository.FullName, "reason", reason)
 		s.writeJSON(w, http.StatusOK, map[string]string{"message": "event ignored", "reason": reason})
 		return
@@ -94,8 +103,10 @@ func (s *Server) forgejoWebhook(w http.ResponseWriter, r *http.Request) {
 	project := payload.Repository.FullName
 
 	checker := buildAuthCheckerFromRequest(r, body, s.manager)
-	jobId, err := FindAndAuthenticateJob(r.Context(), s.manager, namespace, jobName, project, checker)
+	jobId, err := FindAndAuthenticateJob(ctx, s.manager, namespace, jobName, project, checker)
 	if err != nil {
+		s.recordResolverAuthFailure(ctx, provider, err, signatureWasUsed(r))
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.logger.Info("webhook resolve failed", "event", event, "project", project, "error", err)
 		s.handleResolverError(w, err)
 		return
@@ -103,7 +114,7 @@ func (s *Server) forgejoWebhook(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Info("received Forgejo event", "event", event, "repository", project, "action", payload.Action)
 	err = s.manager.UpdateProjectStatus(
-		r.Context(),
+		ctx,
 		project,
 		jobId,
 		&types.RenovateStatusUpdate{
@@ -112,9 +123,11 @@ func (s *Server) forgejoWebhook(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	if s.handleUpdateProjectStatusError(w, err, project, jobId.Name, jobId.Namespace) {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		return
 	}
 
+	metricStore.IncWebhookRequest(ctx, provider, "accepted")
 	s.writeJSON(w, http.StatusAccepted, map[string]string{"message": "renovate job scheduled", "repository": project})
 }
 

--- a/src/webhook/github.go
+++ b/src/webhook/github.go
@@ -7,6 +7,7 @@ import (
 
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/internal/types"
+	"renovate-operator/metricStore"
 )
 
 type GitHubEvent struct {
@@ -36,14 +37,20 @@ type GitHubRepository struct {
 }
 
 func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	const provider = "github"
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read request body"})
 		return
 	}
 
 	var payload GitHubEvent
 	if err := json.Unmarshal(body, &payload); err != nil {
+		metricStore.IncWebhookPayloadDecodeFailure(ctx, provider)
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.logger.Error(err, "failed to decode github webhook payload. Not processing.")
 		s.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to decode payload"})
 		return
@@ -51,6 +58,7 @@ func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
 
 	valid, reason := isValidGitHubEvent(&payload)
 	if !valid {
+		metricStore.IncWebhookRequest(ctx, provider, "ignored")
 		s.logger.Info("ignoring github webhook event", "reason", reason)
 		s.writeJSON(w, http.StatusOK, map[string]string{"message": "event ignored", "reason": reason})
 		return
@@ -61,8 +69,10 @@ func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
 	project := payload.Repository.FullName
 
 	checker := buildAuthCheckerFromRequest(r, body, s.manager)
-	jobId, err := FindAndAuthenticateJob(r.Context(), s.manager, namespace, jobName, project, checker)
+	jobId, err := FindAndAuthenticateJob(ctx, s.manager, namespace, jobName, project, checker)
 	if err != nil {
+		s.recordResolverAuthFailure(ctx, provider, err, signatureWasUsed(r))
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.logger.Info("webhook resolve failed", "project", project, "error", err)
 		s.handleResolverError(w, err)
 		return
@@ -70,7 +80,7 @@ func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Info("received github event", "repository", project, "action", payload.Action, "priority", 1)
 	err = s.manager.UpdateProjectStatus(
-		r.Context(),
+		ctx,
 		project,
 		jobId,
 		&types.RenovateStatusUpdate{
@@ -79,9 +89,11 @@ func (s *Server) githubWebhook(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	if s.handleUpdateProjectStatusError(w, err, project, jobId.Name, jobId.Namespace) {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		return
 	}
 
+	metricStore.IncWebhookRequest(ctx, provider, "accepted")
 	s.writeJSON(w, http.StatusAccepted, map[string]string{"message": "renovate job scheduled", "repository": project})
 }
 

--- a/src/webhook/gitlab.go
+++ b/src/webhook/gitlab.go
@@ -7,6 +7,7 @@ import (
 
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/internal/types"
+	"renovate-operator/metricStore"
 )
 
 type GitLabEvent struct {
@@ -39,14 +40,20 @@ type ChangeDescription struct {
 }
 
 func (s *Server) gitLabWebhook(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	const provider = "gitlab"
+
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read request body"})
 		return
 	}
 
 	var payload GitLabEvent
 	if err := json.Unmarshal(body, &payload); err != nil {
+		metricStore.IncWebhookPayloadDecodeFailure(ctx, provider)
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.logger.Error(err, "failed to decode gitlab webhook payload. Not processing.")
 		s.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to decode payload"})
 		return
@@ -54,6 +61,7 @@ func (s *Server) gitLabWebhook(w http.ResponseWriter, r *http.Request) {
 
 	valid, reason := isValidGitLabEvent(&payload)
 	if !valid {
+		metricStore.IncWebhookRequest(ctx, provider, "ignored")
 		s.logger.Info("ignoring GitLab webhook event", "reason", reason)
 		s.writeJSON(w, http.StatusOK, map[string]string{"message": "event ignored", "reason": reason})
 		return
@@ -64,8 +72,10 @@ func (s *Server) gitLabWebhook(w http.ResponseWriter, r *http.Request) {
 	project := payload.Project.PathWithNamespace
 
 	checker := buildAuthCheckerFromRequest(r, body, s.manager)
-	jobId, err := FindAndAuthenticateJob(r.Context(), s.manager, namespace, jobName, project, checker)
+	jobId, err := FindAndAuthenticateJob(ctx, s.manager, namespace, jobName, project, checker)
 	if err != nil {
+		s.recordResolverAuthFailure(ctx, provider, err, signatureWasUsed(r))
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.logger.Info("webhook resolve failed", "project", project, "error", err)
 		s.handleResolverError(w, err)
 		return
@@ -73,7 +83,7 @@ func (s *Server) gitLabWebhook(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Info("received GitLab event", "repository", project, "action", payload.ObjectAttributes.Action, "priority", 1)
 	err = s.manager.UpdateProjectStatus(
-		r.Context(),
+		ctx,
 		project,
 		jobId,
 		&types.RenovateStatusUpdate{
@@ -82,9 +92,11 @@ func (s *Server) gitLabWebhook(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	if s.handleUpdateProjectStatusError(w, err, project, jobId.Name, jobId.Namespace) {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		return
 	}
 
+	metricStore.IncWebhookRequest(ctx, provider, "accepted")
 	s.writeJSON(w, http.StatusAccepted, map[string]string{"message": "renovate job scheduled", "project": project})
 }
 

--- a/src/webhook/resolver.go
+++ b/src/webhook/resolver.go
@@ -104,6 +104,18 @@ func hasProject(projects []api.ProjectStatus, project string) bool {
 	return false
 }
 
+// signatureWasUsed reports whether an HMAC signature header was the credential that
+// buildAuthCheckerFromRequest would actually use for this request. It mirrors that
+// function's precedence: a bearer/X-Gitlab-Token token takes priority over a
+// signature header, so a signature is only "used" when no token header is present.
+// This lets callers attribute an authentication failure to a signature mismatch.
+func signatureWasUsed(r *http.Request) bool {
+	if r.Header.Get("Authorization") != "" || r.Header.Get("X-Gitlab-Token") != "" {
+		return false
+	}
+	return r.Header.Get("X-Hub-Signature-256") != "" || r.Header.Get("X-Forgejo-Signature") != ""
+}
+
 // buildAuthCheckerFromRequest extracts auth credentials from request headers and returns
 // an AuthChecker that validates them against a RenovateJob. Returns nil if no credential is present.
 func buildAuthCheckerFromRequest(r *http.Request, body []byte, manager credentialValidator) AuthChecker {

--- a/src/webhook/server.go
+++ b/src/webhook/server.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	crdmanager "renovate-operator/internal/crdManager"
 	"renovate-operator/internal/telemetry"
 	"renovate-operator/internal/types"
+	"renovate-operator/metricStore"
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
@@ -69,8 +71,12 @@ func (s *Server) Run() {
 }
 
 func (s *Server) runRenovate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	const provider = "schedule"
+
 	project := r.URL.Query().Get("project")
 	if project == "" {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing project query parameter"})
 		return
 	}
@@ -80,19 +86,22 @@ func (s *Server) runRenovate(w http.ResponseWriter, r *http.Request) {
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read request body"})
 		return
 	}
 
 	checker := buildAuthCheckerFromRequest(r, body, s.manager)
-	jobId, err := FindAndAuthenticateJob(r.Context(), s.manager, namespace, jobName, project, checker)
+	jobId, err := FindAndAuthenticateJob(ctx, s.manager, namespace, jobName, project, checker)
 	if err != nil {
+		s.recordResolverAuthFailure(ctx, provider, err, signatureWasUsed(r))
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		s.handleResolverError(w, err)
 		return
 	}
 
 	err = s.manager.UpdateProjectStatus(
-		r.Context(),
+		ctx,
 		project,
 		jobId,
 		&types.RenovateStatusUpdate{
@@ -101,11 +110,38 @@ func (s *Server) runRenovate(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	if s.handleUpdateProjectStatusError(w, err, project, jobId.Name, jobId.Namespace) {
+		metricStore.IncWebhookRequest(ctx, provider, "rejected")
 		return
 	}
 
+	metricStore.IncWebhookRequest(ctx, provider, "accepted")
 	w.WriteHeader(http.StatusOK)
 	s.logger.V(2).Info("Successfully triggered Renovate for project", "project", project, "renovateJob", jobId.Name, "namespace", jobId.Namespace, "priority", 1)
+}
+
+// recordResolverAuthFailure emits the appropriate webhook auth-failure metric for an
+// error returned by FindAndAuthenticateJob:
+//   - ErrNoMatchingJob       -> "no_matching_job"
+//   - ErrAuthenticationFailed -> "auth_failed"
+//   - any other surfaced error (e.g. secret/credential resolution) -> "secret_error"
+//
+// When authentication failed and an HMAC signature header (rather than a bearer
+// token) was the credential actually used, it additionally records a signature
+// verification failure. This is a heuristic: the resolver collapses signature and
+// token mismatches into ErrAuthenticationFailed, so the signature failure is only
+// counted on the path where a signature header was supplied and used.
+func (s *Server) recordResolverAuthFailure(ctx context.Context, provider string, err error, signatureUsed bool) {
+	switch {
+	case errors.Is(err, ErrNoMatchingJob):
+		metricStore.IncWebhookAuthFailure(ctx, provider, "no_matching_job")
+	case errors.Is(err, ErrAuthenticationFailed):
+		metricStore.IncWebhookAuthFailure(ctx, provider, "auth_failed")
+		if signatureUsed {
+			metricStore.IncWebhookSignatureFailure(ctx, provider)
+		}
+	default:
+		metricStore.IncWebhookAuthFailure(ctx, provider, "secret_error")
+	}
 }
 
 func (s *Server) handleResolverError(w http.ResponseWriter, err error) {


### PR DESCRIPTION
Adds ~23 Prometheus/OTel metrics for SRE observability (job lifecycle, saturation, discovery, scheduler, PR outcomes) plus webhook-integrity and secret-resolution metrics.

Adds a `scheduledAt` field to the RenovateJob CRD status to measure queue wait. `go build`/`vet`/`test` pass; docs in `docs/metrics.md`.