### PR TITLE
fix: keep PR activity metrics when a run aborts with repository-changed

### DIFF
--- a/src/internal/parser/logParser.go
+++ b/src/internal/parser/logParser.go
@@ -20,11 +20,15 @@ const MaxLogIssues = 20
 // MaxIssueMessageLen is the maximum length of a single issue message.
 const MaxIssueMessageLen = 256
 
+// renovateResultRepositoryChanged is Renovate's "Repository finished" result when it
+// aborted the run because the repository changed while it was being renovated.
+const renovateResultRepositoryChanged = "repository-changed"
+
 // LogParseResult contains the result of parsing Renovate logs.
 type LogParseResult struct {
 	HasIssues            bool            // true if any WARN (level 40) or ERROR (level 50) found
 	RenovateResultStatus *string         // nil = unknown; "Disabled", "No Config", "Onboarding Closed", or raw result string
-	PRActivity           *api.PRActivity // nil when logs are empty/unparseable, non-nil (possibly zero counts) when logs were parsed successfully
+	PRActivity           *api.PRActivity // nil when logs are empty/unparseable or the run aborted before branch processing ("repository-changed"), non-nil (possibly zero counts) otherwise
 	LogIssues            *api.LogIssues  // nil when logs are empty/unparseable, non-nil when logs were parsed successfully
 }
 
@@ -288,7 +292,12 @@ func ParseRenovateLogs(logs string) *LogParseResult {
 
 	// Build PRActivity and LogIssues if we parsed any log lines
 	if parsedAnyLine {
-		result.PRActivity = buildPRActivity(branchMap)
+		// A "repository-changed" run aborted before branch processing: its report
+		// carries an empty branch list that means "not evaluated", not "no PRs".
+		// Leave PRActivity nil so consumers keep the last known values.
+		if result.RenovateResultStatus == nil || *result.RenovateResultStatus != renovateResultRepositoryChanged {
+			result.PRActivity = buildPRActivity(branchMap)
+		}
 		result.LogIssues = &api.LogIssues{
 			WarnCount:  warnCount,
 			ErrorCount: errorCount,

--- a/src/internal/parser/logParser_test.go
+++ b/src/internal/parser/logParser_test.go
@@ -1260,3 +1260,30 @@ func TestParseRenovateLogsPrintingReport(t *testing.T) {
 		}
 	})
 }
+
+func TestParseRenovateLogsRepositoryChangedAbort(t *testing.T) {
+	// When the repository changes mid-run, Renovate aborts before branch processing
+	// and still exits successfully. Its report then carries an empty branch list that
+	// means "not evaluated", not "zero PRs" — so PRActivity must stay nil instead of
+	// reporting zero counts that would wipe the last known state.
+	logs := strings.Join([]string{
+		`{"level":30,"msg":"Renovate started"}`,
+		`{"level":30,"msg":"Repository started"}`,
+		`{"level":30,"msg":"Dependency extraction complete"}`,
+		`{"level":30,"msg":"Repository has changed during renovation - aborting"}`,
+		`{"level":30,"msg":"Repository finished","result":"repository-changed"}`,
+		`{"level":30,"msg":"Printing report","report":{"repositories":{"org/repo":{"branches":[]}}}}`,
+	}, "\n")
+
+	result := ParseRenovateLogs(logs)
+
+	if result.RenovateResultStatus == nil || *result.RenovateResultStatus != "repository-changed" {
+		t.Fatalf("RenovateResultStatus = %v, want repository-changed", result.RenovateResultStatus)
+	}
+	if result.PRActivity != nil {
+		t.Errorf("PRActivity = %+v, want nil for an aborted repository-changed run", result.PRActivity)
+	}
+	if result.LogIssues == nil {
+		t.Error("LogIssues = nil, want non-nil (logs were parsed)")
+	}
+}

--- a/src/internal/renovate/discoveryAgent_test.go
+++ b/src/internal/renovate/discoveryAgent_test.go
@@ -27,6 +27,7 @@ type fakeJobManager struct {
 	reconcileProjectsFn          func(ctx context.Context, job *api.RenovateJob, projects []string) error
 	updateProjectStatusBatchedFn func(ctx context.Context, fn func(p crdManager.RenovateProjectStatus) bool, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error
 	getProjectsByStatusFn        func(ctx context.Context, job crdManager.RenovateJobIdentifier, status api.RenovateProjectStatus) ([]crdManager.RenovateProjectStatus, error)
+	updateProjectStatusFn        func(ctx context.Context, project string, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error
 }
 
 func (f *fakeJobManager) GetRenovateJob(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
@@ -64,6 +65,9 @@ func (f *fakeJobManager) GetProjectsForRenovateJob(ctx context.Context, job crdM
 	return nil, fmt.Errorf("not implemented")
 }
 func (f *fakeJobManager) UpdateProjectStatus(ctx context.Context, project string, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
+	if f.updateProjectStatusFn != nil {
+		return f.updateProjectStatusFn(ctx, project, job, status)
+	}
 	return fmt.Errorf("not implemented")
 }
 func (f *fakeJobManager) GetProjectsByStatus(ctx context.Context, job crdManager.RenovateJobIdentifier, status api.RenovateProjectStatus) ([]crdManager.RenovateProjectStatus, error) {
@@ -93,9 +97,13 @@ func (f *fakeJobManager) CancelProjectJob(ctx context.Context, project string, j
 
 type fakePodLogReader struct {
 	getSucceededJobLogFn func(ctx context.Context, job *batchv1.Job) (string, error)
+	getLastJobLogFn      func(ctx context.Context, job *batchv1.Job) (string, error)
 }
 
 func (f *fakePodLogReader) GetLastJobLog(ctx context.Context, job *batchv1.Job) (string, error) {
+	if f.getLastJobLogFn != nil {
+		return f.getLastJobLogFn(ctx, job)
+	}
 	return "", nil
 }
 func (f *fakePodLogReader) StreamJobLogs(ctx context.Context, job *batchv1.Job, follow bool) (io.ReadCloser, error) {

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -267,11 +267,6 @@ func (e *renovateExecutor) ProcessProjectJobResult(ctx context.Context, k8sJob *
 
 	metricStore.SetRunFailed(jobId.Namespace, jobId.Name, project, newStatus == api.JobStatusFailed)
 	metricStore.SetDependencyIssues(jobId.Namespace, jobId.Name, project, hasIssues)
-	approvalsNeeded := 0
-	if newProjectStatus.PRActivity != nil {
-		approvalsNeeded = newProjectStatus.PRActivity.NeedsApproval
-	}
-	metricStore.SetApprovalsNeeded(jobId.Namespace, jobId.Name, project, approvalsNeeded)
 	metricStore.CaptureRenovateProjectExecution(ctx, jobId.Namespace, jobId.Name, project, newStatus)
 
 	// Execution duration (Group A/E). Only emit when the k8s Job reported a StartTime.
@@ -292,15 +287,17 @@ func (e *renovateExecutor) ProcessProjectJobResult(ctx context.Context, k8sJob *
 		metricStore.SetLogIssues(jobId.Namespace, jobId.Name, project, "error", newProjectStatus.LogIssues.ErrorCount)
 	}
 
-	// Pull request activity (Group E/L).
+	// Pull request activity (Group E/L). A nil PRActivity means the run yielded no
+	// branch data (aborted "repository-changed" run, or unreadable logs): keep the
+	// last known gauges instead of zeroing them; the status merge keeps the stored
+	// PRActivity for the same reason.
 	if pr := newProjectStatus.PRActivity; pr != nil {
+		metricStore.SetApprovalsNeeded(jobId.Namespace, jobId.Name, project, pr.NeedsApproval)
 		metricStore.AddPullRequestsCreated(ctx, jobId.Namespace, jobId.Name, pr.Created)
 		metricStore.AddPullRequestsMerged(ctx, jobId.Namespace, jobId.Name, pr.Automerged)
 		metricStore.AddPullRequestsUpdated(ctx, jobId.Namespace, jobId.Name, pr.Updated)
 		// Open managed PRs: automerged ones are closed, so exclude them.
 		metricStore.SetOpenPullRequests(jobId.Namespace, jobId.Name, project, pr.Created+pr.Updated+pr.Unchanged)
-	} else {
-		metricStore.SetOpenPullRequests(jobId.Namespace, jobId.Name, project, 0)
 	}
 
 	if span := trace.SpanFromContext(ctx); span.IsRecording() {

--- a/src/internal/renovate/executor_test.go
+++ b/src/internal/renovate/executor_test.go
@@ -1,0 +1,146 @@
+package renovate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	api "renovate-operator/api/v1alpha1"
+	"renovate-operator/config"
+	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/policy"
+	"renovate-operator/internal/types"
+	"renovate-operator/metricStore"
+
+	"github.com/prometheus/client_golang/prometheus"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// fakeLogStore is a no-op LogStore for executor tests.
+type fakeLogStore struct{}
+
+func (fakeLogStore) Save(namespace, renovateJob, project, logs string) {}
+func (fakeLogStore) Get(namespace, renovateJob, project string) (string, bool) {
+	return "", false
+}
+
+// TestProcessProjectJobResultAbortedRunKeepsPRGauges reproduces the "metric drops to
+// zero" incident: a run aborted with "repository-changed" (repo changed while Renovate
+// was running) completes successfully but carries no branch data. Its result must not
+// overwrite the last known approval/open-PR gauges or the persisted PRActivity.
+func TestProcessProjectJobResultAbortedRunKeepsPRGauges(t *testing.T) {
+	const (
+		ns      = "renovate-operator"
+		jobName = "gitlab"
+		project = "org/repo"
+	)
+
+	_ = config.InitializeConfigModule([]config.ConfigItemDescription{
+		{Key: "DELETE_SUCCESSFUL_JOBS", Optional: true, Default: "false"},
+	})
+
+	reg := prometheus.NewRegistry()
+	metricStore.Register(reg)
+
+	// Last clean run left these values behind.
+	metricStore.SetApprovalsNeeded(ns, jobName, project, 7)
+	metricStore.SetOpenPullRequests(ns, jobName, project, 6)
+
+	abortedLogs := strings.Join([]string{
+		`{"level":30,"msg":"Renovate started"}`,
+		`{"level":30,"msg":"Repository started"}`,
+		`{"level":30,"msg":"Dependency extraction complete"}`,
+		`{"level":30,"msg":"Repository has changed during renovation - aborting"}`,
+		`{"level":30,"msg":"Repository finished","result":"repository-changed"}`,
+		`{"level":30,"msg":"Printing report","report":{"repositories":{"org/repo":{"branches":[]}}}}`,
+	}, "\n")
+
+	var captured *types.RenovateStatusUpdate
+	manager := &fakeJobManager{
+		getProjectsByStatusFn: func(ctx context.Context, job crdManager.RenovateJobIdentifier, status api.RenovateProjectStatus) ([]crdManager.RenovateProjectStatus, error) {
+			return []crdManager.RenovateProjectStatus{{Name: project}}, nil
+		},
+		updateProjectStatusFn: func(ctx context.Context, p string, job crdManager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
+			captured = status
+			return nil
+		},
+	}
+	logReader := &fakePodLogReader{
+		getLastJobLogFn: func(ctx context.Context, job *batchv1.Job) (string, error) {
+			return abortedLogs, nil
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add batch scheme: %v", err)
+	}
+	now := metav1.Now()
+	k8sJob := &batchv1.Job{}
+	k8sJob.Name = "gitlab-org-repo-abc123"
+	k8sJob.Namespace = ns
+	k8sJob.Status = batchv1.JobStatus{
+		Conditions:     []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}},
+		StartTime:      &now,
+		CompletionTime: &now,
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(k8sJob).Build()
+
+	executor := NewRenovateExecutor(scheme, manager, k8sClient, testLogger, nil, fakeLogStore{}, logReader, policy.Policy{})
+
+	jobId := crdManager.RenovateJobIdentifier{Name: jobName, Namespace: ns}
+	if err := executor.ProcessProjectJobResult(context.Background(), k8sJob, project, jobId); err != nil {
+		t.Fatalf("ProcessProjectJobResult() error = %v", err)
+	}
+
+	if captured == nil {
+		t.Fatal("UpdateProjectStatus was not called")
+	}
+	if captured.PRActivity != nil {
+		t.Errorf("persisted PRActivity = %+v, want nil for an aborted run", captured.PRActivity)
+	}
+
+	labels := map[string]string{"renovate_namespace": ns, "renovate_job": jobName, "project": project}
+	if got := gaugeValue(t, reg, "renovate_operator_approvals_needed", labels); got != 7 {
+		t.Errorf("renovate_operator_approvals_needed = %v, want 7 (kept from last clean run)", got)
+	}
+	if got := gaugeValue(t, reg, "renovate_operator_open_pull_requests", labels); got != 6 {
+		t.Errorf("renovate_operator_open_pull_requests = %v, want 6 (kept from last clean run)", got)
+	}
+}
+
+// gaugeValue reads a single gauge with the given labels from the registry.
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+	metric:
+		for _, m := range mf.GetMetric() {
+			for k, v := range labels {
+				found := false
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == k && lp.GetValue() == v {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue metric
+				}
+			}
+			return m.GetGauge().GetValue()
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+	return 0
+}


### PR DESCRIPTION
## Problem

When a repository changes while Renovate is renovating it (e.g. MRs merged in quick succession right after a merge webhook triggered a run), Renovate aborts with *"Repository has changed during renovation - aborting"* but still exits 0. Its final report then contains `"branches": []` — meaning "not evaluated", not "zero PRs".

The log parser turned this empty list into an all-zero `PRActivity`, which the executor wrote unconditionally into `renovate_operator_approvals_needed` / `renovate_operator_open_pull_requests` and into the persisted project status. Every merge burst therefore zeroed the gauges (and the durable state hydration restores from) until the next scheduled run.

Observed in production: the approvals gauge flapped 7 → 0 → back to 7 four hours later, on every batch of MR merges. Any Prometheus alert with a `for:` clause built on these gauges gets its pending timer reset by each dip and effectively never fires.

## Fix

- `logParser.go`: a run that finished with result `repository-changed` now yields `PRActivity = nil` ("no branch data produced") instead of a zero-count struct. `LogIssues` and `RenovateResultStatus` are still reported as before.
- `executor.go`: PR-derived gauges (`approvals_needed`, `open_pull_requests`, PR counters) are only updated when the run actually produced branch data. On nil `PRActivity` the last known values stay in place.
- The status merge (`updatePRActivity`) already ignores nil updates, so the stored `PRActivity` — and metric hydration after an operator restart — keep the last real values without further changes.

## Testing

- `TestParseRenovateLogsRepositoryChangedAbort` — parser returns nil `PRActivity` for an aborted run, modeled on the actual production log lines.
- `TestProcessProjectJobResultAbortedRunKeepsPRGauges` — end-to-end through `ProcessProjectJobResult`: seeds gauges from a previous clean run, processes an aborted run, asserts gauges keep their values and the persisted update carries nil `PRActivity`. The shared test fakes gained two optional function fields for this.
- Both tests reproduced the bug before the fix (gauges 7→0, 6→0, zeroed persisted activity) and pass after; full `go test ./...` and `go vet ./...` are clean.
