### PR TITLE
feat(operator): support username and TLS for host-based Valkey config

### DIFF
--- a/charts/renovate-operator/templates/deployment.yaml
+++ b/charts/renovate-operator/templates/deployment.yaml
@@ -198,7 +198,58 @@ spec:
               value: {{ $githubRedirectUrl | quote }}
             {{- end }}
             {{- end }}
-            {{- if .Values.valkey.existingSecret }}
+            {{- $ekv := .Values.externalKeyValueStore }}
+            {{- if or $ekv.host $ekv.existingSecret.name }}
+            {{- if and $ekv.existingSecret.name $ekv.existingSecret.urlKey }}
+            - name: VALKEY_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $ekv.existingSecret.name }}
+                  key: {{ $ekv.existingSecret.urlKey }}
+            {{- else }}
+            {{- if and $ekv.existingSecret.name $ekv.existingSecret.hostKey }}
+            - name: VALKEY_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $ekv.existingSecret.name }}
+                  key: {{ $ekv.existingSecret.hostKey }}
+            {{- else if $ekv.host }}
+            - name: VALKEY_HOST
+              value: {{ $ekv.host | quote }}
+            {{- end }}
+            {{- if and $ekv.existingSecret.name $ekv.existingSecret.portKey }}
+            - name: VALKEY_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $ekv.existingSecret.name }}
+                  key: {{ $ekv.existingSecret.portKey }}
+            {{- else if $ekv.port }}
+            - name: VALKEY_PORT
+              value: {{ $ekv.port | quote }}
+            {{- end }}
+            {{- if and $ekv.existingSecret.name $ekv.existingSecret.usernameKey }}
+            - name: VALKEY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $ekv.existingSecret.name }}
+                  key: {{ $ekv.existingSecret.usernameKey }}
+            {{- else if $ekv.username }}
+            - name: VALKEY_USERNAME
+              value: {{ $ekv.username | quote }}
+            {{- end }}
+            {{- if and $ekv.existingSecret.name $ekv.existingSecret.passwordKey }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $ekv.existingSecret.name }}
+                  key: {{ $ekv.existingSecret.passwordKey }}
+            {{- end }}
+            {{- if $ekv.useTls }}
+            - name: VALKEY_TLS
+              value: "true"
+            {{- end }}
+            {{- end }}
+            {{- else if .Values.valkey.existingSecret }}
             - name: VALKEY_URL
               valueFrom:
                 secretKeyRef:

--- a/charts/renovate-operator/unittests/deployment/deployment.yaml
+++ b/charts/renovate-operator/unittests/deployment/deployment.yaml
@@ -202,3 +202,148 @@ tests:
       content:
         name: WEBHOOK_BASE_URL
         value: http://webhook.example.org
+
+- it: External key value store url from secret ignores all other keys
+  set:
+    externalKeyValueStore:
+      host: ignored.example.com
+      username: ignored
+      existingSecret:
+        name: my-kv-secret
+        urlKey: url
+        passwordKey: password
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_URL
+        valueFrom:
+          secretKeyRef:
+            name: my-kv-secret
+            key: url
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_HOST
+        value: ignored.example.com
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: my-kv-secret
+            key: password
+
+- it: External key value store with all connection values from secret
+  set:
+    externalKeyValueStore:
+      useTls: true
+      existingSecret:
+        name: my-kv-secret
+        hostKey: SERVICEUSER_HOST
+        portKey: SERVICEUSER_PORT
+        usernameKey: SERVICEUSER_USERNAME
+        passwordKey: SERVICEUSER_PASSWORD
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_HOST
+        valueFrom:
+          secretKeyRef:
+            name: my-kv-secret
+            key: SERVICEUSER_HOST
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_PORT
+        valueFrom:
+          secretKeyRef:
+            name: my-kv-secret
+            key: SERVICEUSER_PORT
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: my-kv-secret
+            key: SERVICEUSER_USERNAME
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: my-kv-secret
+            key: SERVICEUSER_PASSWORD
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_TLS
+        value: "true"
+
+- it: External key value store clear values with secret keys taking precedence
+  set:
+    externalKeyValueStore:
+      host: valkey.example.com
+      port: 6380
+      username: clear-user
+      existingSecret:
+        name: my-kv-secret
+        usernameKey: username
+        passwordKey: password
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_HOST
+        value: valkey.example.com
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_PORT
+        value: "6380"
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: my-kv-secret
+            key: username
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_USERNAME
+        value: clear-user
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_TLS
+        value: "true"
+
+- it: External key value store takes precedence over deprecated valkey.existingSecret
+  set:
+    valkey:
+      existingSecret: legacy-secret
+    externalKeyValueStore:
+      host: valkey.example.com
+      existingSecret:
+        name: my-kv-secret
+        passwordKey: password
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_HOST
+        value: valkey.example.com
+  - notContains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VALKEY_URL
+        valueFrom:
+          secretKeyRef:
+            name: legacy-secret
+            key: valkey-url

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -297,15 +297,48 @@ logging:
   # -- log format for the operator, one of: json, console
   format: "json"
 
+# -- optional: connection to an external redis-protocol-compatible key value store (e.g. Redis / Valkey)
+# -- Takes precedence over the deprecated valkey.existingSecret and the bundled valkey instance.
+# -- Active when host or existingSecret.name is set.
+externalKeyValueStore:
+  # -- whether the connection should be made with TLS encryption enabled (rediss://)
+  useTls: false
+  # -- host for the connection; alternatively provide via existingSecret.hostKey
+  host: ~
+  # -- port for the connection; alternatively provide via existingSecret.portKey
+  port: 6379
+  # -- username for authentication; alternatively provide via existingSecret.usernameKey.
+  # -- Omit to authenticate as the default user.
+  username: ~
+  # -- secret containing connection and authentication values.
+  # -- Keys win over their clear-value counterparts above.
+  existingSecret:
+    # -- name of the secret containing connection and authentication information
+    name: ~
+    # -- key containing the full connection url (e.g. "rediss://user:password@valkey:6379/0").
+    # -- When set, all other keys and clear values are ignored.
+    urlKey: ~
+    # -- key containing the host for the connection
+    hostKey: ~
+    # -- key containing the port for the connection
+    portKey: ~
+    # -- key containing the username for authentication
+    usernameKey: ~
+    # -- key containing the password for authentication.
+    # -- The password can only be provided via secret.
+    passwordKey: ~
+
 # -- optional: deploy a Valkey instance for session storage (recommended for multi-replica)
 valkey:
   # Enable Valkey for session storage. When enabled, the operator will create a Valkey deployment and use it to store sessions.
   enabled: false
 
+  # -- DEPRECATED: use externalKeyValueStore.existingSecret instead; will be removed in a future release.
   # -- name of an existing secret containing the Valkey URL for session storage
   # -- Use this to provide a Valkey URL (e.g., "redis://:password@valkey:6379/0") via a Kubernetes secret
   # -- When set, sessions are stored in Valkey (recommended for multi-replica deployments)
   existingSecret: ""
+  # -- DEPRECATED: use externalKeyValueStore.existingSecret.urlKey instead; will be removed in a future release.
   # -- key in the existing secret that contains the Valkey URL
   existingSecretKey: "valkey-url"
   auth:

--- a/docs/valkey.md
+++ b/docs/valkey.md
@@ -36,14 +36,18 @@ If `VALKEY_URL` has no database component (e.g. `redis://valkey:6379`), the base
 
 Valkey is configured via environment variables (or the equivalent Helm values):
 
-| Environment variable           | Helm value                  | Default    | Description                                                                                            |
-|--------------------------------|-----------------------------|------------|--------------------------------------------------------------------------------------------------------|
-| `VALKEY_URL`                   | —                           | `""`       | Full connection URL, e.g. `redis://:password@valkey:6379/0`. Takes precedence over host/port/password. |
-| `VALKEY_HOST`                  | —                           | `""`       | Valkey hostname. Used when `VALKEY_URL` is not set.                                                    |
-| `VALKEY_PORT`                  | —                           | `6379`     | Valkey port. Used when `VALKEY_URL` is not set.                                                        |
-| `VALKEY_PASSWORD`              | —                           | `""`       | Valkey password. Used when `VALKEY_URL` is not set.                                                    |
-| `VALKEY_FORWARD_CACHE_TO_JOBS` | `config.forwardCacheToJobs` | `true`     | Forward the Renovate cache URL to executor jobs. Requires Valkey to be configured.                     |
-| `LOG_STORE_MODE`               | `config.logStorage.mode`    | `disabled` | Log storage backend: `disabled`, `memory`, `valkey`, or `s3` (see [S3 Object Storage](./s3.md)).       |
+| Environment variable           | Helm value                  | Default    | Description                                                                                                       |
+|--------------------------------|-----------------------------|------------|-------------------------------------------------------------------------------------------------------------------|
+| `VALKEY_URL`                   | —                           | `""`       | Full connection URL, e.g. `redis://user:password@valkey:6379/0`. Takes precedence over all host-based variables.  |
+| `VALKEY_HOST`                  | —                           | `""`       | Valkey hostname. Used when `VALKEY_URL` is not set.                                                               |
+| `VALKEY_PORT`                  | —                           | `6379`     | Valkey port. Used when `VALKEY_URL` is not set.                                                                   |
+| `VALKEY_USERNAME`              | —                           | `""`       | Valkey ACL username. Used when `VALKEY_URL` is not set. Omit to authenticate as the `default` user.               |
+| `VALKEY_PASSWORD`              | —                           | `""`       | Valkey password. Used when `VALKEY_URL` is not set.                                                               |
+| `VALKEY_TLS`                   | —                           | `false`    | Connect with TLS (`rediss://`). Used when `VALKEY_URL` is not set; a URL carries its own scheme.                  |
+| `VALKEY_FORWARD_CACHE_TO_JOBS` | `config.forwardCacheToJobs` | `true`     | Forward the Renovate cache URL to executor jobs. Requires Valkey to be configured.                                |
+| `LOG_STORE_MODE`               | `config.logStorage.mode`    | `disabled` | Log storage backend: `disabled`, `memory`, `valkey`, or `s3` (see [S3 Object Storage](./s3.md)).                  |
+
+The server certificate of a TLS-enabled Valkey must chain to a publicly trusted CA — there is currently no option to supply a custom CA bundle. Note that the executor jobs receive the same URL, so Renovate's containers must be able to verify the certificate too.
 
 ## Deploying with the bundled Helm chart
 
@@ -72,6 +76,41 @@ metadata:
 stringData:
   valkey-url: "redis://:yourpassword@valkey.example.com:6379/0"
 ```
+
+### External Valkey with credentials in separate secret fields
+
+When an external Valkey's credentials arrive as separate secret fields rather than a ready-made URL — for example the [Aiven operator](https://aiven.github.io/aiven-operator/)'s `ServiceUser` secret with its `SERVICEUSER_USERNAME` and `SERVICEUSER_PASSWORD` keys — use the host-based variables via the chart's `extraEnv` instead of templating a URL yourself. The operator constructs the connection URL:
+
+```yaml
+valkey:
+  enabled: false
+
+extraEnv:
+  - name: VALKEY_HOST
+    valueFrom:
+      secretKeyRef:
+        name: my-valkey-serviceuser
+        key: SERVICEUSER_HOST
+  - name: VALKEY_PORT
+    valueFrom:
+      secretKeyRef:
+        name: my-valkey-serviceuser
+        key: SERVICEUSER_PORT
+  - name: VALKEY_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: my-valkey-serviceuser
+        key: SERVICEUSER_USERNAME
+  - name: VALKEY_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: my-valkey-serviceuser
+        key: SERVICEUSER_PASSWORD
+  - name: VALKEY_TLS
+    value: "true"
+```
+
+`extraEnv` entries are appended after the chart's built-in environment variables, so they also take precedence over any Valkey settings the chart emits itself.
 
 ## High availability
 

--- a/docs/valkey.md
+++ b/docs/valkey.md
@@ -36,16 +36,18 @@ If `VALKEY_URL` has no database component (e.g. `redis://valkey:6379`), the base
 
 Valkey is configured via environment variables (or the equivalent Helm values):
 
-| Environment variable           | Helm value                  | Default    | Description                                                                                                       |
-|--------------------------------|-----------------------------|------------|-------------------------------------------------------------------------------------------------------------------|
-| `VALKEY_URL`                   | —                           | `""`       | Full connection URL, e.g. `redis://user:password@valkey:6379/0`. Takes precedence over all host-based variables.  |
-| `VALKEY_HOST`                  | —                           | `""`       | Valkey hostname. Used when `VALKEY_URL` is not set.                                                               |
-| `VALKEY_PORT`                  | —                           | `6379`     | Valkey port. Used when `VALKEY_URL` is not set.                                                                   |
-| `VALKEY_USERNAME`              | —                           | `""`       | Valkey ACL username. Used when `VALKEY_URL` is not set. Omit to authenticate as the `default` user.               |
-| `VALKEY_PASSWORD`              | —                           | `""`       | Valkey password. Used when `VALKEY_URL` is not set.                                                               |
-| `VALKEY_TLS`                   | —                           | `false`    | Connect with TLS (`rediss://`). Used when `VALKEY_URL` is not set; a URL carries its own scheme.                  |
-| `VALKEY_FORWARD_CACHE_TO_JOBS` | `config.forwardCacheToJobs` | `true`     | Forward the Renovate cache URL to executor jobs. Requires Valkey to be configured.                                |
-| `LOG_STORE_MODE`               | `config.logStorage.mode`    | `disabled` | Log storage backend: `disabled`, `memory`, `valkey`, or `s3` (see [S3 Object Storage](./s3.md)).                  |
+| Environment variable           | Helm value                                    | Default    | Description                                                                                                       |
+|--------------------------------|-----------------------------------------------|------------|-------------------------------------------------------------------------------------------------------------------|
+| `VALKEY_URL`                   | `externalKeyValueStore.existingSecret.urlKey` | `""`       | Full connection URL, e.g. `redis://user:password@valkey:6379/0`. Takes precedence over all host-based variables.  |
+| `VALKEY_HOST`                  | `externalKeyValueStore.host` or `.existingSecret.hostKey` | `""` | Valkey hostname. Used when `VALKEY_URL` is not set.                                                          |
+| `VALKEY_PORT`                  | `externalKeyValueStore.port` or `.existingSecret.portKey` | `6379` | Valkey port. Used when `VALKEY_URL` is not set.                                                            |
+| `VALKEY_USERNAME`              | `externalKeyValueStore.username` or `.existingSecret.usernameKey` | `""` | Valkey ACL username. Used when `VALKEY_URL` is not set. Omit to authenticate as the `default` user. |
+| `VALKEY_PASSWORD`              | `externalKeyValueStore.existingSecret.passwordKey` | `""`  | Valkey password. Used when `VALKEY_URL` is not set. Only available via secret.                                    |
+| `VALKEY_TLS`                   | `externalKeyValueStore.useTls`                | `false`    | Connect with TLS (`rediss://`). Used when `VALKEY_URL` is not set; a URL carries its own scheme.                  |
+| `VALKEY_FORWARD_CACHE_TO_JOBS` | `config.forwardCacheToJobs`                   | `true`     | Forward the Renovate cache URL to executor jobs. Requires Valkey to be configured.                                |
+| `LOG_STORE_MODE`               | `config.logStorage.mode`                      | `disabled` | Log storage backend: `disabled`, `memory`, `valkey`, or `s3` (see [S3 Object Storage](./s3.md)).                  |
+
+Host, port, and username can each be set as a clear Helm value or sourced from the secret; the secret key wins when both are set. The password (and the full URL) can only be provided via secret.
 
 The server certificate of a TLS-enabled Valkey must chain to a publicly trusted CA — there is currently no option to supply a custom CA bundle. Note that the executor jobs receive the same URL, so Renovate's containers must be able to verify the certificate too.
 
@@ -58,12 +60,17 @@ valkey:
   enabled: true
 ```
 
-To use an external Valkey instance, provide the URL via an existing Kubernetes secret:
+## Connecting to an external instance
+
+An external Redis-protocol-compatible store (Redis, Valkey, …) is configured via the top-level `externalKeyValueStore` value, which takes precedence over the bundled instance. The connection is active when `host` or `existingSecret.name` is set.
+
+To provide the full connection URL via an existing Kubernetes secret:
 
 ```yaml
-valkey:
-  existingSecret: "my-valkey-secret"
-  existingSecretKey: "valkey-url"  # default key name
+externalKeyValueStore:
+  existingSecret:
+    name: "my-valkey-secret"
+    urlKey: "valkey-url"
 ```
 
 The secret must contain the full connection URL under the configured key:
@@ -74,43 +81,27 @@ kind: Secret
 metadata:
   name: my-valkey-secret
 stringData:
-  valkey-url: "redis://:yourpassword@valkey.example.com:6379/0"
+  valkey-url: "redis://user:yourpassword@valkey.example.com:6379/0"
 ```
 
-### External Valkey with credentials in separate secret fields
+When `urlKey` is set, all other `externalKeyValueStore` values are ignored.
 
-When an external Valkey's credentials arrive as separate secret fields rather than a ready-made URL — for example the [Aiven operator](https://aiven.github.io/aiven-operator/)'s `ServiceUser` secret with its `SERVICEUSER_USERNAME` and `SERVICEUSER_PASSWORD` keys — use the host-based variables via the chart's `extraEnv` instead of templating a URL yourself. The operator constructs the connection URL:
+> **Deprecated:** `valkey.existingSecret` / `valkey.existingSecretKey` configure the same URL-via-secret connection and are superseded by `externalKeyValueStore.existingSecret`; they will be removed in a future release.
+
+### Credentials in separate secret fields
+
+When the credentials arrive as separate secret fields rather than a ready-made URL — for example the [Aiven operator](https://aiven.github.io/aiven-operator/)'s `ServiceUser` secret with its `SERVICEUSER_*` keys — configure the fields individually and the operator constructs the connection URL. Each of host, port, and username can come from the secret (`existingSecret.{param}Key`) or be set as a clear value (`{param}`); the password can only come from the secret:
 
 ```yaml
-valkey:
-  enabled: false
-
-extraEnv:
-  - name: VALKEY_HOST
-    valueFrom:
-      secretKeyRef:
-        name: my-valkey-serviceuser
-        key: SERVICEUSER_HOST
-  - name: VALKEY_PORT
-    valueFrom:
-      secretKeyRef:
-        name: my-valkey-serviceuser
-        key: SERVICEUSER_PORT
-  - name: VALKEY_USERNAME
-    valueFrom:
-      secretKeyRef:
-        name: my-valkey-serviceuser
-        key: SERVICEUSER_USERNAME
-  - name: VALKEY_PASSWORD
-    valueFrom:
-      secretKeyRef:
-        name: my-valkey-serviceuser
-        key: SERVICEUSER_PASSWORD
-  - name: VALKEY_TLS
-    value: "true"
+externalKeyValueStore:
+  useTls: true
+  existingSecret:
+    name: my-valkey-serviceuser
+    hostKey: SERVICEUSER_HOST
+    portKey: SERVICEUSER_PORT
+    usernameKey: SERVICEUSER_USERNAME
+    passwordKey: SERVICEUSER_PASSWORD
 ```
-
-`extraEnv` entries are appended after the chart's built-in environment variables, so they also take precedence over any Valkey settings the chart emits itself.
 
 ## High availability
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -399,9 +399,19 @@ func main() {
 			Default:  "6379",
 		},
 		{
+			Key:      "VALKEY_USERNAME",
+			Optional: true,
+			Default:  "",
+		},
+		{
 			Key:      "VALKEY_PASSWORD",
 			Optional: true,
 			Default:  "",
+		},
+		{
+			Key:      "VALKEY_TLS",
+			Optional: true,
+			Default:  "false",
 		},
 		{
 			Key:      "VALKEY_FORWARD_CACHE_TO_JOBS",

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -524,12 +524,7 @@ func main() {
 
 	gitProviderClientFactory := gitProviderClientFactory.NewGitProviderClientFactory(mgr.GetClient())
 
-	valkeyConf := kvstore.ValkeyConfig{
-		URL:      config.GetValue("VALKEY_URL"),
-		Host:     config.GetValue("VALKEY_HOST"),
-		Port:     config.GetValue("VALKEY_PORT"),
-		Password: config.GetValue("VALKEY_PASSWORD"),
-	}
+	valkeyConf := kvstore.ConfigFromEnv(config.GetValue)
 
 	s3Cfg := objectstore.S3Config{
 		Bucket:          config.GetValue("S3_BUCKET"),

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -92,7 +92,9 @@ func initAuth(valkeyConf kvstore.ValkeyConfig) authSetup {
 
 	// Initialize KV store (Valkey if configured, otherwise nil)
 	kvStore, kvErr := kvstore.NewKVStore(valkeyConf, kvstore.UsageSessionStore)
-	assert.Assert(kvErr == nil || kvErr == kvstore.ErrValkeyNotConfigured, "failed to initialize KV store")
+	if kvErr != nil && kvErr != kvstore.ErrValkeyNotConfigured {
+		assert.NoError(kvErr, "failed to initialize KV store")
+	}
 
 	// Wrap KV store with session-specific encryption and key prefix
 	sessionStore, storeErr := ui.NewSessionStore(kvStore, storeKey)

--- a/src/internal/kvstore/valkey_config.go
+++ b/src/internal/kvstore/valkey_config.go
@@ -20,6 +20,18 @@ func (cfg *ValkeyConfig) IsConfigured() bool {
 	return cfg.URL != "" || cfg.Host != ""
 }
 
+// ConfigFromEnv builds a ValkeyConfig by looking up the VALKEY_* configuration
+// values through the provided getter (typically config.GetValue). Keeping the
+// lookup injected avoids coupling this package to the config singleton.
+func ConfigFromEnv(get func(key string) string) ValkeyConfig {
+	return ValkeyConfig{
+		URL:      get("VALKEY_URL"),
+		Host:     get("VALKEY_HOST"),
+		Port:     get("VALKEY_PORT"),
+		Password: get("VALKEY_PASSWORD"),
+	}
+}
+
 // Usage identifies a logical Valkey database role.
 // The value doubles as an offset from the base database when a predefined URL is used,
 // or as an absolute database index when connecting via host/port.

--- a/src/internal/kvstore/valkey_config.go
+++ b/src/internal/kvstore/valkey_config.go
@@ -8,12 +8,15 @@ import (
 )
 
 // ValkeyConfig holds the configuration for connecting to Valkey.
-// Either URL or Host must be set; URL takes precedence over Host/Port/Password.
+// Either URL or Host must be set; URL takes precedence over
+// Host/Port/Username/Password/TLS.
 type ValkeyConfig struct {
 	URL      string
 	Host     string
 	Port     string
+	Username string
 	Password string
+	TLS      bool
 }
 
 func (cfg *ValkeyConfig) IsConfigured() bool {
@@ -28,7 +31,9 @@ func ConfigFromEnv(get func(key string) string) ValkeyConfig {
 		URL:      get("VALKEY_URL"),
 		Host:     get("VALKEY_HOST"),
 		Port:     get("VALKEY_PORT"),
+		Username: get("VALKEY_USERNAME"),
 		Password: get("VALKEY_PASSWORD"),
+		TLS:      get("VALKEY_TLS") == "true",
 	}
 }
 
@@ -60,25 +65,35 @@ func (cfg ValkeyConfig) URLForUsage(usage Usage) string {
 	if cfg.URL != "" {
 		return offsetURLDB(cfg.URL, int(usage))
 	}
-	return BuildValkeyURL(cfg.Host, cfg.Port, cfg.Password, int(usage))
+	return BuildValkeyURL(cfg.Host, cfg.Port, cfg.Username, cfg.Password, cfg.TLS, int(usage))
 }
 
-// BuildValkeyURL constructs a Valkey URL from host, port, password, and database index.
-// Returns "" if host is empty. Uses the redis:// scheme (wire-compatible with Valkey).
-func BuildValkeyURL(host, port, password string, db int) string {
+// BuildValkeyURL constructs a Valkey URL from host, port, credentials, and
+// database index. Returns "" if host is empty. Uses the redis:// scheme
+// (wire-compatible with Valkey), or rediss:// when useTLS is set.
+// A username without a password is emitted as user@host (valid for ACL users
+// created with nopass).
+func BuildValkeyURL(host, port, username, password string, useTLS bool, db int) string {
 	if host == "" {
 		return ""
 	}
 	if port == "" {
 		port = "6379"
 	}
+	scheme := "redis"
+	if useTLS {
+		scheme = "rediss"
+	}
 	u := url.URL{
-		Scheme: "redis",
+		Scheme: scheme,
 		Host:   host + ":" + port,
 		Path:   fmt.Sprintf("/%d", db),
 	}
-	if password != "" {
-		u.User = url.UserPassword("", password)
+	switch {
+	case password != "":
+		u.User = url.UserPassword(username, password)
+	case username != "":
+		u.User = url.User(username)
 	}
 	return u.String()
 }

--- a/src/internal/renovate/redisSecret.go
+++ b/src/internal/renovate/redisSecret.go
@@ -16,12 +16,7 @@ import (
 const redisURLSecretName = "renovate-operator-job-redis-cache"
 
 func getRenovateCacheURL() string {
-	cfg := kvstore.ValkeyConfig{
-		URL:      config.GetValue("VALKEY_URL"),
-		Host:     config.GetValue("VALKEY_HOST"),
-		Port:     config.GetValue("VALKEY_PORT"),
-		Password: config.GetValue("VALKEY_PASSWORD"),
-	}
+	cfg := kvstore.ConfigFromEnv(config.GetValue)
 	return cfg.URLForUsage(kvstore.UsageRenovateCache)
 }
 

--- a/src/ui/session_store_test.go
+++ b/src/ui/session_store_test.go
@@ -526,14 +526,14 @@ func TestValkeyStore_EncryptionAtRest(t *testing.T) {
 // --- Factory and URL builder tests ---
 
 func TestBuildValkeyURL_EmptyHost(t *testing.T) {
-	result := kvstore.BuildValkeyURL("", "6379", "", 0)
+	result := kvstore.BuildValkeyURL("", "6379", "", "", false, 0)
 	if result != "" {
 		t.Errorf("Expected empty string for empty host, got %q", result)
 	}
 }
 
 func TestBuildValkeyURL_HostAndPort(t *testing.T) {
-	result := kvstore.BuildValkeyURL("valkey.example.com", "6380", "", 0)
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6380", "", "", false, 0)
 	expected := "redis://valkey.example.com:6380/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -541,7 +541,7 @@ func TestBuildValkeyURL_HostAndPort(t *testing.T) {
 }
 
 func TestBuildValkeyURL_DefaultPort(t *testing.T) {
-	result := kvstore.BuildValkeyURL("valkey.example.com", "", "", 0)
+	result := kvstore.BuildValkeyURL("valkey.example.com", "", "", "", false, 0)
 	expected := "redis://valkey.example.com:6379/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -549,7 +549,7 @@ func TestBuildValkeyURL_DefaultPort(t *testing.T) {
 }
 
 func TestBuildValkeyURL_WithPassword(t *testing.T) {
-	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "s3cret", 0)
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "", "s3cret", false, 0)
 	expected := "redis://:s3cret@valkey.example.com:6379/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -557,7 +557,7 @@ func TestBuildValkeyURL_WithPassword(t *testing.T) {
 }
 
 func TestBuildValkeyURL_PasswordWithSpecialChars(t *testing.T) {
-	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "p@ss:word/123", 0)
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "", "p@ss:word/123", false, 0)
 	expected := "redis://:p%40ss%3Aword%2F123@valkey.example.com:6379/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -565,7 +565,7 @@ func TestBuildValkeyURL_PasswordWithSpecialChars(t *testing.T) {
 }
 
 func TestBuildValkeyURL_PasswordWithSpace(t *testing.T) {
-	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "pass word", 0)
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "", "pass word", false, 0)
 	expected := "redis://:pass%20word@valkey.example.com:6379/0"
 	if result != expected {
 		t.Errorf("got %q, want %q", result, expected)
@@ -576,6 +576,68 @@ func TestBuildValkeyURL_PasswordWithSpace(t *testing.T) {
 	}
 	if pw, _ := u.User.Password(); pw != "pass word" {
 		t.Errorf("password round-trip: got %q, want %q", pw, "pass word")
+	}
+}
+
+func TestBuildValkeyURL_WithUsernameAndPassword(t *testing.T) {
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "renovate", "s3cret", false, 0)
+	expected := "redis://renovate:s3cret@valkey.example.com:6379/0"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+func TestBuildValkeyURL_UsernameWithoutPassword(t *testing.T) {
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "renovate", "", false, 0)
+	expected := "redis://renovate@valkey.example.com:6379/0"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+func TestBuildValkeyURL_UsernameWithSpecialChars(t *testing.T) {
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "user@domain", "s3cret", false, 0)
+	expected := "redis://user%40domain:s3cret@valkey.example.com:6379/0"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+func TestBuildValkeyURL_TLS(t *testing.T) {
+	result := kvstore.BuildValkeyURL("valkey.example.com", "6379", "renovate", "s3cret", true, 1)
+	expected := "rediss://renovate:s3cret@valkey.example.com:6379/1"
+	if result != expected {
+		t.Errorf("got %q, want %q", result, expected)
+	}
+}
+
+func TestURLForUsage_HostBased_UsernameAndTLS(t *testing.T) {
+	cfg := kvstore.ValkeyConfig{Host: "valkey.example.com", Port: "6379", Username: "renovate", Password: "s3cret", TLS: true}
+	if got := cfg.URLForUsage(kvstore.UsageRenovateCache); got != "rediss://renovate:s3cret@valkey.example.com:6379/1" {
+		t.Errorf("UsageRenovateCache: got %q", got)
+	}
+}
+
+func TestConfigFromEnv_ReadsAllKeys(t *testing.T) {
+	values := map[string]string{
+		"VALKEY_URL":      "",
+		"VALKEY_HOST":     "valkey.example.com",
+		"VALKEY_PORT":     "6380",
+		"VALKEY_USERNAME": "renovate",
+		"VALKEY_PASSWORD": "s3cret",
+		"VALKEY_TLS":      "true",
+	}
+	cfg := kvstore.ConfigFromEnv(func(key string) string { return values[key] })
+	expected := kvstore.ValkeyConfig{Host: "valkey.example.com", Port: "6380", Username: "renovate", Password: "s3cret", TLS: true}
+	if cfg != expected {
+		t.Errorf("got %+v, want %+v", cfg, expected)
+	}
+}
+
+func TestURLForUsage_URLTakesPrecedenceOverHostFields(t *testing.T) {
+	cfg := kvstore.ValkeyConfig{URL: "redis://valkey.example.com:6379/5", Host: "other.example.com", Username: "renovate", Password: "s3cret", TLS: true}
+	if got := cfg.URLForUsage(kvstore.UsageSessionStore); got != "redis://valkey.example.com:6379/5" {
+		t.Errorf("URL mode must ignore host-based fields: got %q", got)
 	}
 }
 


### PR DESCRIPTION
## What

  - Adds two optional environment variables to the host-based Valkey configuration:
    - `VALKEY_USERNAME` — connect as a specific ACL user; the built URL becomes `redis://user:pass@host:port/db`. A username without a password is emitted as `user@host` (for ACL users created with `nopass`).
    - `VALKEY_TLS` — when `true`, the built URL uses the `rediss://` scheme.
  - Both are ignored when `VALKEY_URL` is set, exactly matching the existing precedence contract for `VALKEY_HOST`/`VALKEY_PORT`/`VALKEY_PASSWORD`. 
  - Precedes the feature with a small refactor: `main.go` and `redisSecret.go` each built the same `ValkeyConfig` from env independently; this is now centralized in `kvstore.ConfigFromEnv`, with the lookup function injected so the `kvstore` package stays decoupled from the config singleton.
  - Fixes startup diagnostics: a failed Valkey connection previously exited with only `failed to initialize KV store` — the underlying error (TLS, auth, DNS, …) was discarded because `assert.Assert` doesn't print it. The error is now surfaced before exit.

  ## Why

  Managed Valkey offerings commonly deliver credentials as separate secret fields rather than a ready-made URL — for example the [Aiven operator](https://aiven.github.io/aiven-operator/)'s `ServiceUser` secret with `SERVICEUSER_HOST` / `SERVICEUSER_PORT` / `SERVICEUSER_USERNAME` / `SERVICEUSER_PASSWORD`. Without a username field, connecting as a non-default ACL user means templating a URL by hand outside the operator. With this change, the existing chart `extraEnv` mechanism covers it end to end — `docs/valkey.md` gains a complete example plus config-table entries for both new variables. No Helm template changes are needed.

  Verified against a real Aiven Valkey over GCP Private Service Connect (TLS with SNI routing, dedicated ACL user): operator startup, Valkey-backed session store, and the DB-offset cache URL in the forwarded job secret all work.

  **Known limitation (upstream, not this PR):** Renovate's own Redis client currently sends no TLS SNI, so executor jobs can't connect to SNI-routed `rediss://` endpoints (e.g. Aiven privatelink) even though the operator can — fix submitted as renovatebot/renovate#44469. Until that ships, `config.forwardCacheToJobs: false` is the workaround for such
  endpoints; sessions and log storage are unaffected.