### PR TITLE
feat(ui): enforce repository-level access

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -795,7 +795,8 @@ func main() {
 	warnAccessRulesEnforceable(ctrl.Log.WithName("auth"), auth.provider, auth.accessDefaults)
 
 	// UI and webhook servers run on all replicas
-	uiServer := ui.NewServer(jobMgr, discovery, cronManager, ctrl.Log.WithName("ui-server"), health, Version, auth.provider, auth.accessDefaults)
+	repoCache := ui.NewMemoryRepoCache()
+	uiServer := ui.NewServer(jobMgr, discovery, cronManager, ctrl.Log.WithName("ui-server"), health, Version, auth.provider, auth.accessDefaults, repoCache)
 
 	if config.GetValue("WEBHOOK_SERVER_ENABLED") != "false" {
 		webhookServer := webhook.NewWebookServer(jobMgr, ctrl.Log.WithName("webhook"))

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1380,6 +1380,13 @@
 
         if (sortConfig.key) {
           sortedProjects.sort((a, b) => {
+            // Always sort read-only repos to the bottom
+            const aReadOnly = a.canWrite === false;
+            const bReadOnly = b.canWrite === false;
+            if (aReadOnly !== bReadOnly) {
+              return aReadOnly ? 1 : -1;
+            }
+
             let aValue = a[sortConfig.key];
             let bValue = b[sortConfig.key];
 
@@ -1852,6 +1859,9 @@
             return next;
           });
         };
+        const writableProjects = useMemo(() => sortedProjects.filter(p => p.canWrite !== false), [sortedProjects]);
+        const readOnlyProjects = useMemo(() => sortedProjects.filter(p => p.canWrite === false), [sortedProjects]);
+        const [showReadOnly, setShowReadOnly] = useState(false);
         const [showOptions, setShowOptions] = useState(false);
         const [optionsPos, setOptionsPos] = useState({ top: 0, right: 0 });
         const optionsBtnRef = useRef(null);
@@ -2261,8 +2271,9 @@
                       </tr>
                     </thead>
                     <tbody className="bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700">
-                      {sortedProjects.length > 0 ? (
-                        sortedProjects.map((project) => {
+                      {job.projects && job.projects.length > 0 ? (
+                        <>
+                        {writableProjects.map((project) => {
                           const ProjectRow = () => {
                             const { containerRef, tooltipProps, tooltipElement } = useTooltip(project);
 
@@ -2402,7 +2413,106 @@
                     };
 
                     return <ProjectRow key={project.name} />;
-                  })
+                  })}
+                  {readOnlyProjects.length > 0 && (
+                    <>
+                      <tr
+                        className="bg-gray-50 dark:bg-slate-900/50 cursor-pointer hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors"
+                        onClick={() => setShowReadOnly(!showReadOnly)}
+                        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setShowReadOnly(!showReadOnly); } }}
+                        role="button"
+                        tabIndex={0}
+                        aria-expanded={showReadOnly}
+                        aria-label={`${showReadOnly ? "Collapse" : "Expand"} ${readOnlyProjects.length} read-only ${readOnlyProjects.length === 1 ? "repo" : "repos"}`}
+                      >
+                        <td colSpan="5" className="px-6 py-2.5">
+                          <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-slate-400">
+                            <svg
+                              className={`w-3.5 h-3.5 transition-transform duration-200 ${showReadOnly ? "rotate-90" : ""}`}
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                              aria-hidden="true"
+                            >
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                            </svg>
+                            <span className="font-medium">
+                              {readOnlyProjects.length} read-only {readOnlyProjects.length === 1 ? "repo" : "repos"}
+                            </span>
+                          </div>
+                        </td>
+                      </tr>
+                      {showReadOnly && readOnlyProjects.map((project) => {
+                        const ReadOnlyRow = () => {
+                          const { containerRef, tooltipProps, tooltipElement } = useTooltip(project);
+                          return (
+                            <>
+                              <tr
+                                ref={containerRef}
+                                {...tooltipProps}
+                                className="hover:bg-gray-50 dark:hover:bg-slate-700/50 transition-colors opacity-50"
+                              >
+                                <td className="px-6 py-4">
+                                  <div className="flex items-center gap-2">
+                                    <span className="font-medium text-gray-900 dark:text-slate-100">{project.name}</span>
+                                    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-slate-700 text-gray-500 dark:text-slate-400">
+                                      read-only
+                                    </span>
+                                    {project.renovateResultStatus && project.renovateResultStatus !== "done" && (
+                                      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400 ring-1 ring-amber-300 dark:ring-amber-700">
+                                        {project.renovateResultStatus}
+                                      </span>
+                                    )}
+                                  </div>
+                                </td>
+                                <td className="px-6 py-4">
+                                  <span className={getBadgeClass(project.status)}>{project.status || "-"}</span>
+                                </td>
+                                <td className="px-6 py-4">
+                                  <span className="text-sm text-gray-600 dark:text-slate-300">
+                                    {project.lastTransition ? formatTimeAgo(project.lastTransition) : "Never"}
+                                  </span>
+                                </td>
+                                <td className="px-6 py-4" data-no-tooltip="true">
+                                  <div className="flex items-center gap-2">
+                                    {(() => {
+                                      const dashboardUrl = buildDashboardUrl(job.platform, job.platformEndpoint, project.name);
+                                      return dashboardUrl ? (
+                                        <a href={dashboardUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm text-primary hover:text-primary-hover font-medium" aria-label={`View Dependency Dashboard for ${project.name}`}>
+                                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>
+                                        </a>
+                                      ) : null;
+                                    })()}
+                                    {(() => {
+                                      const prUrl = buildPRUrl(job.platform, job.platformEndpoint, project.name);
+                                      return prUrl ? (
+                                        <a href={prUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm text-primary hover:text-primary-hover font-medium" aria-label={`View open PRs/MRs for ${project.name}`}>
+                                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                                        </a>
+                                      ) : null;
+                                    })()}
+                                  </div>
+                                </td>
+                                <td className="px-6 py-4 text-right" data-no-tooltip="true">
+                                  <a
+                                    href={`/api/v1/logs?renovate=${encodeURIComponent(job.name)}&namespace=${encodeURIComponent(job.namespace)}&project=${encodeURIComponent(project.name)}`}
+                                    target="_blank"
+                                    className="bg-gray-600 hover:bg-gray-700 text-white px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all inline-block min-w-[60px] text-center"
+                                    aria-label={`View logs for ${project.name}`}
+                                  >
+                                    Logs
+                                  </a>
+                                </td>
+                              </tr>
+                              {tooltipElement}
+                            </>
+                          );
+                        };
+                        return <ReadOnlyRow key={project.name} />;
+                      })}
+                    </>
+                  )}
+                  </>
                       ) : (
                         <tr>
                           <td
@@ -2420,8 +2530,9 @@
                 </div>
 
                 <div className="lg:hidden bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700">
-                  {sortedProjects.length > 0 ? (
-                    sortedProjects.map((project) => {
+                  {job.projects && job.projects.length > 0 ? (
+                    <>
+                    {writableProjects.map((project) => {
                       const ProjectCard = () => {
                         const { containerRef, tooltipProps, tooltipElement } = useTooltip(project);
 
@@ -2605,7 +2716,93 @@
                 };
 
                 return <ProjectCard key={project.name} />;
-              })
+              })}
+              {readOnlyProjects.length > 0 && (
+                <>
+                  <div
+                    className="p-4 bg-gray-50 dark:bg-slate-900/50 cursor-pointer hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors"
+                    onClick={() => setShowReadOnly(!showReadOnly)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setShowReadOnly(!showReadOnly); } }}
+                    role="button"
+                    tabIndex={0}
+                    aria-expanded={showReadOnly}
+                    aria-label={`${showReadOnly ? "Collapse" : "Expand"} ${readOnlyProjects.length} read-only ${readOnlyProjects.length === 1 ? "repo" : "repos"}`}
+                  >
+                    <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-slate-400">
+                      <svg
+                        className={`w-3.5 h-3.5 transition-transform duration-200 ${showReadOnly ? "rotate-90" : ""}`}
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                      <span className="font-medium">
+                        {readOnlyProjects.length} read-only {readOnlyProjects.length === 1 ? "repo" : "repos"}
+                      </span>
+                    </div>
+                  </div>
+                  {showReadOnly && readOnlyProjects.map((project) => {
+                    const ReadOnlyCard = () => {
+                      const { containerRef, tooltipProps, tooltipElement } = useTooltip(project);
+                      return (
+                        <>
+                          <div
+                            ref={containerRef}
+                            {...tooltipProps}
+                            className={`p-4 space-y-3 opacity-50 ${project.renovateResultStatus && project.renovateResultStatus !== "done" ? "bg-amber-50/60 dark:bg-amber-900/10 border-l-4 border-amber-400 dark:border-amber-500" : ""}`}
+                          >
+                            <div className="flex items-start justify-between">
+                              <div>
+                                <div className="flex items-center gap-2">
+                                  <p className="font-medium text-gray-900 dark:text-slate-100">{project.name}</p>
+                                  <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 dark:bg-slate-700 text-gray-500 dark:text-slate-400">
+                                    read-only
+                                  </span>
+                                </div>
+                                <p className="text-xs text-gray-500 dark:text-slate-400 mt-1">
+                                  Last run: {project.lastTransition ? formatTimeAgo(project.lastTransition) : "Never"}
+                                </p>
+                              </div>
+                              <span className={`ml-2 ${getBadgeClass(project.status)}`}>{project.status || "-"}</span>
+                            </div>
+                            <div className="flex gap-2 flex-wrap" data-no-tooltip="true">
+                              <a
+                                href={`/api/v1/logs?renovate=${encodeURIComponent(job.name)}&namespace=${encodeURIComponent(job.namespace)}&project=${encodeURIComponent(project.name)}`}
+                                target="_blank"
+                                className="bg-gray-600 hover:bg-gray-700 text-white px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all inline-block w-[70px] text-center"
+                                aria-label={`View logs for ${project.name}`}
+                              >
+                                Logs
+                              </a>
+                              {(() => {
+                                const dashboardUrl = buildDashboardUrl(job.platform, job.platformEndpoint, project.name);
+                                return dashboardUrl ? (
+                                  <a href={dashboardUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 text-gray-700 dark:text-slate-200 px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all" aria-label={`View Dependency Dashboard for ${project.name}`}>
+                                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" /></svg>
+                                  </a>
+                                ) : null;
+                              })()}
+                              {(() => {
+                                const prUrl = buildPRUrl(job.platform, job.platformEndpoint, project.name);
+                                return prUrl ? (
+                                  <a href={prUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 bg-gray-100 dark:bg-slate-700 hover:bg-gray-200 dark:hover:bg-slate-600 text-gray-700 dark:text-slate-200 px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all" aria-label={`View open PRs/MRs for ${project.name}`}>
+                                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
+                                  </a>
+                                ) : null;
+                              })()}
+                            </div>
+                          </div>
+                          {tooltipElement}
+                        </>
+                      );
+                    };
+                    return <ReadOnlyCard key={project.name} />;
+                  })}
+                </>
+              )}
+              </>
                   ) : (
                     <div className="p-8 text-center text-gray-500 dark:text-slate-400">
                       {hasActiveFilters

--- a/src/ui/auth.go
+++ b/src/ui/auth.go
@@ -28,7 +28,7 @@ const (
 
 // currentSessionVersion is bumped whenever a field access control reads is added
 // to sessionData. Sessions minted by an older operator are then discarded.
-const currentSessionVersion = 1
+const currentSessionVersion = 2
 
 type contextKey string
 

--- a/src/ui/oidc.go
+++ b/src/ui/oidc.go
@@ -314,6 +314,7 @@ func (o *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 	completeURL, err := o.buildCompleteURL(r.Context(), claims.Email, claims.Name, func(s *sessionData) {
 		s.Groups = validatedGroups
+		s.AccessToken = oauth2Token.AccessToken
 		s.Username = claims.PreferredUsername
 		s.EmailVerified = emailVerified
 	})

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -290,11 +290,11 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		platform, _ := utils.GetPlatformAndEndpoint(renovateJob.Spec.Provider)
+		platform, apiEndpoint := utils.GetPlatformAndEndpoint(renovateJob.Spec.Provider)
 		platformEndpoint := utils.GetPublicEndpoint(renovateJob.Spec.Provider)
 
 		// Resolve user's repo permissions for this job's platform
-		userRepos := getUserRepos(r.Context(), session, platform, platformEndpoint, s.repoCache, s.logger)
+		userRepos := getUserRepos(r.Context(), session, platform, apiEndpoint, s.repoCache, s.logger)
 
 		crdProjects := make([]crdmanager.RenovateProjectStatus, 0, len(renovateJob.Status.Projects))
 		for _, p := range renovateJob.Status.Projects {
@@ -312,7 +312,7 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Filter projects by user's repo access on the git platform
-		crdProjects = filterProjectsByAccess(r.Context(), session, platform, platformEndpoint, crdProjects, s.repoCache, s.logger)
+		crdProjects = filterProjectsByAccess(r.Context(), session, platform, apiEndpoint, crdProjects, s.repoCache, s.logger)
 
 		// Build UI project list with write permission annotations
 		projects := make([]UIProjectStatus, 0, len(crdProjects))

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -21,15 +21,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// UIProjectStatus extends the crdmanager project status with UI-specific fields.
+type UIProjectStatus struct {
+	Name                 string                    `json:"name"`
+	Status               api.RenovateProjectStatus `json:"status"`
+	LastTransition       *time.Time                `json:"lastTransition,omitempty"`
+	Priority             int32                     `json:"priority,omitempty"`
+	RenovateResultStatus *string                   `json:"renovateResultStatus,omitempty"`
+	Duration             *string                   `json:"duration,omitempty"`
+	PRActivity           *api.PRActivity           `json:"prActivity,omitempty"`
+	LogIssues            *api.LogIssues            `json:"logIssues,omitempty"`
+	CanWrite             *bool                     `json:"canWrite,omitempty"`
+}
+
 type RenovateJobInfo struct {
-	Name             string                             `json:"name"`
-	Namespace        string                             `json:"namespace"`
-	CronExpression   string                             `json:"cronExpression"`
-	NextSchedule     time.Time                          `json:"nextSchedule"`
-	DiscoveryStatus  api.RenovateProjectStatus          `json:"discoveryStatus"`
-	Projects         []crdmanager.RenovateProjectStatus `json:"projects"`
-	Platform         string                             `json:"platform,omitempty"`
-	PlatformEndpoint string                             `json:"platformEndpoint,omitempty"`
+	Name             string                    `json:"name"`
+	Namespace        string                    `json:"namespace"`
+	CronExpression   string                    `json:"cronExpression"`
+	NextSchedule     time.Time                 `json:"nextSchedule"`
+	DiscoveryStatus  api.RenovateProjectStatus `json:"discoveryStatus"`
+	Projects         []UIProjectStatus         `json:"projects"`
+	Platform         string                    `json:"platform,omitempty"`
+	PlatformEndpoint string                    `json:"platformEndpoint,omitempty"`
 	// Accepted is false when the operator's policy refuses this job, in which case
 	// nothing runs for it and AcceptedMessage says what to fix. Jobs reconciled by an
 	// older operator have no condition yet and are reported as accepted.
@@ -261,6 +274,7 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	renovateJobs, decisions := s.filterReadableJobs(r, renovateJobs)
+	session := getSessionFromContext(r)
 
 	result := make([]RenovateJobInfo, 0)
 	for i := range renovateJobs {
@@ -279,9 +293,12 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 		platform, _ := utils.GetPlatformAndEndpoint(renovateJob.Spec.Provider)
 		platformEndpoint := utils.GetPublicEndpoint(renovateJob.Spec.Provider)
 
-		projects := make([]crdmanager.RenovateProjectStatus, 0, len(renovateJob.Status.Projects))
+		// Resolve user's repo permissions for this job's platform
+		userRepos := getUserRepos(r.Context(), session, platform, platformEndpoint, s.repoCache, s.logger)
+
+		crdProjects := make([]crdmanager.RenovateProjectStatus, 0, len(renovateJob.Status.Projects))
 		for _, p := range renovateJob.Status.Projects {
-			projects = append(projects, crdmanager.RenovateProjectStatus{
+			crdProjects = append(crdProjects, crdmanager.RenovateProjectStatus{
 				Name:                 p.Name,
 				Status:               p.Status,
 				LastTransition:       crdmanager.NonZeroTime(p.LastTransition.Time),
@@ -294,6 +311,30 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
+		// Filter projects by user's repo access on the git platform
+		crdProjects = filterProjectsByAccess(r.Context(), session, platform, platformEndpoint, crdProjects, s.repoCache, s.logger)
+
+		// Build UI project list with write permission annotations
+		projects := make([]UIProjectStatus, 0, len(crdProjects))
+		for _, p := range crdProjects {
+			proj := UIProjectStatus{
+				Name:                 p.Name,
+				Status:               p.Status,
+				LastTransition:       p.LastTransition,
+				Priority:             p.Priority,
+				RenovateResultStatus: p.RenovateResultStatus,
+				Duration:             p.Duration,
+				PRActivity:           p.PRActivity,
+				LogIssues:            p.LogIssues,
+			}
+			if userRepos != nil {
+				if perm, ok := userRepos[p.Name]; ok {
+					canWrite := perm.CanWrite
+					proj.CanWrite = &canWrite
+				}
+			}
+			projects = append(projects, proj)
+		}
 		accepted, acceptedMessage := acceptedState(renovateJob)
 
 		result = append(result, RenovateJobInfo{
@@ -438,8 +479,23 @@ func (s *Server) runRenovateForProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, ok := s.requirePermission(w, r, body.Namespace, body.RenovateJob, permTrigger); !ok {
+	job, ok := s.requirePermission(w, r, body.Namespace, body.RenovateJob, permTrigger)
+	if !ok {
 		return
+	}
+
+	session := getSessionFromContext(r)
+	if job != nil {
+		platform, endpoint := utils.GetPlatformAndEndpoint(job.Spec.Provider)
+		if !canUserWriteRepo(r.Context(), session, platform, endpoint, body.Project, s.repoCache, s.logger) {
+			s.logger.Info("Write access denied for repo",
+				"user", sessionEmail(r),
+				"project", body.Project,
+				"renovateJob", body.RenovateJob,
+				"namespace", body.Namespace)
+			http.Error(w, "forbidden: write access required", http.StatusForbidden)
+			return
+		}
 	}
 
 	err := s.manager.UpdateProjectStatus(
@@ -515,8 +571,17 @@ func (s *Server) runRenovateForAllProjects(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if _, ok := s.requirePermission(w, r, body.Namespace, body.RenovateJob, permTriggerAll); !ok {
+	job, ok := s.requirePermission(w, r, body.Namespace, body.RenovateJob, permTriggerAll)
+	if !ok {
 		return
+	}
+
+	// Resolve writable repos so we only trigger projects the user can write to
+	var userRepos map[string]RepoPermission
+	session := getSessionFromContext(r)
+	if job != nil {
+		platform, endpoint := utils.GetPlatformAndEndpoint(job.Spec.Provider)
+		userRepos = getUserRepos(r.Context(), session, platform, endpoint, s.repoCache, s.logger)
 	}
 
 	jobIdentifier := crdmanager.RenovateJobIdentifier{
@@ -527,7 +592,17 @@ func (s *Server) runRenovateForAllProjects(w http.ResponseWriter, r *http.Reques
 	err := s.manager.UpdateProjectStatusBatched(
 		r.Context(),
 		func(p api.ProjectStatus) bool {
-			return p.Status != api.JobStatusRunning && p.Status != api.JobStatusScheduled
+			if p.Status == api.JobStatusRunning || p.Status == api.JobStatusScheduled {
+				return false
+			}
+			// Skip projects the user doesn't have write access to
+			if userRepos != nil {
+				perm, ok := userRepos[p.Name]
+				if !ok || !perm.CanWrite {
+					return false
+				}
+			}
+			return true
 		},
 		jobIdentifier,
 		&types.RenovateStatusUpdate{

--- a/src/ui/repo_access.go
+++ b/src/ui/repo_access.go
@@ -1,0 +1,352 @@
+package ui
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	crdmanager "renovate-operator/internal/crdManager"
+
+	"github.com/go-logr/logr"
+)
+
+const defaultRepoCacheTTL = 5 * time.Minute
+
+// RepoPermission stores the user's permission level for a repository.
+type RepoPermission struct {
+	CanWrite bool
+}
+
+// RepoCache provides a caching layer for user repository access lookups.
+// The in-memory implementation can be swapped for Valkey/Redis.
+type RepoCache interface {
+	Get(ctx context.Context, key string) (map[string]RepoPermission, bool)
+	Set(ctx context.Context, key string, repos map[string]RepoPermission, ttl time.Duration)
+}
+
+// --- In-memory implementation ---
+
+type memoryCacheEntry struct {
+	repos   map[string]RepoPermission
+	expires time.Time
+}
+
+type MemoryRepoCache struct {
+	mu      sync.RWMutex
+	entries map[string]memoryCacheEntry
+}
+
+func NewMemoryRepoCache() *MemoryRepoCache {
+	c := &MemoryRepoCache{entries: make(map[string]memoryCacheEntry)}
+	go c.cleanup()
+	return c
+}
+
+func (c *MemoryRepoCache) Get(_ context.Context, key string) (map[string]RepoPermission, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[key]
+	if !ok || time.Now().After(entry.expires) {
+		return nil, false
+	}
+	// Return a defensive copy to prevent callers from mutating cached state.
+	copied := make(map[string]RepoPermission, len(entry.repos))
+	for k, v := range entry.repos {
+		copied[k] = v
+	}
+	return copied, true
+}
+
+func (c *MemoryRepoCache) Set(_ context.Context, key string, repos map[string]RepoPermission, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Store a defensive copy so the caller can't mutate cached state.
+	stored := make(map[string]RepoPermission, len(repos))
+	for k, v := range repos {
+		stored[k] = v
+	}
+	c.entries[key] = memoryCacheEntry{repos: stored, expires: time.Now().Add(ttl)}
+}
+
+func (c *MemoryRepoCache) cleanup() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		c.mu.Lock()
+		now := time.Now()
+		for k, v := range c.entries {
+			if now.After(v.expires) {
+				delete(c.entries, k)
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+// --- Cache key helper ---
+
+// normalizeEndpoint strips path, query, and default ports so that semantically
+// equivalent endpoint URLs (e.g. with/without /api/v1, trailing slash) share a cache entry.
+func normalizeEndpoint(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return strings.TrimRight(endpoint, "/")
+	}
+	u.Path = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	u.User = nil
+	u.Host = strings.ToLower(u.Host)
+	return strings.TrimRight(u.String(), "/")
+}
+
+func repoCacheKey(token, endpoint string) string {
+	normalized := normalizeEndpoint(endpoint)
+	h := sha256.Sum256([]byte(token + "\x00" + normalized))
+	return hex.EncodeToString(h[:])
+}
+
+// --- Platform repo fetchers ---
+
+func fetchUserRepos(ctx context.Context, platform, endpoint, token string, logger logr.Logger) (map[string]RepoPermission, error) {
+	switch strings.ToLower(platform) {
+	case "forgejo", "gitea":
+		return fetchForgejoUserRepos(ctx, endpoint, token, logger)
+	case "github":
+		return fetchGitHubUserRepos(ctx, endpoint, token, logger)
+	default:
+		return nil, fmt.Errorf("repo access filtering not supported for platform %q", platform)
+	}
+}
+
+func fetchForgejoUserRepos(ctx context.Context, endpoint, token string, logger logr.Logger) (map[string]RepoPermission, error) {
+	endpoint = strings.TrimSuffix(endpoint, "/")
+	endpoint = strings.TrimSuffix(endpoint, "/api/v1")
+
+	repos := make(map[string]RepoPermission)
+	client := &http.Client{Timeout: 30 * time.Second}
+	page := 1
+	limit := 50
+
+	for {
+		params := url.Values{}
+		params.Set("limit", strconv.Itoa(limit))
+		params.Set("page", strconv.Itoa(page))
+
+		reqURL := fmt.Sprintf("%s/api/v1/repos/search?%s", endpoint, params.Encode())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "token "+token)
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("forgejo API request failed: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("forgejo API returned %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result struct {
+			Data []struct {
+				FullName    string `json:"full_name"`
+				Permissions *struct {
+					Admin bool `json:"admin"`
+					Push  bool `json:"push"`
+					Pull  bool `json:"pull"`
+				} `json:"permissions,omitempty"`
+			} `json:"data"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&result)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode forgejo API response: %w", err)
+		}
+
+		if len(result.Data) == 0 {
+			break
+		}
+		for _, r := range result.Data {
+			canWrite := r.Permissions != nil && (r.Permissions.Push || r.Permissions.Admin)
+			repos[r.FullName] = RepoPermission{CanWrite: canWrite}
+		}
+		logger.V(2).Info("fetched user repos from forgejo", "page", page, "count", len(result.Data))
+		if len(result.Data) < limit {
+			break
+		}
+		page++
+	}
+
+	logger.V(1).Info("fetched all user repos from forgejo", "total", len(repos))
+	return repos, nil
+}
+
+func fetchGitHubUserRepos(ctx context.Context, endpoint, token string, logger logr.Logger) (map[string]RepoPermission, error) {
+	if endpoint == "" {
+		endpoint = "https://api.github.com"
+	}
+	endpoint = strings.TrimSuffix(endpoint, "/")
+
+	repos := make(map[string]RepoPermission)
+	client := &http.Client{Timeout: 30 * time.Second}
+	page := 1
+
+	for {
+		reqURL := fmt.Sprintf("%s/user/repos?per_page=100&page=%d", endpoint, page)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("github API request failed: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("github API returned %d: %s", resp.StatusCode, string(body))
+		}
+
+		var result []struct {
+			FullName    string `json:"full_name"`
+			Permissions *struct {
+				Admin    bool `json:"admin"`
+				Push     bool `json:"push"`
+				Pull     bool `json:"pull"`
+				Maintain bool `json:"maintain"`
+			} `json:"permissions,omitempty"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&result)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode github API response: %w", err)
+		}
+
+		if len(result) == 0 {
+			break
+		}
+		for _, r := range result {
+			canWrite := r.Permissions != nil && (r.Permissions.Push || r.Permissions.Admin || r.Permissions.Maintain)
+			repos[r.FullName] = RepoPermission{CanWrite: canWrite}
+		}
+		logger.V(2).Info("fetched user repos from github", "page", page, "count", len(result))
+		if len(result) < 100 {
+			break
+		}
+		page++
+	}
+
+	logger.V(1).Info("fetched all user repos from github", "total", len(repos))
+	return repos, nil
+}
+
+// --- Project filtering ---
+
+// getUserRepos resolves the user's repo permissions from cache or the platform API.
+// Returns nil if permissions cannot be determined (no token, unsupported platform, API error).
+func getUserRepos(
+	ctx context.Context,
+	session *sessionData,
+	platform, endpoint string,
+	cache RepoCache,
+	logger logr.Logger,
+) map[string]RepoPermission {
+	if session == nil || session.AccessToken == "" || cache == nil {
+		return nil
+	}
+	if platform == "" || endpoint == "" {
+		return nil
+	}
+
+	key := repoCacheKey(session.AccessToken, endpoint)
+
+	userRepos, ok := cache.Get(ctx, key)
+	if !ok {
+		var err error
+		userRepos, err = fetchUserRepos(ctx, platform, endpoint, session.AccessToken, logger)
+		if err != nil {
+			logger.Info("failed to fetch user repos for access filtering, showing all projects",
+				"platform", platform,
+				"endpoint", endpoint,
+				"user", session.Email,
+				"error", err.Error())
+			return nil
+		}
+		cache.Set(ctx, key, userRepos, defaultRepoCacheTTL)
+	}
+
+	return userRepos
+}
+
+// filterProjectsByAccess filters a job's projects to only those the user can access
+// on the git platform. Returns the original list unchanged if filtering is not possible
+// (no token, unsupported platform, API error).
+func filterProjectsByAccess(
+	ctx context.Context,
+	session *sessionData,
+	platform, endpoint string,
+	projects []crdmanager.RenovateProjectStatus,
+	cache RepoCache,
+	logger logr.Logger,
+) []crdmanager.RenovateProjectStatus {
+	userRepos := getUserRepos(ctx, session, platform, endpoint, cache, logger)
+	if userRepos == nil {
+		return projects
+	}
+
+	filtered := make([]crdmanager.RenovateProjectStatus, 0, len(projects))
+	for _, p := range projects {
+		if _, ok := userRepos[p.Name]; ok {
+			filtered = append(filtered, p)
+		}
+	}
+
+	logger.V(1).Info("filtered projects by user access",
+		"user", session.Email,
+		"platform", platform,
+		"total_projects", len(projects),
+		"visible_projects", len(filtered))
+
+	return filtered
+}
+
+// canUserWriteRepo checks if the user has write access to a specific repo.
+// Returns true (fail-open) when permissions cannot be determined — this covers
+// unsupported platforms, missing tokens, and transient API errors. Fail-open is
+// intentional: this is additive security on top of existing group-based auth,
+// and failing closed would block all trigger actions on transient API failures.
+func canUserWriteRepo(
+	ctx context.Context,
+	session *sessionData,
+	platform, endpoint, repoName string,
+	cache RepoCache,
+	logger logr.Logger,
+) bool {
+	userRepos := getUserRepos(ctx, session, platform, endpoint, cache, logger)
+	if userRepos == nil {
+		return true // fail-open when we can't determine permissions
+	}
+	perm, ok := userRepos[repoName]
+	if !ok {
+		return false // not in user's repo list at all
+	}
+	return perm.CanWrite
+}

--- a/src/ui/repo_access.go
+++ b/src/ui/repo_access.go
@@ -106,6 +106,10 @@ func normalizeEndpoint(endpoint string) string {
 	u.Fragment = ""
 	u.User = nil
 	u.Host = strings.ToLower(u.Host)
+	port := u.Port()
+	if (u.Scheme == "http" && port == "80") || (u.Scheme == "https" && port == "443") {
+		u.Host = strings.TrimSuffix(u.Host, ":"+port)
+	}
 	return strings.TrimRight(u.String(), "/")
 }
 

--- a/src/ui/repo_access_test.go
+++ b/src/ui/repo_access_test.go
@@ -1,0 +1,291 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	crdmanager "renovate-operator/internal/crdManager"
+
+	"github.com/go-logr/logr"
+)
+
+func TestMemoryRepoCache(t *testing.T) {
+	cache := NewMemoryRepoCache()
+	ctx := context.Background()
+	key := "test-key"
+	repos := map[string]RepoPermission{
+		"owner/repo1": {CanWrite: true},
+		"owner/repo2": {CanWrite: false},
+	}
+
+	// Miss on empty cache
+	if _, ok := cache.Get(ctx, key); ok {
+		t.Fatal("expected cache miss")
+	}
+
+	// Hit after set
+	cache.Set(ctx, key, repos, 5*time.Minute)
+	got, ok := cache.Get(ctx, key)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(got))
+	}
+	if !got["owner/repo1"].CanWrite {
+		t.Error("expected owner/repo1 to have write access")
+	}
+	if got["owner/repo2"].CanWrite {
+		t.Error("expected owner/repo2 to be read-only")
+	}
+
+	// Expired entry returns miss
+	cache.Set(ctx, key, repos, -1*time.Second)
+	if _, ok := cache.Get(ctx, key); ok {
+		t.Fatal("expected cache miss for expired entry")
+	}
+}
+
+func TestRepoCacheKey(t *testing.T) {
+	k1 := repoCacheKey("token-a", "https://example.com")
+	k2 := repoCacheKey("token-b", "https://example.com")
+	k3 := repoCacheKey("token-a", "https://other.com")
+
+	if k1 == k2 {
+		t.Fatal("different tokens should produce different keys")
+	}
+	if k1 == k3 {
+		t.Fatal("different endpoints should produce different keys")
+	}
+	if k1 != repoCacheKey("token-a", "https://example.com") {
+		t.Fatal("same inputs should produce same key")
+	}
+}
+
+func TestFetchForgejoUserReposWithPermissions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "token test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"full_name": "alice/owned", "permissions": map[string]bool{"admin": true, "push": true, "pull": true}},
+				{"full_name": "alice/collab", "permissions": map[string]bool{"admin": false, "push": true, "pull": true}},
+				{"full_name": "bob/public", "permissions": map[string]bool{"admin": false, "push": false, "pull": true}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	repos, err := fetchForgejoUserRepos(context.Background(), srv.URL, "test-token", logr.Discard())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 3 {
+		t.Fatalf("expected 3 repos, got %d", len(repos))
+	}
+	if !repos["alice/owned"].CanWrite {
+		t.Error("expected alice/owned to have write access (admin)")
+	}
+	if !repos["alice/collab"].CanWrite {
+		t.Error("expected alice/collab to have write access (push)")
+	}
+	if repos["bob/public"].CanWrite {
+		t.Error("expected bob/public to be read-only")
+	}
+}
+
+func TestFetchForgejoUserReposUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	_, err := fetchForgejoUserRepos(context.Background(), srv.URL, "bad-token", logr.Discard())
+	if err == nil {
+		t.Fatal("expected error for unauthorized request")
+	}
+}
+
+func TestFetchGitHubUserReposWithPermissions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"full_name": "alice/repo1", "permissions": map[string]bool{"admin": false, "push": true, "pull": true}},
+			{"full_name": "bob/repo2", "permissions": map[string]bool{"admin": false, "push": false, "pull": true}},
+		})
+	}))
+	defer srv.Close()
+
+	got, err := fetchGitHubUserRepos(context.Background(), srv.URL, "test-token", logr.Discard())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(got))
+	}
+	if !got["alice/repo1"].CanWrite {
+		t.Error("expected alice/repo1 to have write access")
+	}
+	if got["bob/repo2"].CanWrite {
+		t.Error("expected bob/repo2 to be read-only")
+	}
+}
+
+func TestFilterProjectsByAccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"full_name": "alice/repo1", "permissions": map[string]bool{"push": true, "pull": true}},
+				{"full_name": "alice/repo2", "permissions": map[string]bool{"push": false, "pull": true}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	cache := NewMemoryRepoCache()
+	session := &sessionData{
+		Email:       "alice@example.com",
+		AccessToken: "test-token",
+	}
+
+	projects := []crdmanager.RenovateProjectStatus{
+		{Name: "alice/repo1"},
+		{Name: "alice/repo2"},
+		{Name: "alice/repo3"}, // user doesn't have access
+		{Name: "bob/secret"},  // user doesn't have access
+	}
+
+	filtered := filterProjectsByAccess(
+		context.Background(), session, "forgejo", srv.URL, projects, cache, logr.Discard(),
+	)
+
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 filtered projects, got %d", len(filtered))
+	}
+	if filtered[0].Name != "alice/repo1" || filtered[1].Name != "alice/repo2" {
+		t.Errorf("unexpected filtered projects: %v", filtered)
+	}
+}
+
+func TestFilterProjectsByAccessNoToken(t *testing.T) {
+	projects := []crdmanager.RenovateProjectStatus{
+		{Name: "alice/repo1"},
+		{Name: "alice/repo2"},
+	}
+
+	// No access token — should return all projects unchanged
+	session := &sessionData{Email: "alice@example.com"}
+	result := filterProjectsByAccess(
+		context.Background(), session, "forgejo", "https://example.com", projects, NewMemoryRepoCache(), logr.Discard(),
+	)
+	if len(result) != 2 {
+		t.Fatalf("expected all projects returned when no token, got %d", len(result))
+	}
+
+	// Nil session — should return all projects unchanged
+	result = filterProjectsByAccess(
+		context.Background(), nil, "forgejo", "https://example.com", projects, NewMemoryRepoCache(), logr.Discard(),
+	)
+	if len(result) != 2 {
+		t.Fatalf("expected all projects returned with nil session, got %d", len(result))
+	}
+}
+
+func TestFilterProjectsByAccessUnsupportedPlatform(t *testing.T) {
+	projects := []crdmanager.RenovateProjectStatus{
+		{Name: "alice/repo1"},
+	}
+	session := &sessionData{Email: "alice@example.com", AccessToken: "token"}
+
+	result := filterProjectsByAccess(
+		context.Background(), session, "bitbucket", "https://example.com", projects, NewMemoryRepoCache(), logr.Discard(),
+	)
+	if len(result) != 1 {
+		t.Fatalf("expected all projects returned for unsupported platform, got %d", len(result))
+	}
+}
+
+func TestFilterProjectsByAccessCachesResult(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"full_name": "alice/repo1", "permissions": map[string]bool{"push": true, "pull": true}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	cache := NewMemoryRepoCache()
+	session := &sessionData{Email: "alice@example.com", AccessToken: "test-token"}
+	projects := []crdmanager.RenovateProjectStatus{{Name: "alice/repo1"}}
+
+	// First call — cache miss, hits API
+	filterProjectsByAccess(context.Background(), session, "forgejo", srv.URL, projects, cache, logr.Discard())
+	if callCount != 1 {
+		t.Fatalf("expected 1 API call, got %d", callCount)
+	}
+
+	// Second call — cache hit, no additional API call
+	filterProjectsByAccess(context.Background(), session, "forgejo", srv.URL, projects, cache, logr.Discard())
+	if callCount != 1 {
+		t.Fatalf("expected still 1 API call after cache hit, got %d", callCount)
+	}
+}
+
+func TestCanUserWriteRepo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"full_name": "alice/writable", "permissions": map[string]bool{"push": true, "pull": true}},
+				{"full_name": "alice/readonly", "permissions": map[string]bool{"push": false, "pull": true}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	cache := NewMemoryRepoCache()
+	session := &sessionData{Email: "alice@example.com", AccessToken: "test-token"}
+
+	// Writable repo
+	if !canUserWriteRepo(context.Background(), session, "forgejo", srv.URL, "alice/writable", cache, logr.Discard()) {
+		t.Error("expected write access for alice/writable")
+	}
+
+	// Read-only repo
+	if canUserWriteRepo(context.Background(), session, "forgejo", srv.URL, "alice/readonly", cache, logr.Discard()) {
+		t.Error("expected no write access for alice/readonly")
+	}
+
+	// Repo not in user's list
+	if canUserWriteRepo(context.Background(), session, "forgejo", srv.URL, "bob/secret", cache, logr.Discard()) {
+		t.Error("expected no write access for repo not in user's list")
+	}
+
+	// No token — should fail open (return true)
+	noTokenSession := &sessionData{Email: "alice@example.com"}
+	if !canUserWriteRepo(context.Background(), noTokenSession, "forgejo", srv.URL, "anything", cache, logr.Discard()) {
+		t.Error("expected fail-open when no token")
+	}
+
+	// Nil session — should fail open
+	if !canUserWriteRepo(context.Background(), nil, "forgejo", srv.URL, "anything", cache, logr.Discard()) {
+		t.Error("expected fail-open with nil session")
+	}
+}

--- a/src/ui/repo_access_test.go
+++ b/src/ui/repo_access_test.go
@@ -66,6 +66,20 @@ func TestRepoCacheKey(t *testing.T) {
 	}
 }
 
+func TestNormalizeEndpoint(t *testing.T) {
+	tests := map[string]string{
+		"https://EXAMPLE.com:443/api/v1/?page=1#fragment": "https://example.com",
+		"http://EXAMPLE.com:80/api/v1":                    "http://example.com",
+		"https://EXAMPLE.com:8443/api/v1":                 "https://example.com:8443",
+	}
+
+	for endpoint, want := range tests {
+		if got := normalizeEndpoint(endpoint); got != want {
+			t.Errorf("normalizeEndpoint(%q) = %q, want %q", endpoint, got, want)
+		}
+	}
+}
+
 func TestFetchForgejoUserReposWithPermissions(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "token test-token" {

--- a/src/ui/server.go
+++ b/src/ui/server.go
@@ -28,10 +28,11 @@ type Server struct {
 	auth           AuthProvider
 	accessDefaults AccessDefaults
 	accessCheck    accessCheckCache
+	repoCache      RepoCache
 	Router         *mux.Router
 }
 
-func NewServer(manager crdmanager.RenovateJobManager, discovery renovate.DiscoveryAgent, scheduler scheduler.Scheduler, logger logr.Logger, health health.HealthCheck, version string, auth AuthProvider, accessDefaults AccessDefaults) *Server {
+func NewServer(manager crdmanager.RenovateJobManager, discovery renovate.DiscoveryAgent, scheduler scheduler.Scheduler, logger logr.Logger, health health.HealthCheck, version string, auth AuthProvider, accessDefaults AccessDefaults, repoCache RepoCache) *Server {
 	return &Server{
 		manager:        manager,
 		logger:         logger,
@@ -41,6 +42,7 @@ func NewServer(manager crdmanager.RenovateJobManager, discovery renovate.Discove
 		version:        version,
 		auth:           auth,
 		accessDefaults: accessDefaults,
+		repoCache:      repoCache,
 		Router:         mux.NewRouter(),
 	}
 }


### PR DESCRIPTION
## Motivation

RenovateJob authorization currently decides whether a user may view or operate an entire job.
A job can contain repositories with different audiences and different read/write permissions, so granting access to the job can expose projects the user cannot access on the underlying Git provider.

## Why the current OIDC model cannot solve this

OIDC authenticates an identity and provides claims such as username, email, and optional groups.
Those claims do not describe the user's current permission on every repository discovered by Renovate.

Repository access can come from organization membership, team membership, direct collaboration, repository visibility, or administrator grants.
The effective permission can also differ between read and write and can change independently of the user's OIDC claims.
Mapping OIDC groups into `readerGroups` or `adminGroups` therefore remains useful for RenovateJob-level policy, but it cannot reliably answer whether a user may see or trigger a specific repository inside that job.
Replicating repository grants into OIDC groups or RenovateJob configuration would create a second authorization database that drifts from Forgejo or GitHub.

This change keeps the existing OIDC and RenovateJob authorization model as the first gate, then uses the OAuth access token to query the provider's live repository permissions as a second, project-level gate.

## User impact

Users retain the role granted by `spec.access` or the operator authorization defaults, but only see projects their provider account can access.
Trigger controls remain available only for repositories where that account has write permission.
Unsupported providers retain the existing RenovateJob-level behavior.
