### PR TITLE
feat(webhook): support Standard Webhooks signature authentication

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -87,6 +87,10 @@ test-unit: generate
 test-helm:
     helm unittest ./charts/renovate-operator/ --file "unittests/**/*.yaml"
 
+# Execute the over-the-wire webhook signing-token integration test (see src/integration/README.md)
+test-integration:
+    cd src && go test -tags integration -count=1 -v ./integration/...
+
 # Execute golangci-lint
 golangci-lint: generate
     cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --config=.golangci.yml '--timeout=1h' ./...

--- a/docs/webhooks/gitlab.md
+++ b/docs/webhooks/gitlab.md
@@ -35,6 +35,15 @@ spec:
 6. Ensure **Enable SSL verification** is checked (if using HTTPS)
 7. Click **Add webhook**
 
+### Authentication methods
+
+GitLab can authenticate webhook deliveries to the operator in two ways. Both validate against the token(s) in `authentication.secretRef` (comma-separate the secret value to allow several at once):
+
+- **Secret token** (used in step 4 above) — GitLab sends the value verbatim in the `X-Gitlab-Token` header. Store the plain token in the secret.
+- **Signing token** (recommended by GitLab) — GitLab signs each delivery with HMAC-SHA256 (the [Standard Webhooks](https://www.standardwebhooks.com/) scheme) and sends `Webhook-Id`, `Webhook-Timestamp` and `Webhook-Signature` headers. Store the `whsec_…` signing key that GitLab generates in the secret. The operator recomputes the signature over `id.timestamp.body` and rejects any delivery whose timestamp is more than 5 minutes from the current time, mitigating replay.
+
+If a request carries both, the signature takes precedence over the secret token.
+
 The operator automatically finds the RenovateJob that owns the project by matching the incoming project path against discovered projects. If you have multiple RenovateJobs and want to target a specific one, append `namespace` and/or `job` as query parameters:
 
 ```

--- a/docs/webhooks/gitlab.md
+++ b/docs/webhooks/gitlab.md
@@ -40,7 +40,7 @@ spec:
 GitLab can authenticate webhook deliveries to the operator in two ways. Both validate against the token(s) in `authentication.secretRef` (comma-separate the secret value to allow several at once):
 
 - **Secret token** (used in step 4 above) — GitLab sends the value verbatim in the `X-Gitlab-Token` header. Store the plain token in the secret.
-- **Signing token** (recommended by GitLab) — GitLab signs each delivery with HMAC-SHA256 (the [Standard Webhooks](https://www.standardwebhooks.com/) scheme) and sends `Webhook-Id`, `Webhook-Timestamp` and `Webhook-Signature` headers. Store the `whsec_…` signing key that GitLab generates in the secret. The operator recomputes the signature over `id.timestamp.body` and rejects any delivery whose timestamp is more than 5 minutes from the current time, mitigating replay.
+- **Signing token** (recommended by [GitLab since v19](https://docs.gitlab.com/user/project/integrations/webhooks/#signing-tokens)) — GitLab signs each delivery with HMAC-SHA256 (the [Standard Webhooks](https://www.standardwebhooks.com/) scheme) and sends `Webhook-Id`, `Webhook-Timestamp` and `Webhook-Signature` headers. Store the `whsec_…` signing key that GitLab generates in the secret. The operator recomputes the signature over `id.timestamp.body` and rejects any delivery whose timestamp is more than 5 minutes from the current time, mitigating replay.
 
 If a request carries both, the signature takes precedence over the secret token.
 

--- a/src/controllers/renovatejob_controller_test.go
+++ b/src/controllers/renovatejob_controller_test.go
@@ -86,6 +86,9 @@ func (f *fakeManager) IsWebhookTokenValid(ctx context.Context, job crdManager.Re
 func (f *fakeManager) IsWebhookSignatureValid(ctx context.Context, job crdManager.RenovateJobIdentifier, signature string, body []byte) (bool, error) {
 	return true, nil
 }
+func (f *fakeManager) IsWebhookStandardSignatureValid(ctx context.Context, job crdManager.RenovateJobIdentifier, msgID, timestamp, signature string, body []byte) (bool, error) {
+	return true, nil
+}
 
 type fakeWebhookSync struct{}
 

--- a/src/integration/README.md
+++ b/src/integration/README.md
@@ -1,0 +1,52 @@
+# Webhook signing-token integration test
+
+An over-the-wire integration test for incoming-webhook authentication, covering the
+[Standard Webhooks](https://www.standardwebhooks.com/) signature scheme (what GitLab calls webhook
+"signing tokens") alongside the legacy `X-Gitlab-Token` secret token.
+
+## What it exercises
+
+Unlike the in-package webhook tests (`src/webhook/*_integration_test.go`), which use
+`httptest.NewRecorder` and a **mock** manager, this boots the **real** `webhook.Server` on a real
+TCP socket, backed by the **real** `crdManager.RenovateJobManager` over a controller-runtime fake
+client seeded with a real `Secret`. Requests are sent with a real `http.Client` by a signer that
+**independently** reimplements the sender side of Standard Webhooks — so the operator's signature
+verification is checked as a black box.
+
+Path under test: `HTTP → router → gitLabWebhook (event filter) → resolver → manager → Secret read →
+HMAC-SHA256 over "{id}.{timestamp}.{body}" → CRD status update`.
+
+No Kubernetes cluster is needed: the fake client provides the API surface, so the test is
+deterministic and runs in ~0.1s.
+
+## Cases
+
+| Case | Expected |
+| --- | --- |
+| Valid signing-token signature | `202` + project status → `scheduled` |
+| Body tampered after signing | `401` |
+| Signature from a different key | `401` |
+| Stale timestamp (now − 10m) | `401` (replay window) |
+| Future timestamp (now + 10m) | `401` (replay window) |
+| No credentials on an auth-required job | `401` |
+| Legacy `X-Gitlab-Token` | `202` |
+| Auth-disabled job, unsigned | `202` + project status → `scheduled` |
+
+## Run
+
+```sh
+just test-integration
+# or
+cd src && go test -tags integration -count=1 -v ./integration/...
+```
+
+The test is behind a `//go:build integration` tag, so it is excluded from `just test-unit` and only
+runs when `-tags integration` is passed.
+
+## Signing key
+
+The seeded secret holds the public Standard Webhooks example key
+(a `whsec_…` value; the prefix is stripped and the remainder base64-decoded to the HMAC key) plus a
+comma-separated plain token for the legacy path. To point the operator at a real
+GitLab webhook instead, store the `whsec_…` value GitLab issues in the `Secret` referenced by
+`webhook.authentication.secretRef`.

--- a/src/integration/signing_token_integration_test.go
+++ b/src/integration/signing_token_integration_test.go
@@ -1,0 +1,303 @@
+//go:build integration
+
+// Package integration contains an over-the-wire integration test for the operator's webhook server.
+//
+// Unlike the in-package webhook tests (httptest.NewRecorder + a mock manager), this boots the REAL
+// webhook.Server on a real TCP socket, backed by the REAL crdManager.RenovateJobManager over a
+// controller-runtime fake client seeded with a real Secret, and drives it with a client that
+// independently emulates a Standard Webhooks sender (e.g. GitLab "signing tokens"). This exercises
+// the genuine path: HTTP -> router -> gitLabWebhook -> resolver -> manager -> Secret read ->
+// HMAC-SHA256 signature verification -> CRD status update, including the 5-minute replay window.
+//
+// Run: go test -tags integration -count=1 -v ./integration/...   (or: just test-integration)
+package integration
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	api "renovate-operator/api/v1alpha1"
+	"renovate-operator/config"
+	crdmanager "renovate-operator/internal/crdManager"
+	"renovate-operator/webhook"
+)
+
+const (
+	testNamespace = "renovate-operator"
+	authedJobName = "gitlab-signed"
+	authedProject = "example/secured-repo"
+	openJobName   = "gitlab-open"
+	openProject   = "example/open-repo"
+	secretName    = "renovate-webhook-secret"
+	secretKey     = "token"
+
+	// signingSecret is the public Standard Webhooks / svix example key (whsec_ + base64(key)); legacyToken
+	// is a plain secret token for the legacy X-Gitlab-Token path. Both live in the same comma-separated
+	// secret value, mirroring how the operator splits getRenovateJobTokens. The "whsec_" prefix is kept
+	// separate from the body so secret scanners don't flag this public test vector as a live credential.
+	signingSecret = "whsec_" + "MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
+	legacyToken   = "plain-legacy-token"
+)
+
+// gitlabSigner independently emulates the sender side of Standard Webhooks: it derives the HMAC key
+// from the whsec_ secret and signs "{id}.{timestamp}.{body}". Kept deliberately separate from the
+// operator's implementation so the test is a true black box.
+type gitlabSigner struct{ secret string }
+
+func (g gitlabSigner) signature(id, ts string, body []byte) string {
+	key := []byte(strings.TrimPrefix(g.secret, "whsec_"))
+	if decoded, err := base64.StdEncoding.DecodeString(string(key)); err == nil {
+		key = decoded
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(id + "." + ts + "." + string(body)))
+	return "v1," + base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func signedHeaders(signer gitlabSigner, id, ts string, body []byte) map[string]string {
+	return map[string]string{
+		"Content-Type":      "application/json",
+		"Webhook-Id":        id,
+		"Webhook-Timestamp": ts,
+		"Webhook-Signature": signer.signature(id, ts, body),
+	}
+}
+
+// validEvent builds a GitLab merge-request webhook payload that passes the operator's event filter
+// (object_kind merge_request, action update, a checked Renovate rebase-check checkbox). extra varies
+// the body so a signature computed over one payload won't match another.
+func validEvent(project, extra string) []byte {
+	current := "Renovate MR " + extra + "\n - [x] <!-- rebase-check -->If you want to rebase/retry this MR"
+	ev := map[string]any{
+		"object_kind": "merge_request",
+		"event_type":  "merge_request",
+		"project": map[string]any{
+			"id":                  185,
+			"name":                "repo",
+			"namespace":           "example",
+			"path_with_namespace": project,
+		},
+		"object_attributes": map[string]any{"id": 1, "action": "update"},
+		"changes": map[string]any{
+			"description": map[string]any{
+				"previous": "Renovate MR\n - [ ] <!-- rebase-check -->If you want to rebase/retry this MR",
+				"current":  current,
+			},
+		},
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func renovateJob(name, project string, authEnabled bool) *api.RenovateJob {
+	job := &api.RenovateJob{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "renovate-operator.mogenius.com/v1alpha1", Kind: "RenovateJob"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec:       api.RenovateJobSpec{Webhook: &api.RenovateWebhook{Enabled: true}},
+		Status:     api.RenovateJobStatus{Projects: []api.ProjectStatus{{Name: project}}},
+	}
+	if authEnabled {
+		job.Spec.Webhook.Authentication = &api.RenovateWebhookAuth{
+			Enabled:   true,
+			SecretRef: &api.RenovateSecretKeyReference{Name: secretName, Key: secretKey},
+		}
+	}
+	return job
+}
+
+// startWebhookServer boots the real webhook.Server on a free port over a fake-client-backed manager
+// and returns its base URL plus the manager (for CRD status read-back).
+func startWebhookServer(t *testing.T) (string, crdmanager.RenovateJobManager) {
+	t.Helper()
+
+	port := freePort(t)
+	if err := config.InitializeConfigModule([]config.ConfigItemDescription{
+		{Key: "WEBHOOK_SERVER_PORT", Default: port, Optional: true},
+	}); err != nil {
+		t.Fatalf("config init: %v", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := api.AddToScheme(scheme); err != nil {
+		t.Fatalf("add api to scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: testNamespace},
+		Data:       map[string][]byte{secretKey: []byte(signingSecret + "," + legacyToken)},
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(secret, renovateJob(authedJobName, authedProject, true), renovateJob(openJobName, openProject, false)).
+		WithStatusSubresource(&api.RenovateJob{}).
+		Build()
+
+	mgr := crdmanager.NewRenovateJobManager(cl, nil, logr.Discard(), nil, nil)
+	webhook.NewWebookServer(mgr, logr.Discard()).Run()
+
+	baseURL := "http://127.0.0.1:" + port
+	waitReady(t, baseURL)
+	return baseURL, mgr
+}
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	defer l.Close()
+	return strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+}
+
+func waitReady(t *testing.T, baseURL string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		// The route is POST-only, so a GET returns 405 — which still proves the server is listening.
+		if resp, err := http.Get(baseURL + "/webhook/v1/gitlab"); err == nil {
+			resp.Body.Close()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("webhook server did not become ready")
+}
+
+func post(t *testing.T, url string, body []byte, headers map[string]string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+func projectStatus(job *api.RenovateJob, project string) api.RenovateProjectStatus {
+	for _, p := range job.Status.Projects {
+		if p.Name == project {
+			return p.Status
+		}
+	}
+	return ""
+}
+
+func nowUnix() string { return strconv.FormatInt(time.Now().Unix(), 10) }
+
+func TestSigningTokenWebhookIntegration(t *testing.T) {
+	baseURL, mgr := startWebhookServer(t)
+	signer := gitlabSigner{secret: signingSecret}
+	authedURL := baseURL + "/webhook/v1/gitlab?namespace=" + testNamespace + "&job=" + authedJobName
+	openURL := baseURL + "/webhook/v1/gitlab?namespace=" + testNamespace + "&job=" + openJobName
+
+	t.Run("valid signing-token signature is accepted and schedules the project", func(t *testing.T) {
+		body := validEvent(authedProject, "valid")
+		code, msg := post(t, authedURL, body, signedHeaders(signer, "msg-valid", nowUnix(), body))
+		if code != http.StatusAccepted {
+			t.Fatalf("want 202, got %d: %s", code, msg)
+		}
+		job, err := mgr.GetRenovateJob(context.Background(), authedJobName, testNamespace)
+		if err != nil {
+			t.Fatalf("read back job: %v", err)
+		}
+		if got := projectStatus(job, authedProject); got != api.JobStatusScheduled {
+			t.Errorf("project status = %q, want %q", got, api.JobStatusScheduled)
+		}
+	})
+
+	t.Run("tampered body is rejected", func(t *testing.T) {
+		signed := validEvent(authedProject, "original")
+		headers := signedHeaders(signer, "msg-tamper", nowUnix(), signed)
+		tampered := validEvent(authedProject, "tampered-after-signing")
+		if code, msg := post(t, authedURL, tampered, headers); code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d: %s", code, msg)
+		}
+	})
+
+	t.Run("signature from a different key is rejected", func(t *testing.T) {
+		wrong := gitlabSigner{secret: "whsec_" + base64.StdEncoding.EncodeToString([]byte("an-entirely-different-signing-key"))}
+		body := validEvent(authedProject, "wrongkey")
+		if code, msg := post(t, authedURL, body, signedHeaders(wrong, "msg-wrong", nowUnix(), body)); code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d: %s", code, msg)
+		}
+	})
+
+	t.Run("stale timestamp is rejected (replay window)", func(t *testing.T) {
+		body := validEvent(authedProject, "stale")
+		stale := strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10)
+		if code, msg := post(t, authedURL, body, signedHeaders(signer, "msg-stale", stale, body)); code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d: %s", code, msg)
+		}
+	})
+
+	t.Run("future timestamp is rejected (replay window)", func(t *testing.T) {
+		body := validEvent(authedProject, "future")
+		future := strconv.FormatInt(time.Now().Add(10*time.Minute).Unix(), 10)
+		if code, msg := post(t, authedURL, body, signedHeaders(signer, "msg-future", future, body)); code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d: %s", code, msg)
+		}
+	})
+
+	t.Run("missing credentials on an auth-required job is rejected", func(t *testing.T) {
+		body := validEvent(authedProject, "nocreds")
+		headers := map[string]string{"Content-Type": "application/json"}
+		if code, msg := post(t, authedURL, body, headers); code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d: %s", code, msg)
+		}
+	})
+
+	t.Run("legacy X-Gitlab-Token still authenticates", func(t *testing.T) {
+		body := validEvent(authedProject, "legacy")
+		headers := map[string]string{"Content-Type": "application/json", "X-Gitlab-Token": legacyToken}
+		if code, msg := post(t, authedURL, body, headers); code != http.StatusAccepted {
+			t.Fatalf("want 202, got %d: %s", code, msg)
+		}
+	})
+
+	t.Run("auth-disabled job accepts unsigned deliveries", func(t *testing.T) {
+		body := validEvent(openProject, "open")
+		headers := map[string]string{"Content-Type": "application/json"}
+		if code, msg := post(t, openURL, body, headers); code != http.StatusAccepted {
+			t.Fatalf("want 202, got %d: %s", code, msg)
+		}
+		job, err := mgr.GetRenovateJob(context.Background(), openJobName, testNamespace)
+		if err != nil {
+			t.Fatalf("read back job: %v", err)
+		}
+		if got := projectStatus(job, openProject); got != api.JobStatusScheduled {
+			t.Errorf("project status = %q, want %q", got, api.JobStatusScheduled)
+		}
+	})
+}

--- a/src/internal/crdManager/renovateJobManager.go
+++ b/src/internal/crdManager/renovateJobManager.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -59,6 +61,10 @@ type RenovateJobManager interface {
 	IsWebhookTokenValid(ctx context.Context, job RenovateJobIdentifier, token string) (bool, error)
 	// IsWebhookSignatureValid checks if the provided signature is valid for the webhook of the specified RenovateJob CRD.
 	IsWebhookSignatureValid(ctx context.Context, job RenovateJobIdentifier, signature string, body []byte) (bool, error)
+	// IsWebhookStandardSignatureValid checks a Standard Webhooks signature (https://www.standardwebhooks.com/)
+	// against the webhook signing keys configured for the specified RenovateJob CRD. Standard Webhooks is a
+	// vendor-neutral signing scheme; GitLab "signing tokens" are one implementation of it, not the only one.
+	IsWebhookStandardSignatureValid(ctx context.Context, job RenovateJobIdentifier, msgID, timestamp, signature string, body []byte) (bool, error)
 	// UpdateExecutionOptions updates the execution options for the specified RenovateJob CRD.
 	UpdateExecutionOptions(ctx context.Context, job RenovateJobIdentifier, options *api.RenovateExecutionOptions) error
 	// CancelProjectJob deletes the running executor Kubernetes Job for the given project and
@@ -445,6 +451,56 @@ func (r *renovateJobManager) IsWebhookSignatureValid(ctx context.Context, job Re
 	return false, nil
 }
 
+// IsWebhookStandardSignatureValid validates a Standard Webhooks signature against the keys configured for
+// the RenovateJob. Standard Webhooks (https://www.standardwebhooks.com/) is a vendor-neutral webhook
+// signing scheme implemented by multiple providers — GitLab "signing tokens" among them — so this path is
+// not GitLab-specific and works for any compliant sender. The signed content is "{msgID}.{timestamp}.{body}",
+// keyed by the HMAC-SHA256 key decoded from each configured secret. The signature header is a space-separated
+// list of "v1,<base64>" entries; a match against any entry for any configured key authenticates the request.
+// The timestamp must be within standardWebhookTimestampTolerance of now to reject replayed requests.
+func (r *renovateJobManager) IsWebhookStandardSignatureValid(ctx context.Context, job RenovateJobIdentifier, msgID, timestamp, signature string, body []byte) (bool, error) {
+	defer r.globalManagerLock(true)()
+
+	renovateJob, err := loadRenovateJob(ctx, job.Name, job.Namespace, r.client)
+	if err != nil {
+		return false, err
+	}
+
+	if renovateJob.Spec.Webhook == nil ||
+		renovateJob.Spec.Webhook.Authentication == nil ||
+		!renovateJob.Spec.Webhook.Authentication.Enabled {
+		// Webhook authentication is not enabled
+		return false, nil
+	}
+
+	if msgID == "" || signature == "" {
+		return false, nil
+	}
+	if !isStandardWebhookTimestampFresh(timestamp, time.Now()) {
+		r.logger.V(1).Info("rejecting webhook: signature timestamp outside tolerance", "namespace", job.Namespace, "name", job.Name, "timestamp", timestamp)
+		return false, nil
+	}
+
+	tokens, err := r.getRenovateJobTokens(ctx, renovateJob)
+	if err != nil {
+		return false, err
+	}
+
+	signedContent := msgID + "." + timestamp + "." + string(body)
+	for _, token := range tokens {
+		key, ok := decodeStandardWebhookSigningKey(token)
+		if !ok {
+			continue
+		}
+		expected := computeStandardWebhookSignature(key, signedContent)
+		if matchesAnyStandardWebhookSignature(signature, expected) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func (r *renovateJobManager) CancelProjectJob(ctx context.Context, project string, job RenovateJobIdentifier) error {
 	executorJob, err := GetJobByLabel(ctx, r.client, JobSelector{
 		JobType:         ExecutorJobType,
@@ -482,4 +538,65 @@ func computeHMAC256(message []byte, secret string) string {
 	mac.Write(message)
 	expectedMAC := mac.Sum(nil)
 	return "sha256=" + fmt.Sprintf("%x", expectedMAC)
+}
+
+// standardWebhookTimestampTolerance bounds how far a webhook-timestamp may drift from the current
+// time before the request is rejected as a potential replay. Matches the Standard Webhooks default.
+const standardWebhookTimestampTolerance = 5 * time.Minute
+
+// decodeStandardWebhookSigningKey returns the raw HMAC key for a Standard Webhooks signing secret. The
+// canonical form is "whsec_" + base64(key), as issued by Standard Webhooks senders (GitLab among them).
+// A bare value is base64-decoded when possible, otherwise used verbatim as the key.
+func decodeStandardWebhookSigningKey(secret string) ([]byte, bool) {
+	if secret == "" {
+		return nil, false
+	}
+	if rest, found := strings.CutPrefix(secret, "whsec_"); found {
+		decoded, err := base64.StdEncoding.DecodeString(rest)
+		if err != nil {
+			return nil, false
+		}
+		return decoded, true
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(secret); err == nil {
+		return decoded, true
+	}
+	return []byte(secret), true
+}
+
+// computeStandardWebhookSignature returns the base64 HMAC-SHA256 of signedContent, without the
+// "v1," version prefix.
+func computeStandardWebhookSignature(key []byte, signedContent string) string {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(signedContent))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// matchesAnyStandardWebhookSignature reports whether expected (raw base64) matches any "v1" entry
+// in a space-separated webhook-signature header value. Comparison is constant-time.
+func matchesAnyStandardWebhookSignature(header, expected string) bool {
+	for _, part := range strings.Fields(header) {
+		version, sig, found := strings.Cut(part, ",")
+		if !found || version != "v1" {
+			continue
+		}
+		if hmac.Equal([]byte(sig), []byte(expected)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isStandardWebhookTimestampFresh reports whether a unix-seconds timestamp is within the replay
+// tolerance of now.
+func isStandardWebhookTimestampFresh(timestamp string, now time.Time) bool {
+	secs, err := strconv.ParseInt(strings.TrimSpace(timestamp), 10, 64)
+	if err != nil {
+		return false
+	}
+	delta := now.Sub(time.Unix(secs, 0))
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta <= standardWebhookTimestampTolerance
 }

--- a/src/internal/crdManager/webhookSignature_test.go
+++ b/src/internal/crdManager/webhookSignature_test.go
@@ -1,0 +1,85 @@
+package crdmanager
+
+import (
+	"testing"
+	"time"
+)
+
+// canonicalSigningSecret is the public Standard Webhooks / svix example signing secret (published in
+// the spec). The "whsec_" prefix is kept separate from the body so secret scanners don't flag this
+// public test vector as a live credential — the prefix collides with Stripe's webhook-secret format.
+const canonicalSigningSecret = "whsec_" + "MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
+
+// TestStandardWebhookSignatureKnownAnswer pins the GitLab signing-token (Standard Webhooks)
+// computation to the canonical svix test vector, exercising key decode, signing, and header match.
+func TestStandardWebhookSignatureKnownAnswer(t *testing.T) {
+	const (
+		secret    = canonicalSigningSecret
+		msgID     = "msg_p5jXN8AQM9LWM0D4loKWxJek"
+		timestamp = "1614265330"
+		want      = "g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="
+	)
+	body := []byte(`{"test": 2432232314}`)
+
+	key, ok := decodeStandardWebhookSigningKey(secret)
+	if !ok {
+		t.Fatal("decodeStandardWebhookSigningKey returned ok=false for canonical secret")
+	}
+
+	got := computeStandardWebhookSignature(key, msgID+"."+timestamp+"."+string(body))
+	if got != want {
+		t.Fatalf("signature mismatch:\n got %q\nwant %q", got, want)
+	}
+
+	if !matchesAnyStandardWebhookSignature("v1,"+want, got) {
+		t.Error("expected match for single v1 entry")
+	}
+	if !matchesAnyStandardWebhookSignature("v0,ignored v1,"+want+" v2,other", got) {
+		t.Error("expected match for v1 entry within a space-separated list")
+	}
+	if matchesAnyStandardWebhookSignature("v1,deadbeef", got) {
+		t.Error("did not expect a match for a wrong signature")
+	}
+	if matchesAnyStandardWebhookSignature("v2,"+want, got) {
+		t.Error("did not expect a match for a non-v1 version")
+	}
+}
+
+func TestDecodeStandardWebhookSigningKey(t *testing.T) {
+	if _, ok := decodeStandardWebhookSigningKey(""); ok {
+		t.Error("empty secret should return ok=false")
+	}
+	if _, ok := decodeStandardWebhookSigningKey("whsec_not!!base64"); ok {
+		t.Error("whsec_ secret with invalid base64 should return ok=false")
+	}
+	if key, ok := decodeStandardWebhookSigningKey(canonicalSigningSecret); !ok || len(key) == 0 {
+		t.Errorf("canonical whsec_ secret should decode to a non-empty key, got len=%d ok=%v", len(key), ok)
+	}
+	if raw, ok := decodeStandardWebhookSigningKey("plain-secret-!!"); !ok || string(raw) != "plain-secret-!!" {
+		t.Errorf("bare non-base64 secret should be used verbatim, got %q ok=%v", raw, ok)
+	}
+}
+
+func TestIsStandardWebhookTimestampFresh(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		name      string
+		timestamp string
+		want      bool
+	}{
+		{"now", "1700000000", true},
+		{"within tolerance past", "1699999900", true},
+		{"within tolerance future", "1700000100", true},
+		{"too old", "1699999000", false},
+		{"too far future", "1700001000", false},
+		{"empty", "", false},
+		{"non-numeric", "not-a-number", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isStandardWebhookTimestampFresh(tt.timestamp, now); got != tt.want {
+				t.Errorf("isStandardWebhookTimestampFresh(%q) = %v, want %v", tt.timestamp, got, tt.want)
+			}
+		})
+	}
+}

--- a/src/internal/renovate/discoveryAgent_test.go
+++ b/src/internal/renovate/discoveryAgent_test.go
@@ -70,6 +70,9 @@ func (f *fakeJobManager) IsWebhookTokenValid(ctx context.Context, job crdManager
 func (f *fakeJobManager) IsWebhookSignatureValid(ctx context.Context, job crdManager.RenovateJobIdentifier, signature string, body []byte) (bool, error) {
 	return true, nil
 }
+func (f *fakeJobManager) IsWebhookStandardSignatureValid(ctx context.Context, job crdManager.RenovateJobIdentifier, msgID, timestamp, signature string, body []byte) (bool, error) {
+	return true, nil
+}
 func (f *fakeJobManager) UpdateExecutionOptions(ctx context.Context, job crdManager.RenovateJobIdentifier, options *api.RenovateExecutionOptions) error {
 	return nil
 }

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -111,6 +111,9 @@ func (m *mockRenovateJobManager) IsWebhookTokenValid(ctx context.Context, job cr
 func (r *mockRenovateJobManager) IsWebhookSignatureValid(ctx context.Context, job crdmanager.RenovateJobIdentifier, signature string, body []byte) (bool, error) {
 	return true, nil
 }
+func (r *mockRenovateJobManager) IsWebhookStandardSignatureValid(ctx context.Context, job crdmanager.RenovateJobIdentifier, msgID, timestamp, signature string, body []byte) (bool, error) {
+	return true, nil
+}
 
 func (m *mockRenovateJobManager) UpdateExecutionOptions(ctx context.Context, jobId crdmanager.RenovateJobIdentifier, options *api.RenovateExecutionOptions) error {
 	return nil

--- a/src/webhook/authchecker_test.go
+++ b/src/webhook/authchecker_test.go
@@ -1,0 +1,128 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	crdmanager "renovate-operator/internal/crdManager"
+)
+
+func TestBuildAuthCheckerFromRequest(t *testing.T) {
+	body := []byte(`{"hello":"world"}`)
+	jobID := crdmanager.RenovateJobIdentifier{Name: "j", Namespace: "ns"}
+
+	t.Run("standard webhook signature wins over token and forwards all fields", func(t *testing.T) {
+		called := ""
+		var gotMsgID, gotTS, gotSig string
+		var gotBody []byte
+		m := &mockWebhookManager{
+			isWebhookStandardSignatureValidFunc: func(_ context.Context, _ crdmanager.RenovateJobIdentifier, msgID, ts, sig string, b []byte) (bool, error) {
+				called = "standard"
+				gotMsgID, gotTS, gotSig, gotBody = msgID, ts, sig, b
+				return true, nil
+			},
+			isWebhookTokenValidFunc: func(context.Context, crdmanager.RenovateJobIdentifier, string) (bool, error) {
+				called = "token"
+				return true, nil
+			},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/webhook/v1/gitlab", nil)
+		r.Header.Set("Webhook-Id", "msg_1")
+		r.Header.Set("Webhook-Timestamp", "1700000000")
+		r.Header.Set("Webhook-Signature", "v1,abc")
+		r.Header.Set("X-Gitlab-Token", "sometoken") // present, but signature must take precedence
+
+		checker := buildAuthCheckerFromRequest(r, body, m)
+		if checker == nil {
+			t.Fatal("expected non-nil checker")
+		}
+		ok, err := checker(context.Background(), jobID)
+		if err != nil || !ok {
+			t.Fatalf("checker returned ok=%v err=%v", ok, err)
+		}
+		if called != "standard" {
+			t.Fatalf("expected standard validator, got %q", called)
+		}
+		if gotMsgID != "msg_1" || gotTS != "1700000000" || gotSig != "v1,abc" {
+			t.Errorf("wrong args: id=%q ts=%q sig=%q", gotMsgID, gotTS, gotSig)
+		}
+		if string(gotBody) != string(body) {
+			t.Errorf("body not forwarded: got %q", gotBody)
+		}
+	})
+
+	t.Run("x-gitlab-token routes to token validator", func(t *testing.T) {
+		var gotToken string
+		m := &mockWebhookManager{
+			isWebhookTokenValidFunc: func(_ context.Context, _ crdmanager.RenovateJobIdentifier, token string) (bool, error) {
+				gotToken = token
+				return true, nil
+			},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/x", nil)
+		r.Header.Set("X-Gitlab-Token", "secret-token")
+		checker := buildAuthCheckerFromRequest(r, body, m)
+		if checker == nil {
+			t.Fatal("expected non-nil checker")
+		}
+		if _, err := checker(context.Background(), jobID); err != nil {
+			t.Fatal(err)
+		}
+		if gotToken != "secret-token" {
+			t.Errorf("got token %q, want secret-token", gotToken)
+		}
+	})
+
+	t.Run("bearer authorization strips prefix", func(t *testing.T) {
+		var gotToken string
+		m := &mockWebhookManager{
+			isWebhookTokenValidFunc: func(_ context.Context, _ crdmanager.RenovateJobIdentifier, token string) (bool, error) {
+				gotToken = token
+				return true, nil
+			},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/x", nil)
+		r.Header.Set("Authorization", "Bearer abc123")
+		checker := buildAuthCheckerFromRequest(r, body, m)
+		if checker == nil {
+			t.Fatal("expected non-nil checker")
+		}
+		if _, err := checker(context.Background(), jobID); err != nil {
+			t.Fatal(err)
+		}
+		if gotToken != "abc123" {
+			t.Errorf("got token %q, want abc123", gotToken)
+		}
+	})
+
+	t.Run("hub signature routes to signature validator", func(t *testing.T) {
+		called := false
+		m := &mockWebhookManager{
+			isWebhookSignatureValidFunc: func(context.Context, crdmanager.RenovateJobIdentifier, string, []byte) (bool, error) {
+				called = true
+				return true, nil
+			},
+		}
+		r := httptest.NewRequest(http.MethodPost, "/x", nil)
+		r.Header.Set("X-Hub-Signature-256", "sha256=abc")
+		checker := buildAuthCheckerFromRequest(r, body, m)
+		if checker == nil {
+			t.Fatal("expected non-nil checker")
+		}
+		if _, err := checker(context.Background(), jobID); err != nil {
+			t.Fatal(err)
+		}
+		if !called {
+			t.Error("expected signature validator to be called")
+		}
+	})
+
+	t.Run("no credentials returns nil checker", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPost, "/x", nil)
+		if checker := buildAuthCheckerFromRequest(r, body, &mockWebhookManager{}); checker != nil {
+			t.Error("expected nil checker when no credentials present")
+		}
+	})
+}

--- a/src/webhook/mock_test.go
+++ b/src/webhook/mock_test.go
@@ -14,10 +14,11 @@ import (
 
 // mockWebhookManager is used by webhook integration tests.
 type mockWebhookManager struct {
-	listRenovateJobsFullFunc    func(ctx context.Context) ([]api.RenovateJob, error)
-	updateProjectStatusFunc     func(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error
-	isWebhookTokenValidFunc     func(ctx context.Context, job crdmanager.RenovateJobIdentifier, token string) (bool, error)
-	isWebhookSignatureValidFunc func(ctx context.Context, job crdmanager.RenovateJobIdentifier, signature string, body []byte) (bool, error)
+	listRenovateJobsFullFunc            func(ctx context.Context) ([]api.RenovateJob, error)
+	updateProjectStatusFunc             func(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error
+	isWebhookTokenValidFunc             func(ctx context.Context, job crdmanager.RenovateJobIdentifier, token string) (bool, error)
+	isWebhookSignatureValidFunc         func(ctx context.Context, job crdmanager.RenovateJobIdentifier, signature string, body []byte) (bool, error)
+	isWebhookStandardSignatureValidFunc func(ctx context.Context, job crdmanager.RenovateJobIdentifier, msgID, timestamp, signature string, body []byte) (bool, error)
 }
 
 func (m *mockWebhookManager) ListRenovateJobsFull(ctx context.Context) ([]api.RenovateJob, error) {
@@ -44,6 +45,13 @@ func (m *mockWebhookManager) IsWebhookTokenValid(ctx context.Context, job crdman
 func (m *mockWebhookManager) IsWebhookSignatureValid(ctx context.Context, job crdmanager.RenovateJobIdentifier, signature string, body []byte) (bool, error) {
 	if m.isWebhookSignatureValidFunc != nil {
 		return m.isWebhookSignatureValidFunc(ctx, job, signature, body)
+	}
+	return true, nil
+}
+
+func (m *mockWebhookManager) IsWebhookStandardSignatureValid(ctx context.Context, job crdmanager.RenovateJobIdentifier, msgID, timestamp, signature string, body []byte) (bool, error) {
+	if m.isWebhookStandardSignatureValidFunc != nil {
+		return m.isWebhookStandardSignatureValidFunc(ctx, job, msgID, timestamp, signature, body)
 	}
 	return true, nil
 }

--- a/src/webhook/resolver.go
+++ b/src/webhook/resolver.go
@@ -26,6 +26,7 @@ type jobLister interface {
 type credentialValidator interface {
 	IsWebhookTokenValid(ctx context.Context, job crdmanager.RenovateJobIdentifier, token string) (bool, error)
 	IsWebhookSignatureValid(ctx context.Context, job crdmanager.RenovateJobIdentifier, signature string, body []byte) (bool, error)
+	IsWebhookStandardSignatureValid(ctx context.Context, job crdmanager.RenovateJobIdentifier, msgID, timestamp, signature string, body []byte) (bool, error)
 }
 
 // FindAndAuthenticateJob discovers which RenovateJob owns project and authenticates the request.
@@ -106,6 +107,17 @@ func hasProject(projects []api.ProjectStatus, project string) bool {
 // buildAuthCheckerFromRequest extracts auth credentials from request headers and returns
 // an AuthChecker that validates them against a RenovateJob. Returns nil if no credential is present.
 func buildAuthCheckerFromRequest(r *http.Request, body []byte, manager credentialValidator) AuthChecker {
+	// Standard Webhooks signature (https://www.standardwebhooks.com/) — a vendor-neutral scheme used by
+	// GitLab signing tokens among others; prefer the cryptographic signature when present.
+	if sig := r.Header.Get("Webhook-Signature"); sig != "" {
+		msgID := r.Header.Get("Webhook-Id")
+		timestamp := r.Header.Get("Webhook-Timestamp")
+		b := body
+		return func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier) (bool, error) {
+			return manager.IsWebhookStandardSignatureValid(ctx, jobId, msgID, timestamp, sig, b)
+		}
+	}
+
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
 		authHeader = r.Header.Get("X-Gitlab-Token")


### PR DESCRIPTION
## What

Adds a third webhook authentication scheme: [Standard Webhooks](https://www.standardwebhooks.com/) signatures, alongside the existing plain-token (`Authorization` / `X-Gitlab-Token`) and GitHub/Forgejo HMAC (`X-Hub-Signature-256` / `X-Forgejo-Signature`) paths.

Motivating use case: GitLab v19 added [signing tokens](https://docs.gitlab.com/user/project/integrations/webhooks/#signing-tokens) — GitLab's recommended alternative to the legacy plaintext secret token — are an implementation of Standard Webhooks. The scheme itself is vendor-neutral, so verification here is done generically and works for any compliant sender, not just GitLab.

## How

- New `IsWebhookStandardSignatureValid` on `RenovateJobManager`: for each configured secret, strip the `whsec_` prefix and base64-decode it into the HMAC key, recompute `HMAC-SHA256` over `"{webhook-id}.{webhook-timestamp}.{body}"`, and constant-time compare against each `v1,<base64>` entry of the `Webhook-Signature` header.
- Rejects deliveries whose `Webhook-Timestamp` is more than 5 minutes from the current time (replay window).
- `buildAuthCheckerFromRequest` routes requests carrying a `Webhook-Signature` header to the new validator, preferring the signature over a plain token when both are present.
- Reuses the existing `authentication.secretRef` secret (comma-separated values), so a signing key and a legacy token can coexist in one secret.

No changes to the provider abstraction or CRD types — this slots into the existing credential-validator interface.

## Tests

- Unit tests: the canonical Standard Webhooks known-answer vector, key-decode edge cases (`whsec_` prefix / bare / invalid), the timestamp window, and header routing/precedence.
- An over-the-wire integration test (build-tagged `integration`, so it stays out of the default unit run) that boots the real webhook server + real manager over a fake k8s client and drives it with an independent signer: valid → 202 + project scheduled, tampered body → 401, wrong key → 401, stale/future timestamp → 401, missing credentials → 401, legacy `X-Gitlab-Token` → 202, auth-disabled job → 202.

`just build`, `just test-unit` (570 pass), and `just test-integration` (8/8) are green.
