### PR TITLE
feat(helm): Allow overriding the webhook baseUrl

### DIFF
--- a/charts/renovate-operator/templates/_helpers.tpl
+++ b/charts/renovate-operator/templates/_helpers.tpl
@@ -77,12 +77,16 @@ Returns the external base URL of the webhook server. When unifiedWebhookHost
 is true the UI ingress/route values are used; otherwise the webhook-specific
 values are used. Priority within each: route.hostnames[0] (https) →
 ingress.host (https when tls is set, http otherwise). webhook.baseUrlScheme
-overrides the detected scheme. Empty when not exposed.
+overrides the detected scheme. webhook.baseUrl overrides the value. Empty when
+not exposed.
 */}}
 {{- define "renovate-operator.webhookBaseUrl" -}}
 {{- $override := .Values.webhook.baseUrlScheme -}}
 {{- include "renovate-operator.validateScheme" (dict "scheme" $override "key" "webhook.baseUrlScheme") -}}
 {{- $v := .Values.webhook -}}
+{{- if .Values.webhook.baseUrl -}}
+{{- .Values.webhook.baseUrl -}}
+{{- else -}}
 {{- if .Values.webhook.unifiedWebhookHost -}}
 {{- $v = .Values -}}
 {{- end -}}
@@ -97,4 +101,5 @@ overrides the detected scheme. Empty when not exposed.
 {{- $url = printf "%s://%s" (default $scheme $override) $v.ingress.host -}}
 {{- end -}}
 {{- $url -}}
+{{- end -}}
 {{- end -}}

--- a/charts/renovate-operator/unittests/deployment/webhookBaseUrl.yaml
+++ b/charts/renovate-operator/unittests/deployment/webhookBaseUrl.yaml
@@ -128,3 +128,17 @@ tests:
       content:
         name: WEBHOOK_BASE_URL
         value: "http://webhook.example.com"
+
+- it: Allows baseUrl override
+  set:
+    webhook.enabled: true
+    webhook.baseUrl: "https://renovate.example.com"
+    route.enabled: true
+    route.hostnames:
+    - renovate.internal.com
+  asserts:
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: WEBHOOK_BASE_URL
+        value: "https://renovate.example.com"

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -134,6 +134,8 @@ webhook:
   # -- if set to true the ui host will be used for webhooks
   unifiedWebhookHost: false
   port: 8082
+  # -- optional: override the webhook base URL (WEBHOOK_BASE_URL), e.g. when the ingress or gateway is behind a proxy.
+  baseUrl: ""
   # -- optional: override the scheme (http or https) of the auto-derived webhook base URL (WEBHOOK_BASE_URL), e.g. when TLS terminates at an external load balancer or Gateway
   baseUrlScheme: ""
   ingress:


### PR DESCRIPTION
There are cases where the auto-derived value for the web hook route does not match the value that would be consumed by a public platform. Having an easy way to override the web hook's baseUrl solves this problem.