### PR TITLE
feat: add scheme override for auth redirect and webhook base URL (#452)

### DIFF
--- a/charts/renovate-operator/templates/_helpers.tpl
+++ b/charts/renovate-operator/templates/_helpers.tpl
@@ -19,12 +19,22 @@
 {{- end -}}
 
 {{/*
+Validates a scheme override value. Input: dict with keys "scheme" and "key" (values path for the error message).
+*/}}
+{{- define "renovate-operator.validateScheme" -}}
+{{- if and .scheme (not (has .scheme (list "http" "https"))) -}}
+{{- fail (printf "%s must be either \"http\" or \"https\", got %q" .key .scheme) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Returns the effective auth redirect URL.
-Input: dict with keys "redirectUrl" (string) and "Values" (root .Values).
+Input: dict with keys "redirectUrl" (string), "redirectScheme" (string) and "Values" (root .Values).
 Priority: explicit redirectUrl → route.hostnames[0] → ingress.host.
-Scheme: https if ingress.tls is set, http otherwise.
+Scheme: redirectScheme if set, https if ingress.tls is set, http otherwise.
 */}}
 {{- define "renovate-operator.authRedirectUrl" -}}
+{{- include "renovate-operator.validateScheme" (dict "scheme" .redirectScheme "key" "auth.*.redirectScheme") -}}
 {{- $url := .redirectUrl -}}
 {{- if not $url -}}
 {{- $host := "" -}}
@@ -39,6 +49,9 @@ Scheme: https if ingress.tls is set, http otherwise.
 {{- if $values.ingress.tls -}}
 {{- $scheme = "https" -}}
 {{- end -}}
+{{- if .redirectScheme -}}
+{{- $scheme = .redirectScheme -}}
+{{- end -}}
 {{- $url = printf "%s://%s/auth/callback" $scheme $host -}}
 {{- end -}}
 {{- end -}}
@@ -49,22 +62,25 @@ Scheme: https if ingress.tls is set, http otherwise.
 Returns the external base URL of the webhook server. When unifiedWebhookHost
 is true the UI ingress/route values are used; otherwise the webhook-specific
 values are used. Priority within each: route.hostnames[0] (https) →
-ingress.host (https when tls is set, http otherwise). Empty when not exposed.
+ingress.host (https when tls is set, http otherwise). webhook.baseUrlScheme
+overrides the detected scheme. Empty when not exposed.
 */}}
 {{- define "renovate-operator.webhookBaseUrl" -}}
+{{- $override := .Values.webhook.baseUrlScheme -}}
+{{- include "renovate-operator.validateScheme" (dict "scheme" $override "key" "webhook.baseUrlScheme") -}}
 {{- $v := .Values.webhook -}}
 {{- if .Values.webhook.unifiedWebhookHost -}}
 {{- $v = .Values -}}
 {{- end -}}
 {{- $url := "" -}}
 {{- if and $v.route.enabled $v.route.hostnames -}}
-{{- $url = printf "https://%s" (index $v.route.hostnames 0) -}}
+{{- $url = printf "%s://%s" (default "https" $override) (index $v.route.hostnames 0) -}}
 {{- else if and $v.ingress.enabled $v.ingress.host -}}
 {{- $scheme := "http" -}}
 {{- if $v.ingress.tls -}}
 {{- $scheme = "https" -}}
 {{- end -}}
-{{- $url = printf "%s://%s" $scheme $v.ingress.host -}}
+{{- $url = printf "%s://%s" (default $scheme $override) $v.ingress.host -}}
 {{- end -}}
 {{- $url -}}
 {{- end -}}

--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
                   name: {{ .Values.auth.oidc.existingSecret }}
                   key: {{ .Values.auth.oidc.sessionSecretKey }}
             {{- end }}
-            {{- $oidcRedirectUrl := include "renovate-operator.authRedirectUrl" (dict "redirectUrl" .Values.auth.oidc.redirectUrl "Values" .Values) }}
+            {{- $oidcRedirectUrl := include "renovate-operator.authRedirectUrl" (dict "redirectUrl" .Values.auth.oidc.redirectUrl "redirectScheme" .Values.auth.oidc.redirectScheme "Values" .Values) }}
             {{- if $oidcRedirectUrl }}
             - name: OIDC_REDIRECT_URL
               value: {{ $oidcRedirectUrl | quote }}
@@ -183,7 +183,7 @@ spec:
                   name: {{ .Values.auth.github.existingSecret }}
                   key: {{ .Values.auth.github.sessionSecretKey }}
             {{- end }}
-            {{- $githubRedirectUrl := include "renovate-operator.authRedirectUrl" (dict "redirectUrl" .Values.auth.github.redirectUrl "Values" .Values) }}
+            {{- $githubRedirectUrl := include "renovate-operator.authRedirectUrl" (dict "redirectUrl" .Values.auth.github.redirectUrl "redirectScheme" .Values.auth.github.redirectScheme "Values" .Values) }}
             {{- if $githubRedirectUrl }}
             - name: GITHUB_REDIRECT_URL
               value: {{ $githubRedirectUrl | quote }}

--- a/charts/renovate-operator/unittests/deployment/deployment.yaml
+++ b/charts/renovate-operator/unittests/deployment/deployment.yaml
@@ -76,3 +76,129 @@ tests:
       content:
         name: OIDC_PKCE_ENABLED
         value: "false"
+
+- it: OIDC redirect URL derived from route defaults to http without ingress tls
+  set:
+    route:
+      enabled: true
+      hostnames:
+      - renovate.example.org
+    auth:
+      oidc:
+        enabled: true
+        existingSecret: my-oidc-secret
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: OIDC_REDIRECT_URL
+        value: http://renovate.example.org/auth/callback
+
+- it: OIDC redirectScheme overrides the detected scheme
+  set:
+    route:
+      enabled: true
+      hostnames:
+      - renovate.example.org
+    auth:
+      oidc:
+        enabled: true
+        existingSecret: my-oidc-secret
+        redirectScheme: https
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: OIDC_REDIRECT_URL
+        value: https://renovate.example.org/auth/callback
+
+- it: OIDC redirectScheme is ignored when an explicit redirectUrl is set
+  set:
+    auth:
+      oidc:
+        enabled: true
+        existingSecret: my-oidc-secret
+        redirectUrl: https://custom.example.org/auth/callback
+        redirectScheme: http
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: OIDC_REDIRECT_URL
+        value: https://custom.example.org/auth/callback
+
+- it: OIDC redirectScheme rejects invalid values
+  set:
+    route:
+      enabled: true
+      hostnames:
+      - renovate.example.org
+    auth:
+      oidc:
+        enabled: true
+        existingSecret: my-oidc-secret
+        redirectScheme: ftp
+  asserts:
+  - failedTemplate:
+      errorPattern: must be either "http" or "https"
+
+- it: GitHub redirectScheme overrides the detected scheme
+  set:
+    ingress:
+      host: renovate.example.org
+    auth:
+      github:
+        enabled: true
+        existingSecret: my-github-secret
+        redirectScheme: https
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: GITHUB_REDIRECT_URL
+        value: https://renovate.example.org/auth/callback
+
+- it: Webhook base URL derived from ingress defaults to http without tls
+  set:
+    webhook:
+      enabled: true
+      ingress:
+        enabled: true
+        host: webhook.example.org
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: WEBHOOK_BASE_URL
+        value: http://webhook.example.org
+
+- it: Webhook baseUrlScheme overrides the scheme detected from ingress
+  set:
+    webhook:
+      enabled: true
+      baseUrlScheme: https
+      ingress:
+        enabled: true
+        host: webhook.example.org
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: WEBHOOK_BASE_URL
+        value: https://webhook.example.org
+
+- it: Webhook baseUrlScheme overrides the https default of route
+  set:
+    webhook:
+      enabled: true
+      baseUrlScheme: http
+      route:
+        enabled: true
+        hostnames:
+        - webhook.example.org
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: WEBHOOK_BASE_URL
+        value: http://webhook.example.org

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -120,6 +120,8 @@ webhook:
   # -- if set to true the ui host will be used for webhooks
   unifiedWebhookHost: false
   port: 8082
+  # -- optional: override the scheme (http or https) of the auto-derived webhook base URL (WEBHOOK_BASE_URL), e.g. when TLS terminates at an external load balancer or Gateway
+  baseUrlScheme: ""
   ingress:
     # -- whether to enable the ingress for the webhook server
     enabled: false
@@ -178,6 +180,8 @@ auth:
     sessionSecretKey: ""
     # -- optional: OIDC redirect URL (auto-detected from ingress host if empty)
     redirectUrl: ""
+    # -- optional: override the scheme (http or https) of the auto-detected redirect URL, e.g. when TLS terminates at an external load balancer or Gateway (ignored when redirectUrl is set)
+    redirectScheme: ""
     # -- optional: skip TLS verification for the OIDC provider (not recommended for production)
     insecureSkipVerify: false
     # -- optional: OIDC end_session_endpoint URL for provider logout (auto-discovered if available)
@@ -214,6 +218,8 @@ auth:
     sessionSecretKey: ""
     # -- optional: GitHub OAuth redirect URL (auto-detected from ingress host if empty)
     redirectUrl: ""
+    # -- optional: override the scheme (http or https) of the auto-detected redirect URL, e.g. when TLS terminates at an external load balancer or Gateway (ignored when redirectUrl is set)
+    redirectScheme: ""
 
 rbac:
   # -- if true no clusterrole and clusterrolebinding will be created, only role and rolebinding

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -22,6 +22,7 @@ auth:
     secretKey: "client-secret"                 # Key inside the secret
     sessionSecretKey: ""                       # Optional: key for session encryption secret
     redirectUrl: ""                            # Optional: auto-detected from ingress
+    redirectScheme: ""                         # Optional: http or https, overrides the auto-detected scheme
     insecureSkipVerify: false                  # Do not use in production
     logoutUrl: ""                              # Optional: auto-discovered via OIDC metadata
     allowedGroupPrefix: ""                     # Optional: only accept groups with this prefix
@@ -29,6 +30,8 @@ auth:
     additionalScopes: []                        # Optional: extra OIDC scopes (e.g., ["groups"])
     fetchUserInfoGroups: false                   # Optional: fetch groups from userinfo endpoint
 ```
+
+The redirect URL is auto-detected from the chart's `route.hostnames[0]` or `ingress.host`, using `https` only when `ingress.tls` is set. When TLS terminates outside the cluster (external load balancer, Gateway API listener), set `redirectScheme: https` to correct the scheme — or set `redirectUrl` to a full URL, which takes precedence.
 
 ### Secret
 
@@ -95,7 +98,10 @@ auth:
     secretKey: "client-secret"                # Key inside the secret
     sessionSecretKey: ""                      # Optional session encryption key
     redirectUrl: ""                           # Optional: auto-detected from ingress
+    redirectScheme: ""                        # Optional: http or https, overrides the auto-detected scheme
 ```
+
+Redirect URL auto-detection and `redirectScheme` behave exactly as described for [OIDC](#helm-configuration) above.
 
 ### Secret
 

--- a/docs/webhooks/sync.md
+++ b/docs/webhooks/sync.md
@@ -74,6 +74,8 @@ The Helm chart derives `WEBHOOK_BASE_URL` at deploy time from the webhook exposu
 1. **HTTPRoute** — `webhook.route.hostnames[0]`, with `https` (TLS terminates at the Gateway).
 2. **Ingress** — `webhook.ingress.host`, with `https` when `webhook.ingress.tls` is set, `http` otherwise.
 
+Set `webhook.baseUrlScheme` to `http` or `https` to override the detected scheme, e.g. when TLS terminates at an external load balancer the chart cannot see.
+
 ## How sync works
 
 Webhook sync runs automatically at the end of each autodiscovery cycle (controlled by `spec.schedule`).


### PR DESCRIPTION
Closes #452

When TLS terminates outside the cluster (external load balancer, Gateway API
listener), the chart detects `http` even though the public URL is `https`.
This adds three optional chart values to override the detected scheme:

- `auth.oidc.redirectScheme` / `auth.github.redirectScheme` — scheme of the
  auto-detected auth redirect URL (ignored when `redirectUrl` is set)
- `webhook.baseUrlScheme` — scheme of the auto-derived `WEBHOOK_BASE_URL`
  used for automatic webhook sync

All values default to empty, keeping the current auto-detection — rendered
manifests are unchanged unless a value is set. Invalid values (anything but
`http`/`https`) fail the render with a clear error. Chart-only change, no
operator code touched.