### PR TITLE
fix(ui): stop the project table overflowing in Chrome

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -2279,7 +2279,7 @@
                                 >
                                   <td className="px-3 xl:px-6 py-3">
                               <div className="flex items-center gap-2 w-full justify-between">
-                                <span className={`font-medium min-w-0 break-words ${project.renovateResultStatus && project.renovateResultStatus !== "done" ? "text-gray-500 dark:text-slate-400" : "text-gray-900 dark:text-slate-100"}`}>
+                                <span className={`font-medium min-w-0 [overflow-wrap:anywhere] ${project.renovateResultStatus && project.renovateResultStatus !== "done" ? "text-gray-500 dark:text-slate-400" : "text-gray-900 dark:text-slate-100"}`}>
                                   {project.name}
                                 </span>
                                 {project.renovateResultStatus && project.renovateResultStatus !== "done" && (


### PR DESCRIPTION
The Actions column of the project table gets clipped on the right in Chrome, but not in Firefox, and only on windows wider than 1280px.

Measured min-content width of the project name cell (identical font metrics in both browsers):

| Name | Chrome | Firefox |
|---|---|---|
| `mogenius/dynamic-redirects` | 131.1 | 70.9 |
| `mogenius/EchoFail` | 124.9 | 70.9 |

Firefox has a line-break opportunity after the slash, Chrome only at hyphens. `break-words` (`overflow-wrap: break-word`) does not affect min-content sizing per spec — measured identical to `normal`. Together with the Actions column's hard 248px minimum (`w-[130px]` + `min-w-[60px]` + gaps + `px-6`) and `main` capped at `max-w-7xl` (1216px of content, so a wider window adds no room while `xl:px-6` adds 168px of demand), the table exceeds its card and is clipped by its `overflow-hidden`.

`overflow-wrap: anywhere` does affect min-content sizing: 13px in both browsers. Rendering is unchanged as long as there is room; only the column's minimum requirement goes away.