### PR TITLE
docs: add Claranet France to the adopters list

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -25,6 +25,13 @@ Only add yourself if you are running the operator in a permanent deployment (not
 
 ## Adopters
 
+### Claranet France
+Running the operator on Kubernetes to keep dependencies updated across our self-managed GitLab, sweeping every repository hourly.
+- **Providers**: GitLab
+- **Repositories**: ~1350
+- **Link**: https://www.claranet.com/fr
+- **Contact**: @pdecat
+
 ### mogenius
 Running the operator to manage dependency updates across internal services.
 - **Providers**: GitHub


### PR DESCRIPTION
Adds Claranet France to the Adopters section, per #517.

We have been running the operator in production since June 2026 on a Kubernetes cluster, driving Renovate against a self-managed GitLab: hourly sweep, ~1350 repositories discovered, run jobs fanned out onto a dedicated node pool with a Valkey package cache.

Entry follows the template and keeps the section in alphabetical order.