### PR TITLE
feat(ui): make the OIDC groups claim name configurable

### DIFF
--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -171,6 +171,10 @@ spec:
             - name: OIDC_FETCH_USERINFO_GROUPS
               value: "true"
             {{- end }}
+            {{- if .Values.auth.oidc.groupsClaim }}
+            - name: OIDC_GROUPS_CLAIM
+              value: {{ .Values.auth.oidc.groupsClaim | quote }}
+            {{- end }}
             - name: OIDC_PKCE_ENABLED
               value: {{ .Values.auth.oidc.pkceEnabled | toString | quote }}
             {{- else if .Values.auth.github.enabled }}

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -201,6 +201,9 @@ auth:
     # -- optional: only accept groups matching this regex pattern (e.g., "^(team-|platform-).*")
     # -- Leave empty to accept all groups. Can be combined with allowedGroupPrefix.
     allowedGroupPattern: ""
+    # -- optional: name of the OIDC claim that carries group memberships (defaults to "groups")
+    # -- Set this if your provider emits groups under a namespaced claim, e.g. "https://example.com/groups".
+    groupsClaim: ""
     # -- optional: additional OIDC scopes to request (e.g., "groups" for Keycloak)
     additionalScopes: []
     # -- optional: fetch groups from the OIDC userinfo endpoint and merge with ID token groups (for providers that only expose groups via userinfo)

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -132,6 +132,7 @@ func initAuth(valkeyConf kvstore.ValkeyConfig) authSetup {
 			AdditionalScopes:    splitAndTrim(config.GetValue("OIDC_ADDITIONAL_SCOPES"), ","),
 			FetchUserInfoGroups: config.GetValue("OIDC_FETCH_USERINFO_GROUPS") == "true",
 			PKCEEnabled:         config.GetValue("OIDC_PKCE_ENABLED") != "false",
+			GroupsClaim:         config.GetValue("OIDC_GROUPS_CLAIM"),
 		}, cookieKey, ctrl.Log.WithName("oidc"), sessionStore)
 		assert.NoError(oidcErr, "failed to initialize OIDC provider")
 		authProvider = oidcAuth
@@ -376,6 +377,11 @@ func main() {
 			Key:      "OIDC_PKCE_ENABLED",
 			Optional: true,
 			Default:  "true",
+		},
+		{
+			Key:      "OIDC_GROUPS_CLAIM",
+			Optional: true,
+			Default:  "groups",
 		},
 		{
 			Key:      "VALKEY_URL",

--- a/src/ui/oidc.go
+++ b/src/ui/oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -21,6 +22,11 @@ import (
 
 const pkceCookieName = "pkce_verifier"
 
+// defaultGroupsClaim is the OIDC claim that group memberships are read from when
+// OIDC_GROUPS_CLAIM is not set. Providers that emit groups under a namespaced
+// claim (e.g. "https://example.com/groups") can override it.
+const defaultGroupsClaim = "groups"
+
 type OIDCConfig struct {
 	IssuerURL           string
 	ClientID            string
@@ -34,6 +40,7 @@ type OIDCConfig struct {
 	AdditionalScopes    []string
 	FetchUserInfoGroups bool
 	PKCEEnabled         bool
+	GroupsClaim         string
 }
 
 type OIDCAuth struct {
@@ -47,6 +54,7 @@ type OIDCAuth struct {
 	groupFilterConfig   GroupFilterConfig
 	fetchUserInfoGroups bool
 	pkceEnabled         bool
+	groupsClaim         string
 }
 
 func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, encryptionKey [32]byte, logger logr.Logger, sessionStore SessionStore) (*OIDCAuth, error) {
@@ -140,6 +148,14 @@ func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, encryptionKey [32]byte, lo
 		logger.Info("OIDC userinfo group fetching enabled -- groups will be fetched from both ID token and userinfo endpoint; userinfo failures will block login")
 	}
 
+	groupsClaim := cfg.GroupsClaim
+	if groupsClaim == "" {
+		groupsClaim = defaultGroupsClaim
+	}
+	if groupsClaim != defaultGroupsClaim {
+		logger.Info("OIDC groups claim name overridden", "claim", groupsClaim)
+	}
+
 	return &OIDCAuth{
 		baseAuth:            base,
 		provider:            provider,
@@ -151,6 +167,7 @@ func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, encryptionKey [32]byte, lo
 		groupFilterConfig:   groupFilterConfig,
 		fetchUserInfoGroups: cfg.FetchUserInfoGroups,
 		pkceEnabled:         cfg.PKCEEnabled,
+		groupsClaim:         groupsClaim,
 	}, nil
 }
 
@@ -233,10 +250,16 @@ func (o *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	var claims struct {
 		Email  string   `json:"email"`
 		Name   string   `json:"name"`
-		Groups []string `json:"groups,omitempty"`
+		Groups []string `json:"-"` // read from the configurable claim below
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		o.logger.Error(err, "failed to parse claims")
+		http.Error(w, "failed to parse claims", http.StatusInternalServerError)
+		return
+	}
+	claims.Groups, err = extractGroupsClaim(idToken, o.groupsClaim)
+	if err != nil {
+		o.logger.Error(err, "failed to parse group claim")
 		http.Error(w, "failed to parse claims", http.StatusInternalServerError)
 		return
 	}
@@ -259,10 +282,8 @@ func (o *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to fetch userinfo", http.StatusInternalServerError)
 			return
 		}
-		var userInfoClaims struct {
-			Groups []string `json:"groups,omitempty"`
-		}
-		if err := userInfo.Claims(&userInfoClaims); err != nil {
+		userInfoGroups, err := extractGroupsClaim(userInfo, o.groupsClaim)
+		if err != nil {
 			o.logger.Error(err, "failed to parse userinfo claims")
 			http.Error(w, "failed to parse userinfo claims", http.StatusInternalServerError)
 			return
@@ -270,8 +291,8 @@ func (o *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		o.logger.V(1).Info("userinfo groups received",
 			"user", claims.Email,
 			"id_token_groups", claims.Groups,
-			"userinfo_groups", userInfoClaims.Groups)
-		claims.Groups = mergeGroups(claims.Groups, userInfoClaims.Groups)
+			"userinfo_groups", userInfoGroups)
+		claims.Groups = mergeGroups(claims.Groups, userInfoGroups)
 	}
 
 	// Apply 3-layer group validation
@@ -322,6 +343,41 @@ func (o *OIDCAuth) HandleAuthStatus(w http.ResponseWriter, r *http.Request) {
 
 func (o *OIDCAuth) SupportsGroups() bool {
 	return true
+}
+
+// claimReader is implemented by *oidc.IDToken and *oidc.UserInfo; both expose
+// the raw claim set via Claims(v).
+type claimReader interface {
+	Claims(v any) error
+}
+
+// extractGroupsClaim reads group memberships from an OIDC claim set using the
+// configured claim name (see defaultGroupsClaim). It tolerates the claim being
+// absent, a JSON array of strings, or a single string.
+func extractGroupsClaim(r claimReader, claimName string) ([]string, error) {
+	var raw map[string]json.RawMessage
+	if err := r.Claims(&raw); err != nil {
+		return nil, err
+	}
+	return parseGroupsClaim(raw[claimName]), nil
+}
+
+// parseGroupsClaim decodes a single OIDC claim value into a list of groups,
+// accepting either a JSON array of strings or a single string; anything else
+// (absent, null, empty, or a non-string type) yields no groups.
+func parseGroupsClaim(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var groups []string
+	if err := json.Unmarshal(raw, &groups); err == nil {
+		return groups
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil && single != "" {
+		return []string{single}
+	}
+	return nil
 }
 
 // mergeGroups combines groups from the ID token and userinfo endpoint,

--- a/src/ui/oidc_test.go
+++ b/src/ui/oidc_test.go
@@ -135,3 +135,27 @@ func TestMergeGroups(t *testing.T) {
 		})
 	}
 }
+
+func TestParseGroupsClaim(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"array of strings", `["team-a","team-b"]`, []string{"team-a", "team-b"}},
+		{"single string coerced to slice", `"team-a"`, []string{"team-a"}},
+		{"empty array", `[]`, []string{}},
+		{"absent claim", ``, nil},
+		{"null", `null`, nil},
+		{"empty string", `""`, nil},
+		{"non-string type ignored", `42`, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGroupsClaim([]byte(tt.raw))
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("parseGroupsClaim(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The OIDC groups claim is hardcoded to `groups` via Go struct tags on both the ID
token and the userinfo claim sets (`src/ui/oidc.go`). Providers that emit group
memberships under a namespaced claim (e.g. `https://example.com/groups`, common
with Auth0 and some enterprise IdPs) therefore return no groups, so the existing
group filtering (`OIDC_ALLOWED_GROUP_PREFIX` / `OIDC_ALLOWED_GROUP_PATTERN`)
can't be used with them.

- Add `OIDC_GROUPS_CLAIM` (Helm: `auth.oidc.groupsClaim`), defaulting to `groups`
  so existing deployments are unchanged.
- Read the groups claim dynamically by the configured name from both the ID token
  and the userinfo endpoint, tolerating either a JSON array of strings or a single
  string.
- Add a unit test for the claim parser; wire the value through `main.go` and the
  Helm chart (`deployment.yaml` + `values.yaml`).
