### PR TITLE
feat: adding public endpoint option

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -3220,6 +3220,12 @@ spec:
                     type: string
                   name:
                     type: string
+                  publicEndpoint:
+                    description: |-
+                      PublicEndpoint is the externally reachable URL for the provider, used only for UI links.
+                      When set, this overrides Endpoint for dashboard links while Endpoint continues to be
+                      used for Renovate API calls and cloning. Defaults to Endpoint when omitted.
+                    type: string
                 required:
                 - name
                 type: object

--- a/src/api/v1alpha1/renovatejob_types.go
+++ b/src/api/v1alpha1/renovatejob_types.go
@@ -158,6 +158,10 @@ This will be used to fill "RENOVATE_ENDPOINT" and "RENOVATE_PLATFORM" environmen
 type RenovateProvider struct {
 	Name     string `json:"name"`
 	Endpoint string `json:"endpoint,omitempty"`
+	// PublicEndpoint is the externally reachable URL for the provider, used only for UI links.
+	// When set, this overrides Endpoint for dashboard links while Endpoint continues to be
+	// used for Renovate API calls and cloning. Defaults to Endpoint when omitted.
+	PublicEndpoint string `json:"publicEndpoint,omitempty"`
 }
 
 // PRAction represents what happened to a PR in a Renovate run.

--- a/src/internal/utils/platformEndpoints.go
+++ b/src/internal/utils/platformEndpoints.go
@@ -22,6 +22,17 @@ func GetPlatformAndEndpoint(provider *api.RenovateProvider) (string, string) {
 	return provider.Name, endpoint
 }
 
+// GetPublicEndpoint returns the endpoint to use for public-facing UI links.
+// When provider.PublicEndpoint is set it is returned; otherwise the API endpoint
+// from GetPlatformAndEndpoint is used, preserving the existing behaviour.
+func GetPublicEndpoint(provider *api.RenovateProvider) string {
+	if provider != nil && provider.PublicEndpoint != "" {
+		return provider.PublicEndpoint
+	}
+	_, endpoint := GetPlatformAndEndpoint(provider)
+	return endpoint
+}
+
 // WebhookEndpointPath returns the operator's webhook server path for the given
 // platform.
 func WebhookEndpointPath(platform string) (string, error) {

--- a/src/internal/utils/platformEndpoints_test.go
+++ b/src/internal/utils/platformEndpoints_test.go
@@ -84,6 +84,53 @@ func TestGetPlatformAndEndpoint(t *testing.T) {
 	}
 }
 
+func TestGetPublicEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *api.RenovateProvider
+		expected string
+	}{
+		{
+			name: "publicEndpoint set — returned as-is",
+			provider: &api.RenovateProvider{
+				Name:           "gitea",
+				Endpoint:       "http://gitea.internal",
+				PublicEndpoint: "https://gitea.example.com",
+			},
+			expected: "https://gitea.example.com",
+		},
+		{
+			name: "publicEndpoint not set — falls back to endpoint",
+			provider: &api.RenovateProvider{
+				Name:     "gitea",
+				Endpoint: "http://gitea.internal",
+			},
+			expected: "http://gitea.internal",
+		},
+		{
+			name: "publicEndpoint not set, github default — falls back to default API endpoint",
+			provider: &api.RenovateProvider{
+				Name: "github",
+			},
+			expected: "https://api.github.com",
+		},
+		{
+			name:     "nil provider",
+			provider: nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint := GetPublicEndpoint(tt.provider)
+			if endpoint != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, endpoint)
+			}
+		})
+	}
+}
+
 func TestWebhookEndpointPath(t *testing.T) {
 	tests := []struct {
 		platform string

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -255,7 +255,8 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		platform, platformEndpoint := utils.GetPlatformAndEndpoint(renovateJob.Spec.Provider)
+		platform, _ := utils.GetPlatformAndEndpoint(renovateJob.Spec.Provider)
+		platformEndpoint := utils.GetPublicEndpoint(renovateJob.Spec.Provider)
 
 		projects := make([]crdmanager.RenovateProjectStatus, 0, len(renovateJob.Status.Projects))
 		for _, p := range renovateJob.Status.Projects {


### PR DESCRIPTION
This can be used if the user facing endpoint differs from the endpoint that renovate should be using

fixes #502