### PR TITLE
fix(ui): serve /components/ assets without auth to prevent blank page

### DIFF
--- a/src/ui/auth.go
+++ b/src/ui/auth.go
@@ -145,9 +145,13 @@ func isPublicPath(path string) bool {
 	if strings.HasPrefix(path, "/auth/") {
 		return true
 	}
-	// Static assets must be accessible without auth so the page can render
+	// Static assets must be accessible without auth so the page can render.
+	// /components/ is fetched via XHR (Babel), which cannot follow the
+	// cross-origin redirect to the identity provider — a 302 there breaks
+	// rendering entirely instead of triggering a login.
 	if strings.HasPrefix(path, "/js/") || strings.HasPrefix(path, "/css/") ||
-		strings.HasPrefix(path, "/assets/") || path == "/favicon.ico" {
+		strings.HasPrefix(path, "/assets/") || strings.HasPrefix(path, "/components/") ||
+		path == "/favicon.ico" {
 		return true
 	}
 	return false

--- a/src/ui/auth_test.go
+++ b/src/ui/auth_test.go
@@ -208,3 +208,33 @@ func TestAuthMiddleware_StoresSessionInContext(t *testing.T) {
 		t.Errorf("Groups not in context correctly: %v", capturedSession.Groups)
 	}
 }
+
+func TestIsPublicPath(t *testing.T) {
+	public := []string{
+		"/health",
+		"/api/v1/auth/status",
+		"/auth/login",
+		"/auth/callback",
+		"/js/babel.min.js",
+		"/css/styles.css",
+		"/assets/favicon.png",
+		"/components/StatBadge.js",
+		"/favicon.ico",
+	}
+	for _, path := range public {
+		if !isPublicPath(path) {
+			t.Errorf("expected %s to be public", path)
+		}
+	}
+
+	protected := []string{
+		"/",
+		"/api/v1/renovatejobs",
+		"/pages/logs.html",
+	}
+	for _, path := range protected {
+		if isPublicPath(path) {
+			t.Errorf("expected %s to be protected", path)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The UI intermittently rendered as a completely blank page. DevTools showed most assets loading with 200, but individual `/components/*.js` requests returning **302** → `/auth/login` → `login.microsoftonline.com`, which the browser blocked with a CORS error. The React app then crashed with `Uncaught ReferenceError: StatBadge is not defined`.

## Root cause

Two things combined:

1. **`/components/` was not a public path.** `isPublicPath` in `src/ui/auth.go` exempted `/js/`, `/css/` and `/assets/` from authentication, but not `/components/`. The React components are loaded by the in-browser Babel transformer **via XHR**, and an XHR cannot follow a cross-origin redirect to the identity provider (CORS). So instead of a clean login redirect, the page broke mid-render.

2. **Replicas with divergent session encryption keys** (deployment-side trigger, not fixed by this PR). One pod's container restarted and re-read `OIDC_SESSION_SECRET` from the Secret, whose value had changed since the other pods started. Requests load-balanced across pods were then judged inconsistently — some 200, some 302 (`cipher: message authentication failed` in the logs). A rolling restart of the deployment resolves the key divergence.

## Fix

- Add `/components/` to `isPublicPath` so static UI components are served without authentication. They contain no sensitive data — all API routes remain protected, and the frontend already redirects to `/auth/login` when the API returns 401. With this change, a flapping/invalid session can no longer produce a blank page; the user is cleanly sent to login instead.
- Add `TestIsPublicPath` covering public and protected paths.