### PR TITLE
feat(ui): info icon on job cards showing discovery config

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1754,6 +1754,14 @@
           key: "status",
           direction: "asc",
         });
+        const [infoTooltipPos, setInfoTooltipPos] = useState(null);
+        const infoIconRef = useRef(null);
+        const showInfoTooltip = () => {
+          if (!infoIconRef.current) return;
+          const rect = infoIconRef.current.getBoundingClientRect();
+          setInfoTooltipPos({ top: rect.bottom + 8, left: rect.left + rect.width / 2 });
+        };
+        const hideInfoTooltip = () => setInfoTooltipPos(null);
         const actionHint = permissionHint(authInfo);
         const canTrigger = can(job, "trigger");
         const canTriggerAll = can(job, "triggerAll");
@@ -1991,38 +1999,48 @@
 
               {/* Config info icon */}
               {(job.discoveryFilters?.length > 0 || job.discoverTopics?.length > 0) && (
-                <div className="relative flex-shrink-0 group/info" onClick={(e) => e.stopPropagation()}>
+                <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                   <svg
-                    className="w-4 h-4 text-gray-400 dark:text-slate-500 hover:text-primary dark:hover:text-primary cursor-default transition-colors"
+                    ref={infoIconRef}
+                    className={`w-4 h-4 cursor-default transition-colors ${infoTooltipPos ? "text-primary" : "text-gray-400 dark:text-slate-500"}`}
                     fill="currentColor"
                     viewBox="0 0 20 20"
                     aria-label="Job configuration info"
+                    onMouseEnter={showInfoTooltip}
+                    onMouseLeave={hideInfoTooltip}
                   >
                     <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                   </svg>
-                  <div className="absolute left-1/2 -translate-x-1/2 top-6 z-50 hidden group-hover/info:block w-64 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-lg shadow-lg p-3 text-left">
-                    <div className="absolute -top-1.5 left-1/2 -translate-x-1/2 w-3 h-3 bg-white dark:bg-slate-800 border-l border-t border-gray-200 dark:border-slate-600 rotate-45" />
-                    {job.discoveryFilters?.length > 0 && (
-                      <div className="mb-2">
-                        <p className="text-[0.688rem] font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-1">Discovery Filters</p>
-                        <ul className="space-y-0.5">
-                          {job.discoveryFilters.map((f, i) => (
-                            <li key={i} className="font-mono text-xs text-gray-800 dark:text-slate-200 truncate" title={f}>{f}</li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
-                    {job.discoverTopics?.length > 0 && (
-                      <div>
-                        <p className="text-[0.688rem] font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-1">Discover Topics</p>
-                        <ul className="space-y-0.5">
-                          {job.discoverTopics.map((t, i) => (
-                            <li key={i} className="font-mono text-xs text-gray-800 dark:text-slate-200 truncate" title={t}>{t}</li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
-                  </div>
+                  {infoTooltipPos && (
+                    <div
+                      style={{ position: "fixed", top: infoTooltipPos.top, left: infoTooltipPos.left, transform: "translateX(-50%)" }}
+                      className="z-50 w-64 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-lg shadow-lg p-3 text-left pointer-events-none"
+                      onMouseEnter={showInfoTooltip}
+                      onMouseLeave={hideInfoTooltip}
+                    >
+                      <div className="absolute -top-1.5 left-1/2 -translate-x-1/2 w-3 h-3 bg-white dark:bg-slate-800 border-l border-t border-gray-200 dark:border-slate-600 rotate-45" />
+                      {job.discoveryFilters?.length > 0 && (
+                        <div className="mb-2">
+                          <p className="text-[0.688rem] font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-1">Discovery Filters</p>
+                          <ul className="space-y-0.5">
+                            {job.discoveryFilters.map((f, i) => (
+                              <li key={i} className="font-mono text-xs text-gray-800 dark:text-slate-200 truncate" title={f}>{f}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                      {job.discoverTopics?.length > 0 && (
+                        <div>
+                          <p className="text-[0.688rem] font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-1">Discover Topics</p>
+                          <ul className="space-y-0.5">
+                            {job.discoverTopics.map((t, i) => (
+                              <li key={i} className="font-mono text-xs text-gray-800 dark:text-slate-200 truncate" title={t}>{t}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1989,6 +1989,43 @@
                 </p>
               </div>
 
+              {/* Config info icon */}
+              {(job.discoveryFilters?.length > 0 || job.discoverTopics?.length > 0) && (
+                <div className="relative flex-shrink-0 group/info" onClick={(e) => e.stopPropagation()}>
+                  <svg
+                    className="w-4 h-4 text-gray-400 dark:text-slate-500 hover:text-primary dark:hover:text-primary cursor-default transition-colors"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    aria-label="Job configuration info"
+                  >
+                    <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                  </svg>
+                  <div className="absolute left-1/2 -translate-x-1/2 top-6 z-50 hidden group-hover/info:block w-64 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-lg shadow-lg p-3 text-left">
+                    <div className="absolute -top-1.5 left-1/2 -translate-x-1/2 w-3 h-3 bg-white dark:bg-slate-800 border-l border-t border-gray-200 dark:border-slate-600 rotate-45" />
+                    {job.discoveryFilters?.length > 0 && (
+                      <div className="mb-2">
+                        <p className="text-[0.688rem] font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-1">Discovery Filters</p>
+                        <ul className="space-y-0.5">
+                          {job.discoveryFilters.map((f, i) => (
+                            <li key={i} className="font-mono text-xs text-gray-800 dark:text-slate-200 truncate" title={f}>{f}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {job.discoverTopics?.length > 0 && (
+                      <div>
+                        <p className="text-[0.688rem] font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400 mb-1">Discover Topics</p>
+                        <ul className="space-y-0.5">
+                          {job.discoverTopics.map((t, i) => (
+                            <li key={i} className="font-mono text-xs text-gray-800 dark:text-slate-200 truncate" title={t}>{t}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
               {/* Schedule info — hidden on small screens */}
               <div className="hidden lg:flex items-center gap-1.5 flex-shrink-0 w-[15rem]">
                 <svg

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -35,8 +35,10 @@ type RenovateJobInfo struct {
 	// older operator have no condition yet and are reported as accepted.
 	Accepted        bool     `json:"accepted"`
 	AcceptedMessage string   `json:"acceptedMessage,omitempty"`
-	Role            string   `json:"role,omitempty"`
-	Permissions     []string `json:"permissions"`
+	Role              string   `json:"role,omitempty"`
+	Permissions       []string `json:"permissions"`
+	DiscoveryFilters  []string `json:"discoveryFilters,omitempty"`
+	DiscoverTopics    []string `json:"discoverTopics,omitempty"`
 }
 
 func (s *Server) decideJobAccess(r *http.Request, job *api.RenovateJob) accessDecision {
@@ -301,6 +303,8 @@ func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {
 			PlatformEndpoint: platformEndpoint,
 			Role:             decisions[i].Role.String(),
 			Permissions:      decisions[i].permissions(),
+			DiscoveryFilters: renovateJob.Spec.DiscoveryFilters,
+			DiscoverTopics:   renovateJob.Spec.DiscoverTopics,
 		})
 	}
 


### PR DESCRIPTION
## Summary

- Adds a small ⓘ icon to each RenovateJob card header in the dashboard
- On hover, a tooltip lists `discoveryFilters` and/or `discoverTopics` configured on the job
- Icon is only rendered when at least one of those fields is non-empty
- Exposes the two fields via the `/api/v1/renovatejobs` JSON response (`discoveryFilters`, `discoverTopics`)

## Test plan

- [ ] RenovateJob with `discoveryFilters` set → icon appears, tooltip shows filters
- [ ] RenovateJob with `discoverTopics` set → tooltip shows topics
- [ ] Job with both fields → both sections shown in tooltip
- [ ] Job with neither field → no icon rendered
- [ ] `just check` passes