### PR TITLE
fix: propagate operator labels to pod templates so pods carry them for NetworkPolicies

### DIFF
--- a/src/internal/crdManager/jobManager.go
+++ b/src/internal/crdManager/jobManager.go
@@ -155,6 +155,16 @@ func CreateJobWithGeneration(ctx context.Context, client crclient.Client, job *b
 		}
 		job.Annotations[JOB_ANNOTATION_PROJECT] = selector.Project
 	}
+
+	// Propagate all Job labels to the Pod template so that Pods carry the same
+	// operator labels (needed for NetworkPolicies, monitoring selectors, etc.).
+	if job.Spec.Template.Labels == nil {
+		job.Spec.Template.Labels = make(map[string]string)
+	}
+	for k, v := range job.Labels {
+		job.Spec.Template.Labels[k] = v
+	}
+
 	// Create immediately - no deletion needed first
 	err := client.Create(ctx, job)
 	if err != nil {

--- a/src/internal/crdManager/jobManager_test.go
+++ b/src/internal/crdManager/jobManager_test.go
@@ -112,6 +112,85 @@ func TestCreateJob(t *testing.T) {
 	if got.Name != "new-job" {
 		t.Errorf("got job name %q, want %q", got.Name, "new-job")
 	}
+
+	// Verify operator labels were propagated to pod template
+	for _, labelKey := range []string{JOB_LABEL_TYPE, JOB_LABEL_RENOVATEJOB, JOB_LABEL_GENERATION} {
+		jobVal, jobOk := got.Labels[labelKey]
+		tmplVal, tmplOk := got.Spec.Template.Labels[labelKey]
+		if !jobOk {
+			t.Fatalf("expected job label %s to be set", labelKey)
+		}
+		if !tmplOk {
+			t.Fatalf("expected pod template label %s to be set", labelKey)
+		}
+		if jobVal != tmplVal {
+			t.Errorf("pod template label %s=%q does not match job label %s=%q", labelKey, tmplVal, labelKey, jobVal)
+		}
+	}
+}
+
+func TestCreateJobWithGeneration_PreservesExistingTemplateLabels(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add batch scheme: %v", err)
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeled-job",
+			Namespace: "test-ns",
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"custom-label": "custom-value",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: "test:latest",
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	_, err := CreateJobWithGeneration(context.Background(), client, job, JobSelector{
+		RenovateJobName: "labeled-job",
+		JobType:         DiscoveryJobType,
+		Namespace:       "test-ns",
+	})
+	if err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+
+	got, err := GetJobByLabel(context.Background(), client, JobSelector{
+		RenovateJobName: "labeled-job",
+		JobType:         DiscoveryJobType,
+		Namespace:       "test-ns",
+	})
+	if err != nil {
+		t.Fatalf("Failed to get created job: %v", err)
+	}
+
+	// Custom label must be preserved
+	if got.Spec.Template.Labels["custom-label"] != "custom-value" {
+		t.Errorf("expected custom-label to be preserved, got %q", got.Spec.Template.Labels["custom-label"])
+	}
+	// Operator labels must also be present on the pod template
+	if got.Spec.Template.Labels[JOB_LABEL_TYPE] != string(DiscoveryJobType) {
+		t.Errorf("expected pod template to have %s=%s", JOB_LABEL_TYPE, string(DiscoveryJobType))
+	}
+	if got.Spec.Template.Labels[JOB_LABEL_RENOVATEJOB] != "labeled-job" {
+		t.Errorf("expected pod template to have %s=labeled-job", JOB_LABEL_RENOVATEJOB)
+	}
 }
 
 func TestDeleteJob(t *testing.T) {


### PR DESCRIPTION
Fixes #455