### PR TITLE
fix(s3): add missing trailing slash to pathname #542

### DIFF
--- a/docs/s3.md
+++ b/docs/s3.md
@@ -130,7 +130,7 @@ When `config.forwardS3CacheToJobs: true` and `s3.bucket` is set, executor and di
 | Variable                       | Value                                    |
 |--------------------------------|------------------------------------------|
 | `RENOVATE_REPOSITORY_CACHE`    | `enabled`                                |
-| `RENOVATE_REPOSITORY_CACHE_TYPE` | `s3://{bucket}/{cachePrefix}`          |
+| `RENOVATE_REPOSITORY_CACHE_TYPE` | `s3://{bucket}/{cachePrefix}/`         |
 | `AWS_REGION`                   | value of `s3.region`                     |
 | `RENOVATE_S3_ENDPOINT`         | value of `s3.endpoint` (if set)          |
 | `RENOVATE_S3_PATH_STYLE`       | `true` (if `s3.endpoint` is set)         |

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -256,7 +256,7 @@ func getDefaultEnvVars(job *api.RenovateJob) []v1.EnvVar {
 	}
 
 	if config.GetValue("S3_FORWARD_CACHE_TO_JOBS") == "true" && config.GetValue("S3_BUCKET") != "" {
-		s3CacheType := fmt.Sprintf("s3://%s/%s", config.GetValue("S3_BUCKET"), config.GetValue("S3_CACHE_PREFIX"))
+		s3CacheType := fmt.Sprintf("s3://%s/%s/", config.GetValue("S3_BUCKET"), config.GetValue("S3_CACHE_PREFIX"))
 		predefinedEnvVars = append(predefinedEnvVars,
 			v1.EnvVar{Name: "RENOVATE_REPOSITORY_CACHE", Value: "enabled"},
 			v1.EnvVar{Name: "RENOVATE_REPOSITORY_CACHE_TYPE", Value: s3CacheType},


### PR DESCRIPTION
Fix RepoCacheS3.getCacheFolder() - appending missing trailing slash to pathname