### PR TITLE
fix(ui): add Bitbucket Server pull request links

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -197,10 +197,26 @@
           return (endpoint || 'https://gitlab.com').replace(/\/api\/v\d+\/?$/, '').replace(/\/$/, '');
         } else if (platform === 'bitbucket') {
           return 'https://bitbucket.org';
+        } else if (platform === 'bitbucket-server') {
+          return endpoint
+            ? endpoint.replace(/\/rest\/api\/(?:latest|\d+(?:\.\d+)*)\/?$/, '').replace(/\/$/, '')
+            : null;
         } else if (platform === 'gitea' || platform === 'forgejo') {
           return endpoint ? endpoint.replace(/\/api\/v\d+\/?$/, '').replace(/\/$/, '') : null;
         }
         return null;
+      };
+
+      const _bitbucketServerRepoUrl = (base, projectName) => {
+        const separator = projectName ? projectName.indexOf('/') : -1;
+        if (separator <= 0 || separator === projectName.length - 1) return null;
+
+        const projectKey = projectName.slice(0, separator);
+        const repoSlug = projectName.slice(separator + 1);
+        if (projectKey.startsWith('~')) {
+          return `${base}/users/${encodeURIComponent(projectKey.slice(1))}/repos/${encodeURIComponent(repoSlug)}`;
+        }
+        return `${base}/projects/${encodeURIComponent(projectKey)}/repos/${encodeURIComponent(repoSlug)}`;
       };
 
       const buildPRUrl = (platform, endpoint, projectName) => {
@@ -209,6 +225,10 @@
         if (!platform || platform === 'github') return `${base}/${projectName}/pulls`;
         if (platform === 'gitlab') return `${base}/${projectName}/-/merge_requests`;
         if (platform === 'bitbucket') return `${base}/${projectName}/pull-requests`;
+        if (platform === 'bitbucket-server') {
+          const repoUrl = _bitbucketServerRepoUrl(base, projectName);
+          return repoUrl ? `${repoUrl}/pull-requests` : null;
+        }
         if (platform === 'gitea' || platform === 'forgejo') return `${base}/${projectName}/pulls`;
         return null;
       };
@@ -220,6 +240,10 @@
         if (!platform || platform === 'github') return `${base}/${projectName}/pull/${prNumber}`;
         if (platform === 'gitlab') return `${base}/${projectName}/-/merge_requests/${prNumber}`;
         if (platform === 'bitbucket') return `${base}/${projectName}/pull-requests/${prNumber}`;
+        if (platform === 'bitbucket-server') {
+          const repoUrl = _bitbucketServerRepoUrl(base, projectName);
+          return repoUrl ? `${repoUrl}/pull-requests/${prNumber}` : null;
+        }
         if (platform === 'gitea' || platform === 'forgejo') return `${base}/${projectName}/pulls/${prNumber}`;
         return null;
       };


### PR DESCRIPTION
## What changed

- recognize Renovate's `bitbucket-server` platform in the UI URL builder
- preserve Bitbucket Server/Data Center context paths while removing REST API suffixes
- build pull request list and individual pull request links for project repositories
- support personal repositories in the `~user/repository` format

## Why

Bitbucket Server/Data Center jobs currently show no links because the UI only handles the `bitbucket` platform used by Bitbucket Cloud.

Closes #569

## Validation

- `go test ./...`
- `git diff --check`
- manually verified project and personal-repository URLs with base, `/rest/api/1.0`, and `/rest/api/latest` endpoints
- manually verified PR list and individual PR links using an isolated mocked `/api/v1/renovatejobs` response
