### PR TITLE
feat(chart): add optional ListenerSet support to Helm chart

### DIFF
--- a/charts/renovate-operator/templates/_helpers.tpl
+++ b/charts/renovate-operator/templates/_helpers.tpl
@@ -92,7 +92,19 @@ not exposed.
 {{- end -}}
 {{- $url := "" -}}
 {{- if and $v.route.enabled $v.route.hostnames -}}
-{{- $url = printf "%s://%s" (default "https" $override) (index $v.route.hostnames 0) -}}
+{{- $lsScheme := "https" -}}
+{{- if and $v.route.listenerset.enabled $v.route.listenerset.protocol -}}
+{{- if eq $v.route.listenerset.protocol "HTTP" -}}
+{{- $lsScheme = "http" -}}
+{{- end -}}
+{{- end -}}
+{{- $url = printf "%s://%s" (default $lsScheme $override) (index $v.route.hostnames 0) -}}
+{{- else if and $v.route.listenerset.enabled $v.route.listenerset.hostname -}}
+{{- $lsScheme := "https" -}}
+{{- if and $v.route.listenerset.protocol (eq $v.route.listenerset.protocol "HTTP") -}}
+{{- $lsScheme = "http" -}}
+{{- end -}}
+{{- $url = printf "%s://%s" (default $lsScheme $override) $v.route.listenerset.hostname -}}
 {{- else if and $v.ingress.enabled $v.ingress.host -}}
 {{- $scheme := "http" -}}
 {{- if $v.ingress.tls -}}

--- a/charts/renovate-operator/templates/httproute.yaml
+++ b/charts/renovate-operator/templates/httproute.yaml
@@ -13,10 +13,16 @@ metadata:
     {{- toYaml .Values.route.annotations | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.route.parentRefs }}
   parentRefs:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- if .Values.route.parentRefs }}
+    {{- toYaml .Values.route.parentRefs | nindent 4 }}
+    {{- else if .Values.route.listenerset.enabled }}
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ include "renovate-operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      sectionName: {{ .Values.route.listenerset.listenerName }}
+    {{- end }}
   {{- with .Values.route.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}

--- a/charts/renovate-operator/templates/listenerset.yaml
+++ b/charts/renovate-operator/templates/listenerset.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.route.listenerset.enabled }}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ListenerSet
+metadata:
+  name: {{ include "renovate-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.route.listenerset.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.route.listenerset.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRef:
+    {{- toYaml .Values.route.listenerset.parentRef | nindent 4 }}
+  listeners:
+    {{- if .Values.route.listenerset.listeners }}
+    {{- toYaml .Values.route.listenerset.listeners | nindent 4 }}
+    {{- else }}
+    - name: {{ .Values.route.listenerset.listenerName }}
+      port: {{ .Values.route.listenerset.port }}
+      protocol: {{ .Values.route.listenerset.protocol }}
+      hostname: {{ tpl (.Values.route.listenerset.hostname | default (index .Values.route.hostnames 0 | default "")) $ }}
+      {{- if .Values.route.listenerset.tls.enabled }}
+      tls:
+        mode: {{ .Values.route.listenerset.tls.mode }}
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: {{ .Values.route.listenerset.tls.secretName | default (printf "%s-tls" (include "renovate-operator.fullname" .)) }}
+      {{- end }}
+      allowedRoutes:
+        {{- toYaml .Values.route.listenerset.allowedRoutes | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/renovate-operator/templates/webhook-httproute.yaml
+++ b/charts/renovate-operator/templates/webhook-httproute.yaml
@@ -13,10 +13,16 @@ metadata:
     {{- toYaml .Values.webhook.route.annotations | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.webhook.route.parentRefs }}
   parentRefs:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- if .Values.webhook.route.parentRefs }}
+    {{- toYaml .Values.webhook.route.parentRefs | nindent 4 }}
+    {{- else if .Values.webhook.route.listenerset.enabled }}
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: {{ include "renovate-operator.fullname" . }}-webhook
+      namespace: {{ .Release.Namespace }}
+      sectionName: {{ .Values.webhook.route.listenerset.listenerName }}
+    {{- end }}
   {{- with .Values.webhook.route.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}

--- a/charts/renovate-operator/templates/webhook-listenerset.yaml
+++ b/charts/renovate-operator/templates/webhook-listenerset.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.webhook.route.listenerset.enabled .Values.webhook.enabled }}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: ListenerSet
+metadata:
+  name: {{ include "renovate-operator.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.webhook.route.listenerset.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.webhook.route.listenerset.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRef:
+    {{- toYaml .Values.webhook.route.listenerset.parentRef | nindent 4 }}
+  listeners:
+    {{- if .Values.webhook.route.listenerset.listeners }}
+    {{- toYaml .Values.webhook.route.listenerset.listeners | nindent 4 }}
+    {{- else }}
+    - name: {{ .Values.webhook.route.listenerset.listenerName }}
+      port: {{ .Values.webhook.route.listenerset.port }}
+      protocol: {{ .Values.webhook.route.listenerset.protocol }}
+      hostname: {{ tpl (.Values.webhook.route.listenerset.hostname | default (index .Values.webhook.route.hostnames 0 | default "")) $ }}
+      {{- if .Values.webhook.route.listenerset.tls.enabled }}
+      tls:
+        mode: {{ .Values.webhook.route.listenerset.tls.mode }}
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: {{ .Values.webhook.route.listenerset.tls.secretName | default (printf "%s-webhook-tls" (include "renovate-operator.fullname" .)) }}
+      {{- end }}
+      allowedRoutes:
+        {{- toYaml .Values.webhook.route.listenerset.allowedRoutes | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/renovate-operator/values.schema.json
+++ b/charts/renovate-operator/values.schema.json
@@ -101,7 +101,32 @@
         "group": { "type": "string" },
         "kind": { "type": "string" },
         "weight": { "type": "integer" },
-        "additionalRules": { "$ref": "#/$defs/objectList" }
+        "additionalRules": { "$ref": "#/$defs/objectList" },
+        "listenerset": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "labels": { "$ref": "#/$defs/stringMap" },
+            "annotations": { "$ref": "#/$defs/stringMap" },
+            "parentRef": { "type": "object" },
+            "listenerName": { "type": "string" },
+            "port": { "type": "integer" },
+            "protocol": { "type": "string", "enum": ["HTTP", "HTTPS", "TLS"] },
+            "hostname": { "type": "string" },
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "mode": { "type": "string", "enum": ["Terminate", "Passthrough"] },
+                "secretName": { "type": "string" }
+              }
+            },
+            "allowedRoutes": { "type": "object" },
+            "listeners": { "$ref": "#/$defs/objectList" }
+          }
+        }
       }
     }
   },

--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -128,6 +128,37 @@ route:
     # - timeouts:
     #     request: 30s
     #     backendRequest: 30s
+  # -- ListenerSet for the operator web UI (Gateway API v1.3+)
+  listenerset:
+    # -- whether to enable the ListenerSet
+    enabled: false
+    # -- labels to place on the ListenerSet
+    labels: {}
+    # -- annotations to place on the ListenerSet
+    annotations: {}
+    # -- parentRef pointing to the parent Gateway (required when enabled)
+    parentRef: {}
+    # -- name of the listener entry
+    listenerName: https
+    # -- port the listener should bind to
+    port: 443
+    # -- protocol for the listener (HTTP, HTTPS, TLS); used to derive the auth-redirect URL scheme
+    protocol: HTTPS
+    # -- hostname for the listener; defaults to the first entry in route.hostnames
+    hostname: ""
+    tls:
+      # -- whether to configure TLS on the listener
+      enabled: false
+      # -- TLS termination mode (Terminate or Passthrough)
+      mode: Terminate
+      # -- name of the TLS secret; defaults to <fullname>-tls
+      secretName: ""
+    # -- allowedRoutes configuration for the listener
+    allowedRoutes:
+      namespaces:
+        from: Same
+    # -- optional: fully custom listeners list; overrides all listener defaults above
+    listeners: []
 
 webhook:
   enabled: false
@@ -177,6 +208,37 @@ webhook:
       # - timeouts:
       #     request: 30s
       #     backendRequest: 30s
+    # -- ListenerSet for the webhook server (Gateway API v1.3+)
+    listenerset:
+      # -- whether to enable the ListenerSet
+      enabled: false
+      # -- labels to place on the ListenerSet
+      labels: {}
+      # -- annotations to place on the ListenerSet
+      annotations: {}
+      # -- parentRef pointing to the parent Gateway (required when enabled)
+      parentRef: {}
+      # -- name of the listener entry
+      listenerName: https
+      # -- port the listener should bind to
+      port: 443
+      # -- protocol for the listener (HTTP, HTTPS, TLS)
+      protocol: HTTPS
+      # -- hostname for the listener; defaults to the first entry in webhook.route.hostnames
+      hostname: ""
+      tls:
+        # -- whether to configure TLS on the listener
+        enabled: false
+        # -- TLS termination mode (Terminate or Passthrough)
+        mode: Terminate
+        # -- name of the TLS secret; defaults to <fullname>-webhook-tls
+        secretName: ""
+      # -- allowedRoutes configuration for the listener
+      allowedRoutes:
+        namespaces:
+          from: Same
+      # -- optional: fully custom listeners list; overrides all listener defaults above
+      listeners: []
 
 auth:
   # -- comma-separated list of default groups for RenovateJobs without explicit allowedGroups (empty = all authenticated users can see jobs without explicit group restrictions)


### PR DESCRIPTION
# PR: feat(chart): add optional ListenerSet support to Helm chart

Summary
- Adds optional Gateway API `ListenerSet` support via Helm values (`route.listenerset.enabled`).
- When enabled, chart renders `ListenerSet` resources for the operator and webhook.

Changes
- Added: `charts/renovate-operator/templates/listenerset.yaml`
- Added: `charts/renovate-operator/templates/webhook-listenerset.yaml`
- Modified: `charts/renovate-operator/templates/httproute.yaml`
- Modified: `charts/renovate-operator/templates/webhook-httproute.yaml`
- Modified: `charts/renovate-operator/templates/_helpers.tpl`
- Modified: `charts/renovate-operator/values.yaml`
- Modified: `charts/renovate-operator/values.schema.json`

Testing performed
- Ran: `helm template renovate-operator charts/renovate-operator --values charts/renovate-operator/values.yaml --namespace renovate-operator --debug`.
- Verified: `ListenerSet` is rendered when `route.listenerset.enabled=true` and absent when `route.listenerset.enabled=false`.

