### PR TITLE
fix(auth): match the OIDC group filter case-insensitively

### DIFF
--- a/charts/renovate-operator/values.yaml
+++ b/charts/renovate-operator/values.yaml
@@ -280,9 +280,11 @@ auth:
     logoutUrl: ""
     # -- optional: only accept groups with this prefix (e.g., "renovate-")
     # -- Leave empty to accept all groups. High-security environments should set this.
+    # -- Matched case-insensitively, since group names are normalized to lowercase.
     allowedGroupPrefix: ""
     # -- optional: only accept groups matching this regex pattern (e.g., "^(team-|platform-).*")
     # -- Leave empty to accept all groups. Can be combined with allowedGroupPrefix.
+    # -- Matched case-insensitively, since group names are normalized to lowercase.
     allowedGroupPattern: ""
     # -- optional: name of the OIDC claim that carries group memberships (defaults to "groups")
     # -- Set this if your provider emits groups under a namespaced claim, e.g. "https://example.com/groups".

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -391,6 +391,10 @@ This is useful when your identity provider returns many groups but you only want
 to use certain ones for authorization. An OIDC provider that emits no groups at
 all leaves every job hidden.
 
+Both are matched case-insensitively, because group names are normalized to lowercase before filtering, so `allowedGroupPrefix: "Renovate-"` and `allowedGroupPattern: "^Team-Renovate$"` work the same as their lowercase spellings. The pattern is compiled with the case-insensitive flag rather than lowercased, so escapes keep their meaning: `\D`, `\S`, `\W`, `\B` and `\p{Lu}` are not rewritten.
+
+When a filter is configured and a user has no group left after it, the login is refused, so watch for `WARNING: All user groups filtered out by validation` in the operator log. It reports the count after each of the three layers, which distinguishes a provider sending no groups (`original_count: 0`) from a policy that rejects them all (`after_policy: 0`).
+
 ### Deprecated: allowedGroups
 
 `spec.allowedGroups` and `auth.defaultAllowedGroups` still work and are treated

--- a/src/ui/group_validation.go
+++ b/src/ui/group_validation.go
@@ -112,14 +112,54 @@ func normalizeAndValidateGroups(groups []string, logger logr.Logger) []string {
 }
 
 // GroupFilterConfig defines optional filtering rules for LAYER 3 validation.
+//
+// Both fields are matched against the LAYER 2 output, which is lowercased, so
+// they must be case-insensitive themselves. Build them with
+// NewGroupFilterConfig rather than by hand, otherwise a configuration value
+// like "^Team-Renovate$" matches nothing at all.
 type GroupFilterConfig struct {
 	// AllowedPrefix filters groups to only those starting with this prefix.
 	// Example: "renovate-" only allows "renovate-team-a", "renovate-admin"
+	// Must be lowercase; NewGroupFilterConfig takes care of that.
 	AllowedPrefix string
 
 	// AllowedPattern is a regex pattern that groups must match.
 	// Example: "^(team-|platform-|admin-).*" allows team-*, platform-*, admin-*
+	// Must be case-insensitive; NewGroupFilterConfig takes care of that.
 	AllowedPattern *regexp.Regexp
+}
+
+// NewGroupFilterConfig builds the LAYER 3 policy from its configured strings.
+//
+// LAYER 2 lowercases every group before LAYER 3 sees it, so a policy carrying
+// any uppercase character can never match and the user is left with no groups.
+// The same reasoning already applies to the other two group inputs: the
+// operator lowercases DEFAULT_ALLOWED_GROUPS as it parses it, and
+// filterRenovateJobsByGroups runs a RenovateJob's spec.allowedGroups through
+// normalizeGroups. This makes the prefix and pattern consistent with those.
+//
+// The prefix is a literal, so it is simply lowercased. The pattern is compiled
+// case-insensitively instead, because lowercasing a regex source rewrites the
+// negated classes into their opposites (\D -> \d, \S -> \s, \W -> \w,
+// \B -> \b), turns Unicode classes such as \p{Lu} into unknown ones and makes
+// the ungreedy flag (?U) fail to compile. A leading (?i) applies to the whole
+// expression, including every branch of a top-level alternation.
+func NewGroupFilterConfig(allowedPrefix, allowedPattern string) (GroupFilterConfig, error) {
+	config := GroupFilterConfig{
+		AllowedPrefix: strings.ToLower(strings.TrimSpace(allowedPrefix)),
+	}
+
+	if allowedPattern == "" {
+		return config, nil
+	}
+
+	pattern, err := regexp.Compile("(?i)" + allowedPattern)
+	if err != nil {
+		return GroupFilterConfig{}, fmt.Errorf("invalid group pattern regex %q: %w", allowedPattern, err)
+	}
+	config.AllowedPattern = pattern
+
+	return config, nil
 }
 
 // filterGroupsByPolicy performs LAYER 3 validation: policy-based filtering.

--- a/src/ui/group_validation_test.go
+++ b/src/ui/group_validation_test.go
@@ -333,3 +333,103 @@ func TestRegexCompiledOnce(t *testing.T) {
 		t.Error("Valid group names should pass validation")
 	}
 }
+
+// TestNewGroupFilterConfig covers the case handling that LAYER 2 forces on the
+// policy: groups reach LAYER 3 lowercased, so a policy carrying uppercase has
+// to match anyway or the user ends up with no groups at all.
+func TestNewGroupFilterConfig(t *testing.T) {
+	logger := logr.Discard()
+
+	tests := []struct {
+		name    string
+		prefix  string
+		pattern string
+		groups  []string
+		want    []string
+	}{
+		{
+			name:   "mixed case prefix still matches",
+			prefix: "Renovate-",
+			groups: []string{"renovate-team-a", "team-b"},
+			want:   []string{"renovate-team-a"},
+		},
+		{
+			name:    "mixed case pattern still matches",
+			pattern: `^Team-Renovate$`,
+			groups:  []string{"team-renovate", "team-other"},
+			want:    []string{"team-renovate"},
+		},
+		{
+			name:    "case insensitivity reaches every branch of an alternation",
+			pattern: `^(Team-|Platform-).*`,
+			groups:  []string{"team-a", "platform-b", "other-c"},
+			want:    []string{"team-a", "platform-b"},
+		},
+		{
+			name:   "prefix is trimmed",
+			prefix: "  renovate-  ",
+			groups: []string{"renovate-team-a", "team-b"},
+			want:   []string{"renovate-team-a"},
+		},
+		{
+			name:    "lowercase config keeps behaving as before",
+			prefix:  "renovate-",
+			pattern: `^renovate-team-.*`,
+			groups:  []string{"renovate-team-a", "renovate-admin", "team-b"},
+			want:    []string{"renovate-team-a"},
+		},
+		{
+			name:   "empty policy passes everything through",
+			groups: []string{"team-a", "platform-b"},
+			want:   []string{"team-a", "platform-b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := NewGroupFilterConfig(tt.prefix, tt.pattern)
+			if err != nil {
+				t.Fatalf("NewGroupFilterConfig() unexpected error: %v", err)
+			}
+
+			result := filterGroupsByPolicy(tt.groups, config, logger)
+			if len(result) != len(tt.want) {
+				t.Fatalf("filterGroupsByPolicy() = %v, want %v", result, tt.want)
+			}
+			for i := range result {
+				if result[i] != tt.want[i] {
+					t.Errorf("filterGroupsByPolicy()[%d] = %s, want %s", i, result[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestNewGroupFilterConfigKeepsPatternSemantics guards the reason the pattern is
+// compiled case-insensitively rather than lowercased: lowercasing the source
+// would turn every negated class into its opposite, silently inverting which
+// groups a deployment accepts.
+func TestNewGroupFilterConfigKeepsPatternSemantics(t *testing.T) {
+	config, err := NewGroupFilterConfig("", `^\D+$`)
+	if err != nil {
+		t.Fatalf("NewGroupFilterConfig() unexpected error: %v", err)
+	}
+
+	if !config.AllowedPattern.MatchString("team-a") {
+		t.Error(`\D should still match a non-digit group name`)
+	}
+	if config.AllowedPattern.MatchString("12345") {
+		t.Error(`\D must not have been rewritten into \d`)
+	}
+
+	// (?U) is a valid Go flag whose lowercase form does not compile at all.
+	if _, err := NewGroupFilterConfig("", `(?U)team-.+`); err != nil {
+		t.Errorf("NewGroupFilterConfig() should accept the (?U) flag, got %v", err)
+	}
+}
+
+func TestNewGroupFilterConfigRejectsInvalidPattern(t *testing.T) {
+	if _, err := NewGroupFilterConfig("", `^(team-`); err == nil {
+		t.Error("NewGroupFilterConfig() should reject an invalid regex")
+	}
+}

--- a/src/ui/oidc.go
+++ b/src/ui/oidc.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"regexp"
 	"renovate-operator/internal/telemetry"
 	"slices"
 	"strings"
@@ -133,15 +132,10 @@ func NewOIDCAuth(ctx context.Context, cfg OIDCConfig, encryptionKey [32]byte, lo
 		return nil, err
 	}
 
-	// Parse group filter pattern if provided
-	var groupFilterConfig GroupFilterConfig
-	groupFilterConfig.AllowedPrefix = cfg.AllowedGroupPrefix
-	if cfg.AllowedGroupPattern != "" {
-		pattern, err := regexp.Compile(cfg.AllowedGroupPattern)
-		if err != nil {
-			return nil, fmt.Errorf("invalid group pattern regex: %w", err)
-		}
-		groupFilterConfig.AllowedPattern = pattern
+	// Parse the group filter policy if provided
+	groupFilterConfig, err := NewGroupFilterConfig(cfg.AllowedGroupPrefix, cfg.AllowedGroupPattern)
+	if err != nil {
+		return nil, err
 	}
 
 	if cfg.FetchUserInfoGroups {


### PR DESCRIPTION
### Problem

`ValidateAndNormalizeGroups` lowercases every group in layer 2, then layer 3 applies `allowedGroupPrefix` / `allowedGroupPattern` to that lowercased output. So any policy holding an uppercase character matches nothing:

```yaml
auth:
  oidc:
    allowedGroupPattern: "^Team-Renovate$"   # never matches "team-renovate"
```

That used to be invisible, because `HandleCallback` only warned when a configured filter left the user with no groups, and the guard was `len(claims.Groups) > 0 && len(validatedGroups) == 0`, so it didn't even fire when the claim was empty. `460867a` (first released in 5.3.0) replaced it with `isGroupFilterDenied` plus a redirect to `/auth/unauthorized`, which is the right call, but it makes the case mismatch fatal: a deployment that had carried a mixed-case filter for months, believing it was enforced, loses UI access for **every** account on upgrade.

I hit this on a self-hosted install going from 5.0.1 to current main. The filter had never matched anything, so nobody noticed until it started denying. The operator log tells the story once you know to look for it:

```
"msg":"WARNING: All user groups filtered out by validation",
"original_count":7,"after_sanitization":7,"after_normalization":7,"after_policy":0
```

### Why fix it in the config rather than the docs

The codebase already treats "config-supplied group values are lowercased" as the rule, in both other places a group name arrives from configuration:

* `DEFAULT_ALLOWED_GROUPS` is lowercased as it is parsed (`main.go`).
* `RenovateJob.spec.allowedGroups` goes through `normalizeGroups` in `filterRenovateJobsByGroups`.

The OIDC prefix and pattern were the only two inputs left out, so this is an inconsistency rather than a new behaviour.

### What this does

`NewGroupFilterConfig(prefix, pattern)` now owns the conversion and `NewOIDCAuth` calls it:

* the prefix is a literal, so it is trimmed and lowercased, matching what `main.go` does for `DEFAULT_ALLOWED_GROUPS`;
* the pattern is compiled with the case-insensitive flag, **not** lowercased.

That second point is the reason this is not a one-line `strings.ToLower`. Lowercasing a regex source rewrites the negated classes into their opposites, so `^\D+$` (no digits) silently becomes `^\d+$` (only digits), inverting which groups an install accepts. It also breaks `\p{Lu}` and makes the ungreedy flag `(?U)` fail to compile outright:

```
regexp.Compile(strings.ToLower(`(?U)a+`))
  -> error parsing regexp: invalid or unsupported Perl syntax: `(?u`
```

A leading `(?i)` avoids all of that and, verified in the tests, applies to every branch of a top-level alternation, so `^(Team-|Platform-).*` matches both `team-a` and `platform-b`.

### Compatibility

Lowercase policies are unaffected: the inputs are already lowercase, so the case-insensitive flag changes nothing for them. Nothing that previously worked can break, since a case-sensitive distinction between `Team-A` and `team-a` was already impossible: layer 2 lowercases and deduplicates them into one entry before any filtering.

### Tests

`TestNewGroupFilterConfig` covers mixed-case prefix and pattern, prefix trimming, alternation, and the unchanged lowercase behaviour. `TestNewGroupFilterConfigKeepsPatternSemantics` pins the `\D`-is-not-`\d` guarantee and that `(?U)` still compiles, so a future "just lowercase it" simplification fails the suite. Plus an invalid-regex error case.

`just build`, `just test-unit` (910 tests) and `just test-helm` (65) pass. Docs and the chart values comments now state that both are matched case-insensitively, and point at the `after_policy` counter for diagnosing an over-strict filter.

### Not included

An alternative would be to match layer 3 against the original group names instead, so a pattern behaves exactly as written. That preserves author intent more literally but changes what the three-layer pipeline hands downstream, so I kept to the smaller change. Happy to switch if you prefer that shape.
