### PR TITLE
fix(ui): avoid slow renovatejobs loading when discovery jobs are missing

### DIFF
--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -9,7 +9,6 @@ import (
 	"renovate-operator/internal/podLogs"
 	"renovate-operator/internal/types"
 	"sync"
-	"time"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
@@ -81,20 +80,7 @@ func (e *discoveryAgent) GetDiscoveryJobStatus(ctx context.Context, job *api.Ren
 		RenovateJobName: job.Name,
 	})
 	if err != nil && errors.IsNotFound(err) {
-		time.Sleep(1 * time.Second)
-
-		tries := 5
-		for errors.IsNotFound(err) {
-			tries--
-			if tries <= 0 {
-				return api.JobStatusFailed, fmt.Errorf("discovery job not found: %w", err)
-			}
-			existingDiscoveryJob, err = crdManager.GetJobByLabel(ctx, e.client, crdManager.JobSelector{
-				JobType:         crdManager.DiscoveryJobType,
-				Namespace:       job.Namespace,
-				RenovateJobName: job.Name,
-			})
-		}
+		return api.JobStatusScheduled, nil
 	} else if err != nil {
 		return api.JobStatusFailed, fmt.Errorf("failed to get discovery job: %w", err)
 	}

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -15,7 +15,9 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	api "renovate-operator/api/v1alpha1"
 	crdmanager "renovate-operator/internal/crdManager"
@@ -814,6 +816,64 @@ func TestGetRenovateJobs_WithAuthorization(t *testing.T) {
 				t.Errorf("Expected %d jobs, got %d", tt.wantCount, len(result))
 			}
 		})
+	}
+}
+
+func TestGetRenovateJobs_ManyMissingDiscoveryJobsReturnsQuickly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := api.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add api scheme: %v", err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add batch scheme: %v", err)
+	}
+
+	const jobCount = 5
+	jobs := make([]api.RenovateJob, 0, jobCount)
+	for i := range jobCount {
+		jobs = append(jobs, api.RenovateJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-" + string(rune('a'+i)),
+				Namespace: "default",
+			},
+			Spec: api.RenovateJobSpec{Schedule: "0 0 * * *"},
+		})
+	}
+
+	mockManager := &mockRenovateJobManager{
+		listRenovateJobsFullFunc: func(ctx context.Context) ([]api.RenovateJob, error) {
+			return jobs, nil
+		},
+	}
+
+	server := &Server{
+		manager:   mockManager,
+		logger:    logr.Discard(),
+		discovery: renovate.NewDiscoveryAgent(scheme, fake.NewClientBuilder().WithScheme(scheme).Build(), logr.Discard(), nil, nil),
+		scheduler: &mockScheduler{},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/renovatejobs", nil)
+	w := httptest.NewRecorder()
+
+	start := time.Now()
+	server.getRenovateJobs(w, req)
+	elapsed := time.Since(start)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var result []RenovateJobInfo
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if len(result) != jobCount {
+		t.Fatalf("Expected %d jobs, got %d", jobCount, len(result))
+	}
+	if elapsed > 750*time.Millisecond {
+		t.Fatalf("getRenovateJobs took %s for %d jobs without discovery jobs, expected it to return without per-job polling", elapsed, jobCount)
 	}
 }
 


### PR DESCRIPTION
## What changed

  Draft PR for https://github.com/mogenius/renovate-operator/issues/486.

  This adds a regression test for the slow `/api/v1/renovatejobs` path and removes the retry/sleep behavior when a discovery Kubernetes Job is missing.

  The current code calls `GetDiscoveryJobStatus` once per RenovateJob while building the UI response. If the discovery Job no longer exists, that function sleeps/retries before returning. With many
  RenovateJobs this adds up quickly. In our case, ~50 RenovateJobs made the endpoint take around 40-60 seconds.

  ## Why this is a draft

  I am not fully sure what exact race the original sleep workaround was meant to address. From the history it looks like it was added to wait for a discovery Job to appear, probably around manual discovery
  triggering or Kubernetes cache visibility.

  For the dashboard read path, though, a missing discovery Job is a normal state:
  - successful discovery Jobs may be deleted
  - TTL cleanup may remove them
  - old generations may be cleaned up
  - `status.projects` can still be populated even when the discovery Job is gone

  So this PR is mainly meant to show the problem with a focused failing test and propose the smallest fix.

  ## Test added

  The new test covers the real slow path:

  ```bash
  go test ./ui -run TestGetRenovateJobs_ManyMissingDiscoveryJobsReturnsQuickly -count=1
```
  Without the fix, it fails like this:
```
  --- FAIL: TestGetRenovateJobs_ManyMissingDiscoveryJobsReturnsQuickly (5.07s)
      renovateController_test.go:876: getRenovateJobs took 5.025843419s for 5 jobs without discovery jobs, expected it to return without per-job polling
```
  That reproduces the same multiplier we see in larger clusters: roughly one second per RenovateJob without a discovery Job.

  ## Proposed fix

  When GetDiscoveryJobStatus cannot find a discovery Job, it now returns scheduled immediately instead of sleeping/retrying.

  This keeps the UI fast and treats a missing discovery Job as an idle/scheduled state rather than an exceptional condition.

  ## Open question

  If the sleep is still needed for the manual discovery trigger path, it may be better to handle that specifically instead of in the shared status-read method.

  I did not try to redesign that in this PR, because I wanted to keep the change small and focused on the UI latency issue.

  ## Testing
```
  go test ./ui -run TestGetRenovateJobs_ManyMissingDiscoveryJobsReturnsQuickly -count=1
  go test ./internal/renovate ./ui
  ```