### PR TITLE
chore(chart): regenerate the RenovateJob CRD after the Kubernetes v0.37.0 bump

### DIFF
--- a/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
+++ b/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml
@@ -1063,7 +1063,9 @@ spec:
                           description: Selects a key of a ConfigMap.
                           properties:
                             key:
-                              description: The key to select.
+                              description: |-
+                                The key to select from the ConfigMap's Data field.
+                                Keys in the BinaryData field are not currently propagated to container env vars.
                               type: string
                             name:
                               default: ""
@@ -1243,10 +1245,21 @@ spec:
                   description: VolumeMount describes a mounting of a Volume within
                     a container.
                   properties:
-                    mountPath:
+                    bindMountOptions:
                       description: |-
-                        Path within the container at which the volume should be mounted.  Must
-                        not contain ':'.
+                        bindMountOptions is the list of additional bind mount options to apply when
+                        mounting this volume into the container. Allowed values are noexec,
+                        nodev, and nosuid. These are Linux mount options and have no effect on
+                        Windows nodes.
+                        This field is not supported with image volumes.
+                        This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    mountPath:
+                      description: Path within the container at which the volume should
+                        be mounted.
                       type: string
                     mountPropagation:
                       description: |-
@@ -1520,6 +1533,13 @@ spec:
                             mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
+                        defaultUser:
+                          description: |-
+                            defaultUser is Optional: The owner UID of the created files by default.
+                            The defaultUser field is only used as a fallback when the item-level user field is unset.
+                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                          format: int64
+                          type: integer
                         items:
                           description: |-
                             items if unspecified, each key-value pair in the Data field of the referenced
@@ -1552,6 +1572,13 @@ spec:
                                   May not contain the path element '..'.
                                   May not start with the string '..'.
                                 type: string
+                              user:
+                                description: |-
+                                  user is Optional: The owner UID of the created file.
+                                  If specified, the item-level user field takes precedence over defaultUser.
+                                  (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                format: int64
+                                type: integer
                             required:
                             - key
                             - path
@@ -1638,6 +1665,13 @@ spec:
                             mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
+                        defaultUser:
+                          description: |-
+                            defaultUser is Optional: The owner UID of the created files by default.
+                            The defaultUser field is only used as a fallback when the item-level user field is unset.
+                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                          format: int64
+                          type: integer
                         items:
                           description: Items is a list of downward API volume file
                           items:
@@ -1702,6 +1736,13 @@ spec:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              user:
+                                description: |-
+                                  user is Optional: The owner UID of the created file.
+                                  If specified, the item-level user field takes precedence over defaultUser.
+                                  (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                format: int64
+                                type: integer
                             required:
                             - path
                             type: object
@@ -1720,6 +1761,18 @@ spec:
                             Must be an empty string (default) or Memory.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                           type: string
+                        mode:
+                          description: |-
+                            mode specifies the permission bits for the emptyDir directory, in numeric
+                            notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                            If not specified, defaults to 0777.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                            will override the mode specified here.
+                            This field has no effect on Windows.
+                            This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                          format: int32
+                          type: integer
                         sizeLimit:
                           anyOf:
                           - type: integer
@@ -1813,8 +1866,8 @@ spec:
                                     * An existing PVC (PersistentVolumeClaim)
                                     If the provisioner or an external controller can support the specified data source,
                                     it will create a new volume based on the contents of the specified data source.
-                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                    dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                    copied to dataSource when dataSourceRef.namespace is not specified.
                                     If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                   properties:
                                     apiGroup:
@@ -1859,7 +1912,6 @@ spec:
                                       specified.
                                     * While dataSource only allows local objects, dataSourceRef allows objects
                                       in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                     (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                   properties:
                                     apiGroup:
@@ -2426,6 +2478,13 @@ spec:
                             mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
+                        defaultUser:
+                          description: |-
+                            defaultUser is Optional: The owner UID of the created files by default.
+                            The defaultUser field is only used as a fallback when the item-level user field is unset.
+                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                          format: int64
+                          type: integer
                         sources:
                           description: |-
                             sources is the list of volume projections. Each entry in this list
@@ -2525,6 +2584,13 @@ spec:
                                       Mutually-exclusive with name.  The contents of all selected
                                       ClusterTrustBundles will be unified and deduplicated.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - path
                                 type: object
@@ -2565,6 +2631,13 @@ spec:
                                             May not contain the path element '..'.
                                             May not start with the string '..'.
                                           type: string
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - key
                                       - path
@@ -2660,6 +2733,13 @@ spec:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - path
                                       type: object
@@ -2767,6 +2847,13 @@ spec:
                                     description: Kubelet's generated CSRs will be
                                       addressed to this signer.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   userAnnotations:
                                     additionalProperties:
                                       type: string
@@ -2826,6 +2913,13 @@ spec:
                                             May not contain the path element '..'.
                                             May not start with the string '..'.
                                           type: string
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - key
                                       - path
@@ -2873,6 +2967,13 @@ spec:
                                       path is the path relative to the mount point of the file to project the
                                       token into.
                                     type: string
+                                  user:
+                                    description: |-
+                                      user is Optional: The owner UID of the created file.
+                                      If specified, the item-level user field takes precedence over defaultUser.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                 required:
                                 - path
                                 type: object
@@ -3079,6 +3180,13 @@ spec:
                             mode, like fsGroup, and the result can be other mode bits set.
                           format: int32
                           type: integer
+                        defaultUser:
+                          description: |-
+                            defaultUser is Optional: The owner UID of the created files by default.
+                            The defaultUser field is only used as a fallback when the item-level user field is unset.
+                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                          format: int64
+                          type: integer
                         items:
                           description: |-
                             items If unspecified, each key-value pair in the Data field of the referenced
@@ -3111,6 +3219,13 @@ spec:
                                   May not contain the path element '..'.
                                   May not start with the string '..'.
                                 type: string
+                              user:
+                                description: |-
+                                  user is Optional: The owner UID of the created file.
+                                  If specified, the item-level user field takes precedence over defaultUser.
+                                  (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                format: int64
+                                type: integer
                             required:
                             - key
                             - path
@@ -3468,8 +3583,8 @@ spec:
                                   * An existing PVC (PersistentVolumeClaim)
                                   If the provisioner or an external controller can support the specified data source,
                                   it will create a new volume based on the contents of the specified data source.
-                                  When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                  and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                  dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                  copied to dataSource when dataSourceRef.namespace is not specified.
                                   If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                 properties:
                                   apiGroup:
@@ -3514,7 +3629,6 @@ spec:
                                     specified.
                                   * While dataSource only allows local objects, dataSourceRef allows objects
                                     in any namespaces.
-                                  (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                   (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                 properties:
                                   apiGroup:
@@ -3978,11 +4092,8 @@ spec:
                           Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
                           whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
                           CSIDriver instance. Other volumes are always re-labelled recursively.
-                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
 
-                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
-                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
-                          and "Recursive" for all other volumes.
+                          If not specified, "MountOption" is used.
 
                           This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
 


### PR DESCRIPTION
## What

`just generate` produces a diff against the committed CRD on a clean checkout of `main`, so the schema still describes the API types as they were before #631 moved `k8s.io/api` and friends from v0.36.4 to v0.37.0.

`RenovateJobSpec` embeds core types (`corev1.EnvVar`, `ResourceRequirements`, `Affinity`, `Toleration`, `TopologySpreadConstraint`), and controller-gen derives their schema from the compiled structs, so bumping the library changes the generated CRD.

## What is in the diff

Only that:

- `VolumeMount.bindMountOptions` and its nested fields, new in v0.37.0 (alpha, behind the `VolumeBindMountOptions` feature gate)
- reworded upstream descriptions, for example `ConfigMapKeySelector.key`, `VolumeMount.mountPath`, and the `dataSource`/SELinux notes

No field of the operator's own API is touched and nothing is removed. `renovateprojects.yaml` is unchanged, since it embeds no core types.

Generated with the controller-gen the Justfile installs. The `controller-gen.kubebuilder.io/version` annotation reads v0.21.0 both before and after, so there is no generator churn mixed in.

## Why bother

Low impact by itself: the missing fields are optional and new, so the practical effect is that setting one on a RenovateJob pod spec would be silently pruned by the API server. Mostly it stops `just generate` dirtying the tree during unrelated work, which is how I noticed it.

Split out from #637 deliberately, so that a one-line template fix is not reviewed alongside a 125-line regenerated schema.
