### PR TITLE
fix(chart): install every CRD from the hook, not just renovatejobs

### DIFF
--- a/charts/renovate-operator/templates/crd-hook.yaml
+++ b/charts/renovate-operator/templates/crd-hook.yaml
@@ -51,8 +51,16 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "-5"
 data:
-  renovatejob.yaml: |
-{{ .Files.Get "crd/renovate-operator.mogenius.com_renovatejobs.yaml" | indent 4 }}
+  # Every CRD the chart ships, so adding one to crd/ is enough to have it
+  # installed. Naming files individually here means a new CRD is silently left
+  # uninstalled, and the operator only fails later, at the first API call that
+  # needs the missing kind. Mirrors the glob in crds.yaml, which the "template"
+  # install mode uses.
+{{- $files := .Files }}
+{{- range $path, $_ := .Files.Glob "crd/**" }}
+  {{ base $path }}: |
+{{ $files.Get $path | indent 4 }}
+{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -93,7 +101,7 @@ spec:
             - --server-side
             - --force-conflicts
             - -f
-            - /crd/renovatejob.yaml
+            - /crd
           volumeMounts:
             - name: crd
               mountPath: /crd

--- a/charts/renovate-operator/unittests/crd/crdHook.yaml
+++ b/charts/renovate-operator/unittests/crd/crdHook.yaml
@@ -1,0 +1,53 @@
+chart:
+  appVersion: 0.1.0
+  version: 0.1.0
+suite: CRD install hook ships every CRD
+release:
+  name: renovate-operator-unittest
+  namespace: testing
+tests:
+# The hook used to name one CRD file explicitly, so adding a second CRD to the
+# chart left it uninstalled and the operator failed later, on the first API call
+# needing the missing kind.
+- it: mounts the RenovateJob CRD
+  set:
+    crd.install: true
+    crd.mode: hook
+  templates:
+  - templates/crd-hook.yaml
+  documentIndex: 3
+  asserts:
+  - isKind:
+      of: ConfigMap
+  - exists:
+      path: data["renovate-operator.mogenius.com_renovatejobs.yaml"]
+
+- it: mounts the RenovateProject CRD
+  set:
+    crd.install: true
+    crd.mode: hook
+  templates:
+  - templates/crd-hook.yaml
+  documentIndex: 3
+  asserts:
+  - exists:
+      path: data["renovate-operator.mogenius.com_renovateprojects.yaml"]
+
+# Applying the directory rather than a named file is what keeps the two in step:
+# whatever the ConfigMap mounts gets applied.
+- it: applies the whole mounted directory
+  set:
+    crd.install: true
+    crd.mode: hook
+  templates:
+  - templates/crd-hook.yaml
+  documentIndex: 4
+  asserts:
+  - isKind:
+      of: Job
+  - contains:
+      path: spec.template.spec.containers[0].command
+      content: /crd
+  - notContains:
+      path: spec.template.spec.containers[0].command
+      content: /crd/renovatejob.yaml


### PR DESCRIPTION
## What

`crd.mode` defaults to `hook`, and the hook names one CRD file explicitly:

```yaml
data:
  renovatejob.yaml: |
{{ .Files.Get "crd/renovate-operator.mogenius.com_renovatejobs.yaml" | indent 4 }}
```

```yaml
            - -f
            - /crd/renovatejob.yaml
```

So the `RenovateProject` CRD added in #632 is shipped in the chart but never applied. `crd.mode: template` is unaffected, because `crds.yaml` already globs `crd/**`.

This is queued to ship: #625 (release 6.1.0) contains `extract project status into a separate crd per project`, `chart: adding permissions for renovateprojects` and `make crd project field immutable`. The permissions for the new kind landed in #634; this is the other half.

## What happens without it

The operator does not start. `controllers/renovateproject_controller.go` does `For(&api.RenovateProject{})` and is registered in `cmd/main.go`, so the manager tries to start an informer for a kind the API server does not serve, cache sync never completes and the pod crash-loops.

On a cluster where the CRD was never applied, the kind is simply absent:

```
$ kubectl apply -f renovateproject.yaml
error: resource mapping not found for name: "probe" namespace: "default":
no matches for kind "RenovateProject" in version "renovate-operator.mogenius.com/v1alpha1"
ensure CRDs are installed first
```

So a default install upgrading to 6.1.0 gets a crash-looping operator rather than a working one.

## The change

Glob `crd/**` into the ConfigMap and apply the mounted directory, so both install modes pick up whatever the chart ships and adding a CRD is not something to remember in a second place.

Three helm unittests cover it: both CRDs reach the ConfigMap, and the Job applies the directory rather than a named file. They fail against the template as it stands today (3 failed, 0 passed).

## Note on the ConfigMap keys

They change from `renovatejob.yaml` to the CRD filenames. The ConfigMap is a hook resource with `helm.sh/hook-delete-policy: before-hook-creation`, so it is recreated on every install and upgrade and nothing carries over.

I have not touched the committed CRDs. `just generate` currently rewrites ~125 lines of `renovatejobs.yaml`, which looks like drift from the Kubernetes 0.37 bump rather than anything to do with this, so it seemed better left out of a one-line template fix.
