### PR TITLE
feat(ui): guided first-run setup and in-flight spinners

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ Prerequisites: [`just`](https://github.com/casey/just) must be installed.
    just run
    ```
 
+`KUBECONFIG` may also name several files separated by `:`; they are merged the
+way kubectl merges them.
+
+A local run has no pod and therefore no namespace of its own. The setup guide's
+secret check refuses every namespace in that state — deliberately, so a
+cluster-exposed UI cannot probe secrets in namespaces that are none of its
+business — and logs why. Export `POD_NAMESPACE` with the namespace you are
+setting up to exercise that step locally:
+
+```sh
+export POD_NAMESPACE=renovate-operator
+```
+
+`just run` loads `.env`, so both variables can live there instead of your shell.
+
 **Running Tests**
 
 | Command              | Description                      |

--- a/docs/configuration/auth.md
+++ b/docs/configuration/auth.md
@@ -204,7 +204,9 @@ take access away.
 > **Fail closed**: a job with no access configuration anywhere is hidden from
 > everyone once authentication is enabled. Set `authorization.defaults.adminUsers` or
 > `authorization.defaults.adminGroups` (or `spec.access` per job) or the dashboard
-> will look empty.
+> will look empty. The dashboard detects this state and shows a warning banner
+> (served on `/api/v1/access/status` as `warning` with reason `NoAccessRules`),
+> and the operator log names the affected jobs.
 
 ### Naming users instead of groups
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,18 @@ helm -n renovate-operator upgrade --install renovate-operator \
   --create-namespace --wait
 ```
 
+## Open the UI
+
+The chart creates no ingress by default, so reach the UI with a port-forward:
+
+```sh
+kubectl -n renovate-operator port-forward svc/renovate-operator 8081:8081
+```
+
+Then open <http://localhost:8081>. A fresh install greets you with a setup
+guide that tracks the remaining steps on this page and checks them off as you
+apply the resources. For a permanent URL, set `ingress.enabled` (or
+`route.enabled` for the Gateway API) in the chart values.
 
 ## Create a credentials secret
 
@@ -58,7 +70,7 @@ Apply it:
 kubectl apply -f renovatejob.yaml
 ```
 
-The operator runs a discovery job on the next cron tick, finds matching repositories, and queues them for Renovate. Open the UI to follow progress — the URL is whatever hostname you pointed at the operator.
+The operator runs a discovery job on the next cron tick, finds matching repositories, and queues them for Renovate. Follow progress in the UI — the setup guide at `/setup` also lets you start discovery immediately instead of waiting for the schedule.
 
 ## Next steps
 

--- a/docs/platforms/github-app-native.md
+++ b/docs/platforms/github-app-native.md
@@ -19,11 +19,17 @@ type: Opaque
 metadata:
   name: github-app-credentials
   namespace: renovate-operator
+  labels:
+    renovate-operator.mogenius.com/allow-ref: "true"
 data:
   PEM: <base64-encoded private key>
   APP_ID: <base64-encoded App ID>
   INSTALL_ID: <base64-encoded Installation ID>
 ```
+
+> **Note:** the `allow-ref` label opts the Secret in to being referenced at
+> caller-chosen keys. It is enforced once the [policy engine](../security/security.md)
+> is enabled — set it now so enabling the policy later does not break this job.
 
 ## 2. Create the RenovateJob
 

--- a/src/clientProvider/clientProvider.go
+++ b/src/clientProvider/clientProvider.go
@@ -1,6 +1,8 @@
 package clientProvider
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"k8s.io/client-go/discovery"
@@ -29,22 +31,24 @@ type K8sClientProvider interface {
 }
 type k8sClientProvider struct {
 	clientConfig *rest.Config
+	inCluster    bool
 }
 
 func NewClientProvider() (K8sClientProvider, error) {
-	kubeConfig, err := createKubernetesConfig()
+	kubeConfig, inCluster, err := createKubernetesConfig()
 	if err != nil {
 		return nil, err
 	}
 	return k8sClientProvider{
 		clientConfig: kubeConfig,
+		inCluster:    inCluster,
 	}, nil
 }
 func (provider k8sClientProvider) ClientConfig() *rest.Config {
 	return provider.clientConfig
 }
 func (provider k8sClientProvider) RunsInCluster() bool {
-	return getKubernetesConfig() == ""
+	return provider.inCluster
 }
 
 func (provider k8sClientProvider) K8sClientSet() (clientset kubernetes.Interface, err error) {
@@ -95,15 +99,54 @@ func (provider k8sClientProvider) ApiExtensionsClient() (clientset apiextensions
 	return cachedApiextensionsClient, err
 }
 
-func createKubernetesConfig() (*rest.Config, error) {
-	cfg := getKubernetesConfig()
-	if cfg != "" {
-		return clientcmd.BuildConfigFromFlags("", cfg)
-	} else {
-		return rest.InClusterConfig()
+// createKubernetesConfig resolves the client configuration: an explicit
+// KUBECONFIG wins, then the in-cluster service account, then the default
+// kubeconfig at ~/.kube/config — so a local run works without exporting
+// KUBECONFIG, matching ctrl.GetConfigOrDie in main.go. The bool reports
+// whether the in-cluster configuration was used.
+func createKubernetesConfig() (*rest.Config, bool, error) {
+	if os.Getenv(clientcmd.RecommendedConfigPathEnvVar) != "" {
+		config, err := loadKubeConfig()
+		if err != nil {
+			return nil, false, fmt.Errorf("unable to load the kubeconfig from %s=%s: %w",
+				clientcmd.RecommendedConfigPathEnvVar, os.Getenv(clientcmd.RecommendedConfigPathEnvVar), err)
+		}
+		return config, false, nil
 	}
+
+	config, err := rest.InClusterConfig()
+	if err == nil {
+		return config, true, nil
+	}
+	// Any other error means we ARE in a cluster with a broken service account
+	// setup; falling back to a kubeconfig would mask that.
+	if !errors.Is(err, rest.ErrNotInCluster) {
+		return nil, false, err
+	}
+
+	config, err = loadKubeConfig()
+	if err != nil {
+		return nil, false, fmt.Errorf("not running in a cluster and no usable kubeconfig found at %s (set KUBECONFIG to use another path): %w",
+			clientcmd.RecommendedHomeFile, err)
+	}
+	return config, false, nil
 }
 
-func getKubernetesConfig() string {
-	return os.Getenv("KUBECONFIG")
+// loadKubeConfig defers to client-go's own loading rules instead of reading a
+// single file: KUBECONFIG may name a whole precedence list of files separated
+// by filepath.ListSeparator, which the rules merge the way kubectl does, and
+// they fall back to ~/.kube/config when the variable is unset.
+//
+// Deliberately not NewNonInteractiveDeferredLoadingClientConfig: that
+// substitutes the in-cluster configuration whenever the files turn out to be
+// unusable, which would both hide a broken kubeconfig behind a working client
+// and report the result as out-of-cluster when it is anything but. Loading the
+// rules directly keeps an unusable kubeconfig an error, and the caller decides
+// what the in-cluster case means.
+func loadKubeConfig() (*rest.Config, error) {
+	apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	if err != nil {
+		return nil, err
+	}
+	return clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
 }

--- a/src/clientProvider/clientProvider_test.go
+++ b/src/clientProvider/clientProvider_test.go
@@ -1,0 +1,56 @@
+package clientProvider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const testKubeConfig = `apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+  - name: test
+    cluster:
+      server: https://kubernetes.test:6443
+contexts:
+  - name: test
+    context:
+      cluster: test
+      user: test
+users:
+  - name: test
+    user:
+      token: test-token
+`
+
+// KUBECONFIG holds a precedence list, not a single file: a missing entry is
+// skipped and the remaining files are merged, the way kubectl resolves them.
+func TestCreateKubernetesConfigWithKubeConfigList(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "config")
+	if err := os.WriteFile(existing, []byte(testKubeConfig), 0o600); err != nil {
+		t.Fatalf("writing the kubeconfig: %v", err)
+	}
+
+	t.Setenv("KUBECONFIG", filepath.Join(dir, "missing-cluster")+string(filepath.ListSeparator)+existing)
+
+	config, inCluster, err := createKubernetesConfig()
+	if err != nil {
+		t.Fatalf("resolving the kubeconfig: %v", err)
+	}
+	if inCluster {
+		t.Error("expected the resolution to report an out-of-cluster config")
+	}
+	if config.Host != "https://kubernetes.test:6443" {
+		t.Errorf("host = %q, want the server of the merged kubeconfig", config.Host)
+	}
+}
+
+func TestCreateKubernetesConfigWithUnusableKubeConfig(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "missing"))
+
+	if _, _, err := createKubernetesConfig(); err == nil {
+		t.Fatal("expected an error when KUBECONFIG names no usable file")
+	}
+}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -722,7 +723,11 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	cfg := ctrl.GetConfigOrDie()
+	// Not GetConfigOrDie: it reports the reason through controller-runtime's
+	// logger, which has no sink yet — the process would exit 1 without ever
+	// saying why an unusable kubeconfig was the problem.
+	cfg, err := ctrl.GetConfig()
+	assert.NoError(err, "failed to resolve the Kubernetes client configuration")
 	adaptKubeConfig(cfg)
 
 	otelCleanup := initObservability(&opts)
@@ -832,7 +837,12 @@ func main() {
 	warnAccessRulesEnforceable(ctrl.Log.WithName("auth"), auth.provider, auth.accessDefaults)
 
 	// UI and webhook servers run on all replicas
-	uiServer := ui.NewServer(jobMgr, discovery, cronManager, ctrl.Log.WithName("ui-server"), health, Version, auth.provider, auth.accessDefaults)
+	uiServer := ui.NewServer(jobMgr, discovery, cronManager, ctrl.Log.WithName("ui-server"), health, Version, auth.provider, auth.accessDefaults, ui.SetupEnvironment{
+		PolicyEnabled:        !guardRails.Disabled,
+		LogStorageConfigured: config.GetValue("LOG_STORE_MODE") != "disabled",
+		OwnNamespace:         operatorNamespace(),
+		SecretReader:         mgr.GetClient(),
+	})
 
 	if config.GetValue("WEBHOOK_SERVER_ENABLED") != "false" {
 		webhookServer := webhook.NewWebookServer(jobMgr, ctrl.Log.WithName("webhook"))
@@ -928,4 +938,21 @@ func initObservability(zapOpts *zap.Options) func() {
 			ctrl.Log.WithName("telemetry").Error(shutdownErr, "failed to shut down OpenTelemetry")
 		}
 	}
+}
+
+// operatorNamespace resolves the namespace the operator itself runs in. The
+// chart sets POD_NAMESPACE from the pod's metadata, but a hand-rolled
+// manifest may not, so the pod's service account token directory is the
+// fallback — it is authoritative for a pod and needs no wiring. Empty only
+// outside a cluster, and the setup guide's secret probe then refuses every
+// namespace rather than widening.
+func operatorNamespace() string {
+	if ns := config.GetValue("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(ns))
 }

--- a/src/gitProviderClients/factory/gitProviderClientFactory.go
+++ b/src/gitProviderClients/factory/gitProviderClientFactory.go
@@ -16,6 +16,7 @@ import (
 	"renovate-operator/internal/telemetry"
 	"renovate-operator/internal/utils"
 	"renovate-operator/metricStore"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -175,14 +176,18 @@ func readToken(ctx context.Context, c client.Client, job *api.RenovateJob, platf
 	return tokenFromSecret(secret, secretName)
 }
 
+// WellKnownTokenKeys are the secret keys Renovate and the operator recognize
+// as platform tokens, in order of preference.
+var WellKnownTokenKeys = []string{"RENOVATE_TOKEN", "GITHUB_COM_TOKEN", "GITLAB_TOKEN", "BITBUCKET_TOKEN", "GITEA_TOKEN", "FORGEJO_TOKEN"}
+
 // tokenFromSecret extracts a platform token from a secret by trying the common
 // token key names used by Renovate, in order of preference.
 func tokenFromSecret(secret *corev1.Secret, secretName string) (string, error) {
-	for _, key := range []string{"RENOVATE_TOKEN", "GITHUB_COM_TOKEN", "GITLAB_TOKEN", "BITBUCKET_TOKEN", "GITEA_TOKEN", "FORGEJO_TOKEN"} {
+	for _, key := range WellKnownTokenKeys {
 		if val, ok := secret.Data[key]; ok && len(val) > 0 {
 			return string(val), nil
 		}
 	}
 
-	return "", fmt.Errorf("no platform token found in secret %s (expected one of: RENOVATE_TOKEN, GITHUB_COM_TOKEN, GITLAB_TOKEN, BITBUCKET_TOKEN, GITEA_TOKEN, FORGEJO_TOKEN)", secretName)
+	return "", fmt.Errorf("no platform token found in secret %s (expected one of: %s)", secretName, strings.Join(WellKnownTokenKeys, ", "))
 }

--- a/src/static/components/Footer.js
+++ b/src/static/components/Footer.js
@@ -1,16 +1,128 @@
+// Shared footer for every page: a single slim bar on the header's surface.
+// Brand on the left, documentation quick links with icons in the middle,
+// icon-only project links on the right. The docs links are static and
+// absolute (the documentation is not shipped with the operator) and cover
+// the topics the setup guide's dynamic hints promote — auth, policy, log
+// storage — so they stay discoverable after the guide is gone without
+// leaking any of this install's configuration state.
+const FOOTER_REPO = "https://github.com/mogenius/renovate-operator";
+const FOOTER_DOCS = `${FOOTER_REPO}/blob/main/docs`;
+
+// Heroicons outline paths, matching the icon style used across the app.
+const FOOTER_DOC_LINKS = [
+  {
+    label: "Getting Started",
+    href: `${FOOTER_DOCS}/getting-started.md`,
+    icon: "M13 10V3L4 14h7v7l9-11h-7z",
+  },
+  {
+    label: "Platforms",
+    href: `${FOOTER_REPO}/tree/main/docs/platforms`,
+    icon: "M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253",
+  },
+  {
+    label: "Authentication",
+    href: `${FOOTER_DOCS}/configuration/auth.md`,
+    icon: "M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z",
+  },
+  {
+    label: "Security & Policy",
+    href: `${FOOTER_DOCS}/security/security.md`,
+    icon: "M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z",
+  },
+  {
+    label: "Webhooks",
+    href: `${FOOTER_REPO}/tree/main/docs/webhooks`,
+    icon: "M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1",
+  },
+  {
+    label: "Operations",
+    href: `${FOOTER_REPO}/tree/main/docs/operations`,
+    icon: "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z",
+  },
+];
+
+const FOOTER_PROJECT_LINKS = [
+  {
+    label: "GitHub",
+    href: FOOTER_REPO,
+    fill: true,
+    icon: "M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z",
+  },
+  {
+    label: "Issues",
+    href: `${FOOTER_REPO}/issues`,
+    icon: "M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+  },
+  {
+    label: "Releases",
+    href: `${FOOTER_REPO}/releases`,
+    icon: "M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-5 5a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 10V5a2 2 0 012-2z",
+  },
+];
+
 function Footer() {
+  const base = window.__BASE_PATH__ || "";
+
   return (
-    <footer className="border-t border-gray-200 dark:border-slate-700 py-3 px-3 sm:px-6 lg:px-8 transition-colors duration-200">
-      <div className="max-w-7xl mx-auto text-center text-xs text-gray-400 dark:text-slate-500">
-        Want to contribute? Check us out on{" "}
-        <a
-          href="https://github.com/mogenius/renovate-operator"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-primary transition-colors underline underline-offset-2"
-        >
-          GitHub
-        </a>
+    <footer className="bg-white dark:bg-slate-800 border-t border-gray-200 dark:border-slate-700 transition-colors duration-200">
+      <div className="max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-3">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <a
+            href={`${base}/`}
+            className="flex items-center gap-2 shrink-0"
+            aria-label="Renovate Operator dashboard"
+          >
+            <div className="w-1 h-5 bg-gradient-to-b from-primary to-primary-hover rounded-full" aria-hidden="true"></div>
+            <span className="text-sm font-bold text-gray-900 dark:text-slate-100 whitespace-nowrap">
+              Renovate Operator
+            </span>
+          </a>
+
+          <nav
+            aria-label="Documentation"
+            className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-gray-500 dark:text-slate-400"
+          >
+            {FOOTER_DOC_LINKS.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 hover:text-primary transition-colors whitespace-nowrap"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={link.icon} />
+                </svg>
+                {link.label}
+              </a>
+            ))}
+          </nav>
+
+          <nav aria-label="Project" className="ml-auto flex items-center gap-1">
+            {FOOTER_PROJECT_LINKS.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={link.label}
+                aria-label={link.label}
+                className="p-1.5 rounded-lg text-gray-400 dark:text-slate-500 hover:text-primary hover:bg-gray-100 dark:hover:bg-slate-700 transition-colors"
+              >
+                {link.fill ? (
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path fillRule="evenodd" clipRule="evenodd" d={link.icon} />
+                  </svg>
+                ) : (
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={link.icon} />
+                  </svg>
+                )}
+              </a>
+            ))}
+          </nav>
+        </div>
       </div>
     </footer>
   );

--- a/src/static/components/SetupGuide.js
+++ b/src/static/components/SetupGuide.js
@@ -1,0 +1,542 @@
+// First-run setup guide rendered by the dashboard while /api/v1/setup/status
+// reports an incomplete install. The backend owns the step states; this
+// component owns the copy and the copy-paste YAML for each step. It never
+// writes to the cluster — the admin applies the generated manifests with
+// kubectl, and the 30s dashboard poll ticks the steps off as the cluster
+// state changes.
+//
+// The sub-components live at module scope: defining them inside SetupGuide
+// would mint a new component type per render, and React would then remount
+// the inputs on every keystroke and drop their focus.
+
+const SETUP_DOCS_BASE = "https://github.com/mogenius/renovate-operator/blob/main/docs";
+
+const SETUP_PROVIDERS = [
+  { key: "github", label: "GitHub (PAT)", provider: "github" },
+  { key: "github-app", label: "GitHub App", provider: "github" },
+  { key: "gitlab", label: "GitLab", provider: "gitlab" },
+  { key: "gitea", label: "Gitea", provider: "gitea" },
+  { key: "forgejo", label: "Forgejo", provider: "forgejo" },
+  { key: "bitbucket", label: "Bitbucket", provider: "bitbucket" },
+];
+
+const SETUP_HINTS = {
+  auth: {
+    title: "Secure the UI",
+    body: "The UI is currently open to everyone who can reach it. Configure OIDC or GitHub OAuth, and set authorization.defaults.adminUsers so you keep access.",
+    href: `${SETUP_DOCS_BASE}/configuration/auth.md`,
+  },
+  policy: {
+    title: "Turn on the policy engine",
+    body: "The policy engine ships disabled so a new install works out of the box. Without it, anyone who can create a RenovateJob can point tokens and webhooks at hosts of their choosing.",
+    href: `${SETUP_DOCS_BASE}/security/security.md`,
+  },
+  logStorage: {
+    title: "Keep logs after pods are cleaned up",
+    body: "Log storage is disabled, so Renovate logs disappear with their pods. Set config.logStorage.mode to memory, valkey or s3.",
+    href: `${SETUP_DOCS_BASE}/README.md`,
+  },
+};
+
+function SetupStateIcon({ state, index }) {
+  if (state === "done") {
+    return (
+      <span className="flex h-7 w-7 items-center justify-center rounded-full bg-success/15 text-success flex-shrink-0">
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+          <path
+            fillRule="evenodd"
+            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </span>
+    );
+  }
+  if (state === "blocked") {
+    return (
+      <span className="flex h-7 w-7 items-center justify-center rounded-full bg-warning/15 text-warning flex-shrink-0">
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+          <path
+            fillRule="evenodd"
+            d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </span>
+    );
+  }
+  return (
+    <span className="flex h-7 w-7 items-center justify-center rounded-full border border-gray-300 dark:border-slate-600 text-xs font-bold text-gray-500 dark:text-slate-400 flex-shrink-0">
+      {index}
+    </span>
+  );
+}
+
+function SetupYamlBlock({ id, text, copiedId, onCopy }) {
+  // "Copy kubectl" wraps the manifest in a pipe to kubectl apply, ready to
+  // paste into a terminal without saving a file first. printf with a
+  // single-quoted multiline string works in fish, bash and zsh alike — a
+  // heredoc would not (fish has none) — and the single quotes keep the shell
+  // from expanding anything inside the manifest. The generated manifests
+  // never contain a single quote (Kubernetes names cannot), so no escaping
+  // is needed.
+  const kubectlText = `printf '%s\\n' '${text}' | kubectl apply -f -`;
+  const buttonClass =
+    "px-2 py-1 text-xs font-medium rounded-md bg-gray-700/80 text-gray-200 hover:bg-gray-600 transition-colors";
+  return (
+    <div className="relative mt-3">
+      {/* pt-10 keeps the whole overlay button row in padding space, so even a
+          long first line scrolls beneath nothing. */}
+      <pre className="rounded-lg bg-gray-900 dark:bg-slate-950 text-gray-100 text-xs p-3 pt-10 overflow-x-auto font-mono leading-relaxed">
+        {text}
+      </pre>
+      <div className="absolute top-2 right-2 flex gap-1.5">
+        <button
+          type="button"
+          onClick={() => onCopy(id, text)}
+          className={buttonClass}
+          aria-label="Copy the manifest to the clipboard"
+          title="Copy the raw manifest"
+        >
+          {copiedId === id ? "Copied!" : "Copy YAML"}
+        </button>
+        <button
+          type="button"
+          onClick={() => onCopy(`${id}-kubectl`, kubectlText)}
+          className={buttonClass}
+          aria-label="Copy a ready-to-run kubectl apply command to the clipboard"
+          title="Copy as kubectl apply command"
+        >
+          {copiedId === `${id}-kubectl` ? "Copied!" : "Copy kubectl"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SetupTextInput({ label, value, onChange, width = "w-40" }) {
+  return (
+    <label className="flex flex-col gap-1 text-xs font-medium text-gray-600 dark:text-slate-300">
+      {label}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`${width} rounded-md border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-2 py-1.5 text-sm font-mono text-gray-900 dark:text-slate-100 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary`}
+      />
+    </label>
+  );
+}
+
+function SetupBlockedDetail({ detail }) {
+  if (!detail) return null;
+  return (
+    <div className="mt-3 rounded-lg bg-warning/10 border border-warning/30 px-3 py-2 text-sm text-gray-700 dark:text-slate-300 break-words">
+      {detail}
+    </div>
+  );
+}
+
+// A done step collapses to its title; the active step and blocked steps show
+// their body so the admin always sees exactly one thing to do next.
+function SetupStep({ step, index, isLast, expanded, title, doneSummary, children }) {
+  return (
+    <li className="flex gap-3">
+      <div className="flex flex-col items-center">
+        <SetupStateIcon state={step.state} index={index} />
+        {!isLast && (
+          <div className="w-px flex-1 bg-gray-200 dark:bg-slate-700 mt-1" aria-hidden="true"></div>
+        )}
+      </div>
+      <div className={`${isLast ? "pb-1" : "pb-6"} min-w-0 flex-1`}>
+        <h4
+          className={`text-sm font-semibold leading-7 ${
+            step.state === "done"
+              ? "text-gray-500 dark:text-slate-400"
+              : "text-gray-900 dark:text-slate-100"
+          }`}
+        >
+          {title}
+          {step.state === "done" && doneSummary && (
+            <span className="ml-2 font-normal text-xs text-gray-400 dark:text-slate-500">
+              {doneSummary}
+            </span>
+          )}
+        </h4>
+        {expanded && <div className="mt-1">{children}</div>}
+      </div>
+    </li>
+  );
+}
+
+function SetupGuide({ setup, jobs, onRunDiscovery, onDismiss }) {
+  const { useState, useEffect } = React;
+
+  const [providerKey, setProviderKey] = useState("github");
+  // The operator reports its own namespace, so the generated manifests land
+  // where it actually runs; the literal is only a fallback for a backend
+  // that reports none.
+  const [namespace, setNamespace] = useState(setup?.namespace || "renovate-operator");
+  const [secretName, setSecretName] = useState("renovate-secret");
+  const [jobName, setJobName] = useState("renovate");
+  const [schedule, setSchedule] = useState("0 2 * * *");
+  const [filter, setFilter] = useState("my-org/*");
+  const [copiedId, setCopiedId] = useState(null);
+  const [secretCheck, setSecretCheck] = useState(null);
+
+  const provider = SETUP_PROVIDERS.find((p) => p.key === providerKey) || SETUP_PROVIDERS[0];
+  const isGithubApp = providerKey === "github-app";
+
+  const steps = Array.isArray(setup?.steps) ? setup.steps : [];
+  const stepById = (id) => steps.find((s) => s.id === id) || { id, state: "pending" };
+  const jobsExist = Array.isArray(jobs) && jobs.length > 0;
+
+  // Before any RenovateJob exists the backend cannot verify the secret (it
+  // does not know which one is meant), but the guide does: it knows the
+  // namespace and name the admin typed. Poll for exactly that secret so
+  // applying it advances the guide to step 2 without waiting for the job.
+  // The polling deliberately keeps running while the backend still reports
+  // the step pending — even once jobs exist — because the status is served
+  // from a short cache and must not un-tick a step it already confirmed.
+  const backendCredentials = stepById("credentials");
+  const wantSecretCheck = backendCredentials.state === "pending";
+  useEffect(() => {
+    if (!wantSecretCheck || !namespace || !secretName) {
+      setSecretCheck(null);
+      return;
+    }
+    let cancelled = false;
+    const base = window.__BASE_PATH__ || "";
+    const check = () => {
+      fetch(
+        `${base}/api/v1/setup/secret?namespace=${encodeURIComponent(namespace)}&name=${encodeURIComponent(secretName)}`
+      )
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (!cancelled) setSecretCheck(data);
+        })
+        .catch(() => {});
+    };
+    // Debounced first check so typing in the fields does not fire per key,
+    // then a 10s poll so an applied secret is picked up promptly.
+    const timeout = setTimeout(check, 500);
+    const interval = setInterval(check, 10000);
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+      clearInterval(interval);
+    };
+  }, [wantSecretCheck, namespace, secretName]);
+
+  const secretKeysOk =
+    !!secretCheck?.found && (isGithubApp ? secretCheck.hasGithubAppKeys : secretCheck.hasToken);
+  const credentialsLocallyDone = wantSecretCheck && secretKeysOk;
+
+  // The job list is fetched live while the setup status is served from a
+  // short server-side cache. Right after the admin applies the RenovateJob
+  // the two disagree for up to a cache period, and without these overrides
+  // the guide would briefly reopen every step it had already ticked off.
+  const effectiveSteps = steps.map((s) => {
+    if (s.id === "credentials" && credentialsLocallyDone) {
+      return { ...s, state: "done" };
+    }
+    if (s.id === "renovatejob" && s.state === "pending" && jobsExist) {
+      return { ...s, state: "done" };
+    }
+    return s;
+  });
+
+  const doneCount = effectiveSteps.filter((s) => s.state === "done").length;
+  const activeId = (effectiveSteps.find((s) => s.state !== "done") || {}).id;
+  const stepProps = (id) => {
+    const step = effectiveSteps.find((s) => s.id === id) || { id, state: "pending" };
+    return {
+      step,
+      index: effectiveSteps.findIndex((s) => s.id === id) + 1,
+      isLast: effectiveSteps.length > 0 && effectiveSteps[effectiveSteps.length - 1].id === id,
+      expanded: step.state === "blocked" || id === activeId,
+    };
+  };
+
+  const firstJob = Array.isArray(jobs) && jobs.length > 0 ? jobs[0] : null;
+  const canRunDiscovery =
+    firstJob && Array.isArray(firstJob.permissions) && firstJob.permissions.includes("discovery");
+
+  const copyText = (id, text) => {
+    const done = () => {
+      setCopiedId(id);
+      setTimeout(() => setCopiedId((current) => (current === id ? null : current)), 2000);
+    };
+    try {
+      navigator.clipboard.writeText(text).then(done, () => {});
+    } catch {
+      // Clipboard API unavailable (plain http): the manual path still works.
+    }
+  };
+
+  const secretYaml = () => {
+    if (isGithubApp) {
+      return [
+        "apiVersion: v1",
+        "kind: Secret",
+        "metadata:",
+        `  name: ${secretName}`,
+        `  namespace: ${namespace}`,
+        "  labels:",
+        "    # Required once the policy engine is enabled: it marks this secret",
+        "    # as intentionally referenced at caller-chosen keys.",
+        '    renovate-operator.mogenius.com/allow-ref: "true"',
+        "stringData:",
+        '  APP_ID: "<your-app-id>"',
+        '  INSTALL_ID: "<your-installation-id>"',
+        "  PEM: |",
+        "    <your-private-key>",
+      ].join("\n");
+    }
+    const lines = [
+      "apiVersion: v1",
+      "kind: Secret",
+      "metadata:",
+      `  name: ${secretName}`,
+      `  namespace: ${namespace}`,
+      "stringData:",
+    ];
+    if (providerKey === "github") {
+      lines.push(
+        '  GITHUB_COM_USER: "<your-github-username>"',
+        '  GITHUB_COM_TOKEN: "<your-github-pat>"',
+        '  RENOVATE_TOKEN: "<your-github-pat>"'
+      );
+    } else {
+      lines.push(`  RENOVATE_TOKEN: "<your-${provider.provider}-token>"`);
+    }
+    return lines.join("\n");
+  };
+
+  const jobYaml = () => {
+    const lines = [
+      "apiVersion: renovate-operator.mogenius.com/v1alpha1",
+      "kind: RenovateJob",
+      "metadata:",
+      `  name: ${jobName}`,
+      `  namespace: ${namespace}`,
+      "spec:",
+      `  schedule: "${schedule}"`,
+    ];
+    if (isGithubApp) {
+      lines.push(
+        "  githubAppReference:",
+        `    secretName: ${secretName}`,
+        "    appIdSecretKey: APP_ID",
+        "    installationIdSecretKey: INSTALL_ID",
+        "    pemSecretKey: PEM"
+      );
+    } else {
+      lines.push(`  secretRef: ${secretName}`);
+    }
+    lines.push(
+      "  provider:",
+      `    name: ${provider.provider}`,
+      "  image: ghcr.io/renovatebot/renovate:latest",
+      "  parallelism: 3",
+      "  discoveryFilters:",
+      `    - "${filter}"`
+    );
+    return lines.join("\n");
+  };
+
+  const hints = Array.isArray(setup?.hints) ? setup.hints : [];
+  const openHints = hints.filter((h) => !h.done && SETUP_HINTS[h.id]);
+
+  const acceptedStep = stepById("accepted");
+  const discoveryStep = stepById("discovery");
+  // Two sources say "busy": the backend's own step detail, and the optimistic
+  // flag the click sets — the latter covers the seconds until the next status
+  // poll confirms the run, so the button never looks idle mid-launch.
+  const discoveryRunning =
+    discoveryStep.detail === "discovery is running" || !!firstJob?.discoveryRunning;
+
+  return (
+    <div
+      data-testid="setup-guide"
+      className="mb-6 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-sm overflow-hidden"
+    >
+      <div className="px-4 sm:px-6 py-4 border-b border-gray-200 dark:border-slate-700 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-bold text-gray-900 dark:text-slate-100">
+            Set up Renovate Operator
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-slate-400 mt-0.5">
+            {doneCount} of {steps.length} steps done — this guide updates itself as you apply
+            resources to the cluster.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="text-xs text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 transition-colors whitespace-nowrap"
+        >
+          Skip guide
+        </button>
+      </div>
+
+      <div className="px-4 sm:px-6 py-5 grid gap-8 lg:grid-cols-[1fr_20rem]">
+        <ol className="min-w-0">
+          <SetupStep
+            {...stepProps("credentials")}
+            title="Create a credentials Secret"
+            doneSummary={
+              !credentialsLocallyDone
+                ? "credentials verified"
+                : isGithubApp && !secretCheck?.hasAllowRefLabel
+                ? "secret found (allow-ref label missing)"
+                : "secret found"
+            }
+          >
+            <p className="text-sm text-gray-600 dark:text-slate-400">
+              The operator reads platform credentials from a Secret in the RenovateJob's
+              namespace. Pick your platform:
+            </p>
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {SETUP_PROVIDERS.map((p) => (
+                <button
+                  key={p.key}
+                  type="button"
+                  onClick={() => setProviderKey(p.key)}
+                  aria-pressed={providerKey === p.key}
+                  className={`px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
+                    providerKey === p.key
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-gray-300 dark:border-slate-600 text-gray-600 dark:text-slate-300 hover:border-primary/50"
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-3 mt-3">
+              <SetupTextInput label="Namespace" value={namespace} onChange={setNamespace} />
+              <SetupTextInput label="Secret name" value={secretName} onChange={setSecretName} />
+            </div>
+            {isGithubApp && (
+              <p className="text-xs text-gray-500 dark:text-slate-400 mt-2">
+                No GitHub App yet? Follow the{" "}
+                <a
+                  href={`${SETUP_DOCS_BASE}/platforms/github-app-setup.md`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline"
+                >
+                  GitHub App setup guide
+                </a>{" "}
+                first.
+              </p>
+            )}
+            <SetupYamlBlock id="secret-yaml" text={secretYaml()} copiedId={copiedId} onCopy={copyText} />
+            <p className="text-xs text-gray-500 dark:text-slate-400 mt-2">
+              Fill in the placeholders, then apply it — <em>Copy kubectl</em> gives you a
+              ready-to-paste <code className="font-mono">kubectl apply</code> command. Other
+              platforms and token variables:{" "}
+              <a
+                href={`${SETUP_DOCS_BASE}/platforms`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                platform guides
+              </a>
+              . The guide detects the secret automatically once it exists.
+            </p>
+            <SetupBlockedDetail
+              detail={
+                backendCredentials.detail ||
+                (wantSecretCheck && secretCheck?.found && !secretKeysOk
+                  ? isGithubApp
+                    ? `Secret "${secretName}" exists, but is missing APP_ID, INSTALL_ID or PEM.`
+                    : `Secret "${secretName}" exists, but holds no platform token (expected one of RENOVATE_TOKEN, GITHUB_COM_TOKEN, GITLAB_TOKEN, BITBUCKET_TOKEN, GITEA_TOKEN, FORGEJO_TOKEN).`
+                  : "")
+              }
+            />
+          </SetupStep>
+
+          <SetupStep {...stepProps("renovatejob")} title="Create your first RenovateJob" doneSummary="created">
+            <p className="text-sm text-gray-600 dark:text-slate-400">
+              The RenovateJob tells the operator what to discover and when to run.
+            </p>
+            <div className="flex flex-wrap gap-3 mt-3">
+              <SetupTextInput label="Job name" value={jobName} onChange={setJobName} />
+              <SetupTextInput label="Cron schedule" value={schedule} onChange={setSchedule} />
+              <SetupTextInput label="Discovery filter" value={filter} onChange={setFilter} width="w-48" />
+            </div>
+            <SetupYamlBlock id="job-yaml" text={jobYaml()} copiedId={copiedId} onCopy={copyText} />
+            <p className="text-xs text-gray-500 dark:text-slate-400 mt-2">
+              Apply it with <em>Copy kubectl</em>, or save it as{" "}
+              <code className="font-mono">renovatejob.yaml</code> for your GitOps repo. The filter
+              limits autodiscovery to your organisation — without one, every repository the token
+              can see is discovered.
+            </p>
+          </SetupStep>
+
+          <SetupStep {...stepProps("accepted")} title="Job accepted by the operator" doneSummary="accepted">
+            <p className="text-sm text-gray-600 dark:text-slate-400">
+              {acceptedStep.state === "blocked"
+                ? "The operator's policy refused the job. Fix the value named below and the operator re-checks automatically."
+                : "Checked automatically once the RenovateJob exists."}
+            </p>
+            <SetupBlockedDetail detail={acceptedStep.detail} />
+          </SetupStep>
+
+          <SetupStep
+            {...stepProps("discovery")}
+            title="Discover your repositories"
+            doneSummary={discoveryStep.detail || "done"}
+          >
+            <p className="text-sm text-gray-600 dark:text-slate-400">
+              {discoveryRunning
+                ? "Discovery is running — this step ticks off as soon as the operator reports the first repository."
+                : "Discovery runs on the next cron tick, or start it now:"}
+            </p>
+            {canRunDiscovery && (
+              <button
+                type="button"
+                onClick={() => onRunDiscovery(firstJob)}
+                disabled={discoveryRunning}
+                className="mt-3 bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all inline-flex items-center gap-1.5"
+                aria-label={discoveryRunning ? "Discovery running" : `Run discovery for ${firstJob.name}`}
+              >
+                {discoveryRunning && <Spinner />}
+                {discoveryRunning ? "Discovery running..." : "Run discovery now"}
+              </button>
+            )}
+          </SetupStep>
+        </ol>
+
+        {openHints.length > 0 && (
+          <aside className="lg:border-l lg:border-gray-200 lg:dark:border-slate-700 lg:pl-6">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-slate-400 mb-3">
+              Recommended next steps
+            </h3>
+            <ul className="space-y-4">
+              {openHints.map((hint) => (
+                <li key={hint.id} className="text-sm">
+                  <a
+                    href={SETUP_HINTS[hint.id].href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-primary hover:underline"
+                  >
+                    {SETUP_HINTS[hint.id].title}
+                  </a>
+                  <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                    {SETUP_HINTS[hint.id].body}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}
+window.SetupGuide = SetupGuide;

--- a/src/static/components/Spinner.js
+++ b/src/static/components/Spinner.js
@@ -1,0 +1,24 @@
+// The one spinner in the UI. Every button that stays disabled while an
+// operation runs — discovery, trigger, trigger-all, cancel — renders this in
+// place of its idle icon, so "busy" looks the same everywhere.
+//
+// currentColor and a caller-supplied size keep it usable inside a button
+// (w-3.5) and on a full-page loading state (w-5) alike.
+//
+// Decorative on purpose: every call site already states the busy state in
+// visible text or the button's aria-label, so announcing the spinner too
+// would read it out twice.
+function Spinner({ className = "w-3.5 h-3.5" }) {
+  return (
+    <svg
+      className={`animate-spin flex-shrink-0 ${className}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+    </svg>
+  );
+}
+window.Spinner = Spinner;

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -42,6 +42,7 @@
       window.React = React;
       window.createRoot = createRoot;
     </script>
+    <script type="text/babel" src="components/Spinner.js"></script>
     <script type="text/babel" src="components/ThemeToggle.js"></script>
     <script type="text/babel" src="components/SiteHeader.js"></script>
     <script type="text/babel" src="components/StatBadge.js"></script>
@@ -520,6 +521,19 @@
         // Set when the operator cannot enforce its access rules. It then hides
         // every job, so this is the only explanation the visitor gets.
         const [accessStatus, setAccessStatus] = useState(null);
+        // First-run setup state. The guide itself lives on /setup; the
+        // dashboard only decides whether to send the visitor there. Null
+        // until the first fetch answers, {visible: false} once an auth
+        // provider is configured. The dismissed flag is written on /setup
+        // ("Skip guide") and cleared by opening /setup again.
+        const [setupStatus, setSetupStatus] = useState(null);
+        const [setupGuideDismissed] = useState(() => {
+          try {
+            return localStorage.getItem("setupGuideDismissed") === "true";
+          } catch {
+            return false;
+          }
+        });
         const STAT_FILTER_LABELS = {
           failed: "Failed",
           scheduled: "Scheduled",
@@ -777,6 +791,13 @@
               .then((data) => setAccessStatus(data))
               .catch(() => {});
 
+            // Plain fetch on purpose: for anonymous visitors with auth enabled
+            // this answers 401, which must not bounce them to the login page.
+            fetch(BASE + "/api/v1/setup/status")
+              .then((res) => (res.ok ? res.json() : null))
+              .then((data) => { if (data) setSetupStatus(data); })
+              .catch(() => {});
+
             const response = await authFetch("/api/v1/renovatejobs");
             if (!response.ok)
               throw new Error(`HTTP ${response.status}: Failed to fetch jobs`);
@@ -1013,6 +1034,26 @@
           return () => clearInterval(interval);
         }, [loadJobs]);
 
+        // A fresh install (no jobs at all) is sent to the dedicated /setup
+        // page outright; once jobs exist the dashboard stays usable and a
+        // slim banner links back until setup is finished. The
+        // misconfiguration banner outranks both: nothing else is
+        // trustworthy in that state.
+        const setupIncomplete =
+          !!setupStatus?.visible &&
+          !setupStatus.complete &&
+          !setupGuideDismissed &&
+          !loading &&
+          !error &&
+          !accessStatus?.misconfigured;
+        const goToSetup = setupIncomplete && jobs.length === 0;
+
+        useEffect(() => {
+          if (goToSetup) {
+            window.location.replace(withBase("/setup"));
+          }
+        }, [goToSetup]);
+
         return (
           <div className="min-h-screen flex flex-col">
             <ToastContainer toasts={toasts} onRemove={removeToast} />
@@ -1188,6 +1229,37 @@
                 </div>
               )}
 
+              {accessStatus?.warning && !accessStatus?.misconfigured && (
+                <div
+                  role="alert"
+                  data-testid="access-warning"
+                  className="mb-6 rounded-lg bg-warning/10 border border-warning/30 p-4 sm:p-6"
+                >
+                  <div className="flex items-start gap-3">
+                    <svg
+                      className="w-6 h-6 text-warning flex-shrink-0"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                      aria-hidden="true"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                    <div className="min-w-0">
+                      <h3 className="text-base sm:text-lg font-semibold text-warning">
+                        Some RenovateJobs grant no one access
+                      </h3>
+                      <p className="mt-1 text-sm text-gray-700 dark:text-slate-300 break-words">
+                        {accessStatus.warning.message}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
               {loading && jobs.length === 0 && (
                 <div className="space-y-6">
                   <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-gray-200 dark:border-slate-700 shadow-sm animate-pulse">
@@ -1236,9 +1308,25 @@
                 </div>
               )}
 
+              {setupIncomplete && jobs.length > 0 && (
+                <a
+                  href={withBase("/setup")}
+                  data-testid="setup-banner"
+                  className="mb-6 flex items-center justify-between gap-3 rounded-lg border border-primary/20 bg-primary/5 dark:bg-primary/10 px-4 py-3 hover:border-primary/40 transition-colors"
+                >
+                  <p className="text-sm text-gray-700 dark:text-slate-300">
+                    Setup is not finished yet — some steps still need your attention.
+                  </p>
+                  <span className="text-sm font-semibold text-primary whitespace-nowrap">
+                    Continue setup →
+                  </span>
+                </a>
+              )}
+
               {/* The misconfiguration banner already explains an empty list, and
-                  its advice outranks the sign-in prompt this would show. */}
-              {!loading && !error && jobs.length === 0 && !accessStatus?.misconfigured && (
+                  its advice outranks the sign-in prompt this would show. A fresh
+                  install is redirected to /setup instead of seeing this. */}
+              {!loading && !error && jobs.length === 0 && !accessStatus?.misconfigured && !goToSetup && (
                 <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg p-6 text-center">
                   <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-2">
                     No RenovateJobs visible
@@ -1313,7 +1401,11 @@
                     />
                   ))}
 
-                  {searchFilteredJobs.length === 0 && !loading && !error && (
+                  {/* Only when a filter or search hid existing jobs: a genuinely
+                      empty install is covered by the setup guide or the empty
+                      state above, and this card would just repeat them. */}
+                  {searchFilteredJobs.length === 0 && !loading && !error &&
+                    (jobs.length > 0 || searchTerm.trim() || selectedStatFilter) && (
                     <div className="text-center py-12 bg-white dark:bg-slate-800 rounded-lg border border-gray-200 dark:border-slate-700 shadow-sm">
                       <svg
                         className="w-16 h-16 text-gray-400 mx-auto mb-4"
@@ -1691,9 +1783,10 @@
               onClick={onCancel}
               disabled={isCancelling || !canCancel}
               title={canCancel ? undefined : hint}
-              className={`bg-error hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all ${width || ""}`}
+              className={`bg-error hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-1.5 rounded-lg font-semibold text-[0.813rem] shadow-sm hover:shadow-md transition-all inline-flex items-center justify-center gap-1.5 ${width || ""}`}
               aria-label={isCancelling ? "Cancelling renovate" : `Cancel renovate for ${project.name}`}
             >
+              {isCancelling && <Spinner />}
               <span>{isCancelling ? "Cancelling..." : "Cancel"}</span>
             </button>
           );
@@ -1721,7 +1814,7 @@
               onClick={onTrigger}
               disabled={isTriggering || isPrioritized || !!blocked}
               title={blocked}
-              className="flex-1 bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-1.5 font-semibold text-[0.813rem] transition-all"
+              className="flex-1 bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-white px-3 py-1.5 font-semibold text-[0.813rem] transition-all inline-flex items-center justify-center gap-1.5"
               aria-label={
                 blocked
                   ? blocked
@@ -1734,6 +1827,7 @@
                   : `Trigger renovate for ${project.name}`
               }
             >
+              {isTriggering && <Spinner />}
               {label}
             </button>
             <button
@@ -1829,6 +1923,38 @@
             <title>{logo.label}</title>
             <path d={logo.path} />
           </svg>
+        );
+      }
+
+      const getBadgeClass = (status) => {
+        const base =
+          "inline-flex items-center rounded-full px-3 py-1 text-sm font-medium whitespace-nowrap";
+        switch (status) {
+          case "scheduled":
+            return `${base} bg-warning/10 text-warning`;
+          case "running":
+            return `${base} bg-primary/10 text-primary`;
+          case "completed":
+            return `${base} bg-success/10 text-success`;
+          case "failed":
+            return `${base} bg-error/10 text-error`;
+          case "cancelled":
+            return `${base} bg-gray-200 text-gray-600 dark:bg-slate-700 dark:text-slate-300`;
+          default:
+            return `${base} bg-primary/10 text-primary`;
+        }
+      };
+
+      // A running project spins in its own status cell, so a long run reads as
+      // work in flight instead of a row stuck on "running". Every other state
+      // is static, so the badge stays a plain label there.
+      function StatusBadge({ status, className = "" }) {
+        const isRunning = (status || "").toLowerCase() === "running";
+        return (
+          <span className={`${getBadgeClass(status)} ${className}`.trim()}>
+            {isRunning && <Spinner className="w-3 h-3 mr-1.5" />}
+            {status || "-"}
+          </span>
         );
       }
 
@@ -1950,25 +2076,6 @@
         const [showOptions, setShowOptions] = useState(false);
         const [optionsPos, setOptionsPos] = useState({ top: 0, right: 0 });
         const optionsBtnRef = useRef(null);
-
-        const getBadgeClass = (status) => {
-          const base =
-            "inline-flex items-center rounded-full px-3 py-1 text-sm font-medium whitespace-nowrap";
-          switch (status) {
-            case "scheduled":
-              return `${base} bg-warning/10 text-warning`;
-            case "running":
-              return `${base} bg-primary/10 text-primary`;
-            case "completed":
-              return `${base} bg-success/10 text-success`;
-            case "failed":
-              return `${base} bg-error/10 text-error`;
-            case "cancelled":
-              return `${base} bg-gray-200 text-gray-600 dark:bg-slate-700 dark:text-slate-300`;
-            default:
-              return `${base} bg-primary/10 text-primary`;
-          }
-        };
 
         const handleSort = (key) => {
           let direction = "asc";
@@ -2194,19 +2301,21 @@
                         : `Run discovery for ${job.name}`
                   }
                 >
-                  <svg
-                    className={`w-3.5 h-3.5 flex-shrink-0 ${
-                      job.discoveryRunning ? "animate-spin" : ""
-                    }`}
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
+                  {job.discoveryRunning ? (
+                    <Spinner />
+                  ) : (
+                    <svg
+                      className="w-3.5 h-3.5 flex-shrink-0"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  )}
                   <span className="hidden sm:inline">
                     {job.discoveryRunning ? "Running..." : "Run Discovery"}
                   </span>
@@ -2229,19 +2338,21 @@
                           : `Trigger all projects for ${job.name}`
                     }
                   >
-                    <svg
-                      className={`w-3.5 h-3.5 flex-shrink-0 ${
-                        job.triggeringAll ? "animate-spin" : ""
-                      }`}
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
+                    {job.triggeringAll ? (
+                      <Spinner />
+                    ) : (
+                      <svg
+                        className="w-3.5 h-3.5 flex-shrink-0"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    )}
                     <span className="hidden sm:inline">
                       {job.triggeringAll ? "Triggering..." : "Trigger All"}
                     </span>
@@ -2429,9 +2540,7 @@
                               </div>
                             </td>
                             <td className="px-3 xl:px-6 py-3">
-                              <span className={getBadgeClass(project.status)}>
-                                {project.status || "-"}
-                              </span>
+                              <StatusBadge status={project.status} />
                             </td>
                             <td className="px-3 xl:px-6 py-3" data-no-tooltip="true">
                               <PRActivityBadges
@@ -2592,11 +2701,7 @@
                               </p>
                             )}
                           </div>
-                          <span
-                            className={`ml-2 ${getBadgeClass(project.status)}`}
-                          >
-                            {project.status || "-"}
-                          </span>
+                          <StatusBadge status={project.status} className="ml-2" />
                         </div>
                         {/* PR Activity section */}
                         {project.prActivity?.prs?.length > 0 && (

--- a/src/static/pages/logs.html
+++ b/src/static/pages/logs.html
@@ -33,6 +33,7 @@
     window.React = React;
     window.createRoot = createRoot;
   </script>
+  <script type="text/babel" src="components/Spinner.js"></script>
   <script type="text/babel" src="components/ThemeToggle.js"></script>
   <script type="text/babel" src="components/SiteHeader.js"></script>
   <script type="text/babel" src="components/StatBadge.js"></script>
@@ -471,10 +472,7 @@
 
             {loading && (
               <div className="flex items-center justify-center py-16 text-gray-500 dark:text-slate-400">
-                <svg className="animate-spin w-5 h-5 mr-2" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-                </svg>
+                <Spinner className="w-5 h-5 mr-2" />
                 Loading logs…
               </div>
             )}

--- a/src/static/pages/setup.html
+++ b/src/static/pages/setup.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Setup - Renovate Operator</title>
+  <link rel="icon" type="image/png" sizes="16x16" href="assets/favicon-small.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon.png" />
+
+  <script src="js/tailwind.min.js"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            primary: "#009bc5",
+            "primary-hover": "#00556c",
+            success: "#00c567",
+            error: "#c22828",
+            warning: "#ff8c1a",
+          },
+        },
+      },
+    };
+  </script>
+  <script src="js/theme-utils.js"></script>
+  <script src="js/babel.min.js"></script>
+  <script src="js/babel-config.js"></script>
+  <script type="module">
+    import { React, createRoot } from './js/react-bundle.esm.js';
+    window.React = React;
+    window.createRoot = createRoot;
+  </script>
+  <script type="text/babel" src="components/Spinner.js"></script>
+  <script type="text/babel" src="components/ThemeToggle.js"></script>
+  <script type="text/babel" src="components/SiteHeader.js"></script>
+  <script type="text/babel" src="components/Footer.js"></script>
+  <script type="text/babel" src="components/SetupGuide.js"></script>
+
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+
+<body class="bg-gray-50 dark:bg-slate-900 text-gray-900 dark:text-slate-100 transition-colors duration-200">
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+
+    const BASE = window.__BASE_PATH__ || "";
+
+    // How long the button trusts its own click over the operator's reported
+    // discovery status — a few poll cycles, so a slow start still spins.
+    const OPTIMISTIC_DISCOVERY_MS = 60000;
+
+    // The dedicated setup page: header, the guide, footer — none of the
+    // dashboard's stat toolbar. The dashboard redirects fresh installs here
+    // and links back while setup is unfinished; once /api/v1/setup/status
+    // reports the guide unavailable or complete, this page returns to the
+    // dashboard.
+    function App() {
+      const [version, setVersion] = useState(null);
+      const [authInfo, setAuthInfo] = useState(null);
+      const [setup, setSetup] = useState(null);
+      const [jobs, setJobs] = useState([]);
+
+      useEffect(() => {
+        // Opening /setup deliberately re-enables a hidden guide: the dashboard
+        // never links here while dismissed, so this cannot loop.
+        try { localStorage.removeItem("setupGuideDismissed"); } catch {}
+
+        fetch(BASE + "/api/v1/version")
+          .then((r) => (r.ok ? r.json() : null))
+          .then((d) => d && setVersion(d.version))
+          .catch(() => {});
+
+        fetch(BASE + "/api/v1/auth/status")
+          .then((r) => (r.ok ? r.json() : null))
+          .then((d) => d && setAuthInfo(d))
+          .catch(() => {});
+      }, []);
+
+      useEffect(() => {
+        const load = () => {
+          fetch(BASE + "/api/v1/setup/status")
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+              // Unavailable (auth configured): this page has no purpose,
+              // hand over to the dashboard. A completed setup stays here
+              // and celebrates instead — the success card below ends the
+              // guide with a click.
+              if (!data || !data.visible) {
+                window.location.replace(BASE + "/");
+                return;
+              }
+              setSetup(data);
+            })
+            .catch(() => {});
+
+          fetch(BASE + "/api/v1/renovatejobs")
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => {
+              if (Array.isArray(data)) {
+                setJobs((prev) =>
+                  data.map((job) => {
+                    const existing = prev.find(
+                      (p) => p.name === job.name && p.namespace === job.namespace
+                    );
+                    // The click's optimistic flag bridges the gap until the
+                    // operator reports the discovery job as running, but it
+                    // expires: a discovery that never starts, or one that
+                    // fails without ever being seen as running, must give
+                    // the button back instead of spinning forever.
+                    const startedAt = existing?.discoveryStartedAt || 0;
+                    const awaitingStart =
+                      !!existing?.discoveryRunning &&
+                      Date.now() - startedAt < OPTIMISTIC_DISCOVERY_MS;
+                    return {
+                      ...job,
+                      discoveryStartedAt: startedAt || undefined,
+                      discoveryRunning: job.discoveryStatus === "running" || awaitingStart,
+                    };
+                  })
+                );
+              }
+            })
+            .catch(() => {});
+        };
+
+        load();
+        const interval = setInterval(load, 10000);
+        return () => clearInterval(interval);
+      }, []);
+
+      const runDiscovery = async (job) => {
+        if (job.discoveryRunning) return;
+        setJobs((prev) =>
+          prev.map((j) =>
+            j.name === job.name && j.namespace === job.namespace
+              ? { ...j, discoveryRunning: true, discoveryStartedAt: Date.now() }
+              : j
+          )
+        );
+        try {
+          const response = await fetch(BASE + "/api/v1/discovery/start", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ renovateJob: job.name, namespace: job.namespace }),
+          });
+          if (!response.ok) throw new Error(await response.text());
+        } catch (err) {
+          console.error("Error running discovery:", err);
+          setJobs((prev) =>
+            prev.map((j) =>
+              j.name === job.name && j.namespace === job.namespace
+                ? { ...j, discoveryRunning: false }
+                : j
+            )
+          );
+        }
+      };
+
+      const dismiss = () => {
+        try { localStorage.setItem("setupGuideDismissed", "true"); } catch {}
+        window.location.href = BASE + "/";
+      };
+
+      return (
+        <div className="min-h-screen flex flex-col">
+          <SiteHeader version={version} authInfo={authInfo} />
+
+          <main className="flex-1 max-w-5xl mx-auto w-full px-3 sm:px-6 lg:px-8 pt-4 sm:pt-6 pb-6 sm:pb-8">
+            {setup && setup.complete ? (
+              <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-sm px-6 py-12 text-center">
+                <span className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-success/15 text-success">
+                  <svg className="w-9 h-9" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                </span>
+                <h2 className="mt-5 text-2xl font-bold text-gray-900 dark:text-slate-100">
+                  Setup complete!
+                </h2>
+                <p className="mt-2 text-sm text-gray-600 dark:text-slate-400 max-w-md mx-auto">
+                  Your repositories are discovered and their first Renovate runs are on the
+                  way. The operator now runs on its schedule — follow every project, run and
+                  pull request on the dashboard.
+                </p>
+                <a
+                  href={`${BASE}/`}
+                  className="mt-6 inline-block bg-primary hover:bg-primary-hover text-white px-5 py-2.5 rounded-lg font-semibold text-sm shadow-sm hover:shadow-md transition-all"
+                >
+                  Open the dashboard
+                </a>
+              </div>
+            ) : setup ? (
+              <SetupGuide setup={setup} jobs={jobs} onRunDiscovery={runDiscovery} onDismiss={dismiss} />
+            ) : (
+              <div className="bg-white dark:bg-slate-800 rounded-lg p-6 border border-gray-200 dark:border-slate-700 shadow-sm animate-pulse">
+                <div className="h-8 w-1/3 bg-gray-200 dark:bg-slate-700 rounded-lg mb-4"></div>
+                <div className="flex flex-col gap-3">
+                  <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded"></div>
+                  <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded"></div>
+                  <div className="h-4 w-2/3 bg-gray-200 dark:bg-slate-700 rounded"></div>
+                </div>
+              </div>
+            )}
+          </main>
+
+          <Footer />
+        </div>
+      );
+    }
+
+    window.createRoot(document.getElementById("root")).render(<App />);
+  </script>
+</body>
+
+</html>

--- a/src/ui/access.go
+++ b/src/ui/access.go
@@ -158,6 +158,46 @@ func detectAccessMisconfiguration(provider AuthProvider, defaults AccessDefaults
 	}, jobsWithGroups
 }
 
+// ReasonNoAccessRules marks RenovateJobs that no request can ever see: they
+// configure no access rules of their own and the operator-wide defaults grant
+// nothing either. Unlike ReasonGroupsUnsupported this is not unenforceable —
+// the rules are enforced exactly as written — so it is served as a warning
+// and hides nothing beyond what the rules already hide.
+const ReasonNoAccessRules = "NoAccessRules"
+
+const noAccessRulesMessage = "At least one RenovateJob is not visible to anyone: it sets no access rules itself " +
+	"and the operator-wide authorization defaults grant no access either. " +
+	"Set authorization.defaults.adminUsers or adminGroups (AUTHORIZATION_DEFAULT_ADMIN_USERS / AUTHORIZATION_DEFAULT_ADMIN_GROUPS), " +
+	"or add spec.access to the RenovateJob. See the operator logs for the affected RenovateJobs."
+
+// detectLockedOutJobs reports jobs whose effective access configuration grants
+// no user, no group and no anonymous visitor anything — the state
+// docs/configuration/auth.md warns turns the dashboard silently empty.
+func detectLockedOutJobs(provider AuthProvider, defaults AccessDefaults, jobs []api.RenovateJob) (m *AccessMisconfiguration, lockedJobs []string) {
+	// Without a provider everyone is an admin; with authorization disabled any
+	// session is. Either way nothing is locked out.
+	if provider == nil || defaults.AuthorizationDisabled {
+		return nil, nil
+	}
+
+	for i := range jobs {
+		eff := resolveEffectiveAccess(&jobs[i], defaults)
+		if len(eff.adminUsers) == 0 && len(eff.adminGroups) == 0 &&
+			len(eff.readerUsers) == 0 && len(eff.readerGroups) == 0 &&
+			!eff.anonymousRead {
+			lockedJobs = append(lockedJobs, jobs[i].Namespace+"/"+jobs[i].Name)
+		}
+	}
+
+	if len(lockedJobs) == 0 {
+		return nil, nil
+	}
+	return &AccessMisconfiguration{
+		Reason:  ReasonNoAccessRules,
+		Message: noAccessRulesMessage,
+	}, lockedJobs
+}
+
 func jobConfiguresGroups(job *api.RenovateJob) bool {
 	if len(job.Spec.AllowedGroups) > 0 { //nolint:staticcheck // deprecated field is intentionally still honoured
 		return true

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -33,12 +33,12 @@ type RenovateJobInfo struct {
 	// Accepted is false when the operator's policy refuses this job, in which case
 	// nothing runs for it and AcceptedMessage says what to fix. Jobs reconciled by an
 	// older operator have no condition yet and are reported as accepted.
-	Accepted        bool     `json:"accepted"`
-	AcceptedMessage string   `json:"acceptedMessage,omitempty"`
-	Role              string   `json:"role,omitempty"`
-	Permissions       []string `json:"permissions"`
-	DiscoveryFilters  []string `json:"discoveryFilters,omitempty"`
-	DiscoverTopics    []string `json:"discoverTopics,omitempty"`
+	Accepted         bool     `json:"accepted"`
+	AcceptedMessage  string   `json:"acceptedMessage,omitempty"`
+	Role             string   `json:"role,omitempty"`
+	Permissions      []string `json:"permissions"`
+	DiscoveryFilters []string `json:"discoveryFilters,omitempty"`
+	DiscoverTopics   []string `json:"discoverTopics,omitempty"`
 }
 
 func (s *Server) decideJobAccess(r *http.Request, job *api.RenovateJob) accessDecision {
@@ -219,6 +219,8 @@ func (s *Server) registerApiV1Routes(router *mux.Router) {
 	apiV1.Use(telemetry.MuxMiddleware("renovate-operator-ui-api-v1"))
 	apiV1.HandleFunc("/version", s.getVersion).Methods("GET")
 	apiV1.HandleFunc("/access/status", s.getAccessStatus).Methods("GET")
+	apiV1.HandleFunc("/setup/status", s.getSetupStatus).Methods("GET")
+	apiV1.HandleFunc("/setup/secret", s.getSetupSecretCheck).Methods("GET")
 	apiV1.HandleFunc("/renovatejobs", s.getRenovateJobs).Methods("GET")
 	apiV1.HandleFunc("/renovate", s.runRenovateForProject).Methods("POST")
 	apiV1.HandleFunc("/renovate/all", s.runRenovateForAllProjects).Methods("POST")
@@ -237,22 +239,57 @@ func (s *Server) getVersion(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// getAccessStatus reports whether the operator can enforce its access rules.
+// getAccessStatus reports whether the operator can enforce its access rules,
+// and warns when jobs exist that the rules hide from absolutely everyone.
 func (s *Server) getAccessStatus(w http.ResponseWriter, r *http.Request) {
 	result := struct {
-		Misconfigured bool   `json:"misconfigured"`
-		Reason        string `json:"reason,omitempty"`
-		Message       string `json:"message,omitempty"`
+		Misconfigured bool                    `json:"misconfigured"`
+		Reason        string                  `json:"reason,omitempty"`
+		Message       string                  `json:"message,omitempty"`
+		Warning       *AccessMisconfiguration `json:"warning,omitempty"`
 	}{}
 
 	if misconfiguration := s.accessEnforceable(r.Context()); misconfiguration != nil {
 		result.Misconfigured = true
 		result.Reason = misconfiguration.Reason
 		result.Message = misconfiguration.Message
+	} else {
+		result.Warning = s.lockedOutJobsWarning(r.Context())
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result)
+}
+
+// lockedOutJobsWarning checks for jobs no one can see, cached like the
+// misconfiguration verdict because this endpoint is public and polled.
+func (s *Server) lockedOutJobsWarning(ctx context.Context) *AccessMisconfiguration {
+	if s.auth == nil || s.accessDefaults.AuthorizationDisabled {
+		return nil
+	}
+
+	if verdict, ok := s.lockoutCheck.load(); ok {
+		return verdict
+	}
+
+	jobs, err := s.manager.ListRenovateJobsFull(ctx)
+	if err != nil {
+		// No list, no verdict — an API blip must not fabricate or clear a warning.
+		s.logger.Error(err, "failed to list renovatejobs to check for locked-out jobs, continuing")
+		return nil
+	}
+
+	verdict, lockedJobs := detectLockedOutJobs(s.auth, s.accessDefaults, jobs)
+	if s.lockoutCheck.store(verdict) {
+		if verdict != nil {
+			s.logger.Error(nil, "RenovateJobs exist that grant no one access",
+				"reason", verdict.Reason,
+				"lockedJobs", lockedJobs)
+		} else {
+			s.logger.Info("every RenovateJob grants someone access again")
+		}
+	}
+	return verdict
 }
 
 func (s *Server) getRenovateJobs(w http.ResponseWriter, r *http.Request) {

--- a/src/ui/server.go
+++ b/src/ui/server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync/atomic"
 
 	"renovate-operator/assert"
 	"renovate-operator/config"
@@ -28,10 +29,17 @@ type Server struct {
 	auth           AuthProvider
 	accessDefaults AccessDefaults
 	accessCheck    accessCheckCache
-	Router         *mux.Router
+	lockoutCheck   accessCheckCache
+	setup          SetupEnvironment
+	setupCheck     setupStatusCache
+	// setupComplete latches once every setup step is done, so the steady
+	// state stops checking projects and secrets for a guide nobody sees.
+	// It resets when the last RenovateJob is deleted (starting over).
+	setupComplete atomic.Bool
+	Router        *mux.Router
 }
 
-func NewServer(manager crdmanager.RenovateJobManager, discovery renovate.DiscoveryAgent, scheduler scheduler.Scheduler, logger logr.Logger, health health.HealthCheck, version string, auth AuthProvider, accessDefaults AccessDefaults) *Server {
+func NewServer(manager crdmanager.RenovateJobManager, discovery renovate.DiscoveryAgent, scheduler scheduler.Scheduler, logger logr.Logger, health health.HealthCheck, version string, auth AuthProvider, accessDefaults AccessDefaults, setup SetupEnvironment) *Server {
 	return &Server{
 		manager:        manager,
 		logger:         logger,
@@ -41,6 +49,7 @@ func NewServer(manager crdmanager.RenovateJobManager, discovery renovate.Discove
 		version:        version,
 		auth:           auth,
 		accessDefaults: accessDefaults,
+		setup:          setup,
 		Router:         mux.NewRouter(),
 	}
 }

--- a/src/ui/setup.go
+++ b/src/ui/setup.go
@@ -1,0 +1,430 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	api "renovate-operator/api/v1alpha1"
+	gitProviderClientFactory "renovate-operator/gitProviderClients/factory"
+	crdmanager "renovate-operator/internal/crdManager"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SetupEnvironment carries the install-wide facts the setup guide reports.
+// The booleans are fixed at startup. SecretReader is used to verify the
+// credential secrets RenovateJobs reference and may be nil, which skips that
+// verification; the reads are live because main.go disables the informer
+// cache for Secrets.
+type SetupEnvironment struct {
+	PolicyEnabled        bool
+	LogStorageConfigured bool
+	// OwnNamespace is the operator's own namespace (POD_NAMESPACE). The guide
+	// prefills it and the secret probe is limited to it, so the probe cannot
+	// be pointed at arbitrary namespaces.
+	OwnNamespace string
+	SecretReader client.Reader
+}
+
+// Setup step states. "blocked" means the operator found the step attempted but
+// broken (missing secret, refused job), which outranks "pending" (not started).
+const (
+	setupStateDone    = "done"
+	setupStatePending = "pending"
+	setupStateBlocked = "blocked"
+)
+
+// Step and hint IDs are the contract with the frontend, which owns the copy
+// for each of them. Details carry the dynamic part (names, refusal reasons).
+type SetupStep struct {
+	ID     string `json:"id"`
+	State  string `json:"state"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// SetupHint marks an optional subsystem the admin should consider next.
+type SetupHint struct {
+	ID   string `json:"id"`
+	Done bool   `json:"done"`
+}
+
+// SetupStatus is the response of /api/v1/setup/status. Visible is false when
+// the guide is disabled (an auth provider is configured) or the state cannot
+// be computed, in which case every other field is empty so nothing about the
+// install leaks.
+type SetupStatus struct {
+	Visible  bool        `json:"visible"`
+	Complete bool        `json:"complete"`
+	Steps    []SetupStep `json:"steps,omitempty"`
+	Hints    []SetupHint `json:"hints,omitempty"`
+	// Namespace is the operator's own namespace, which the guide prefills as
+	// the target for its generated manifests — a guessed default would send
+	// them to a namespace the operator may not even watch.
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// setupStatusCache reuses the accessCheckTTL trade-off: the dashboard polls,
+// and computing the status lists every RenovateJob, its projects and its
+// credential secrets.
+type setupStatusCache struct {
+	mu       sync.Mutex
+	status   *SetupStatus
+	computed time.Time
+}
+
+func (c *setupStatusCache) load() (*SetupStatus, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.computed.IsZero() || time.Since(c.computed) > accessCheckTTL {
+		return nil, false
+	}
+	return c.status, true
+}
+
+func (c *setupStatusCache) store(status *SetupStatus) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.status = status
+	c.computed = time.Now()
+}
+
+// setupGuideAvailable reports whether the setup guide exists on this install
+// at all. It is a first-run aid: an install with a configured auth provider
+// is past first-run setup, so the guide (and its secret probing) is disabled
+// entirely rather than gated per session. Without a provider every request
+// is an admin anyway, matching decideJobAccess.
+func (s *Server) setupGuideAvailable() bool {
+	return s.auth == nil
+}
+
+// getSetupStatus serves the first-run checklist. When the guide is disabled
+// the response is {"visible": false} rather than an error so the frontend
+// can probe it unconditionally.
+func (s *Server) getSetupStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if !s.setupGuideAvailable() {
+		_ = json.NewEncoder(w).Encode(SetupStatus{})
+		return
+	}
+
+	status := s.setupStatus(r.Context())
+	_ = json.NewEncoder(w).Encode(&status)
+}
+
+// setupStatus returns the current status, computing it when the cache is cold
+// so callers other than the status endpoint can depend on it too.
+func (s *Server) setupStatus(ctx context.Context) SetupStatus {
+	if cached, ok := s.setupCheck.load(); ok && cached != nil {
+		return *cached
+	}
+	status := s.computeSetupStatus(ctx)
+	s.setupCheck.store(&status)
+	return status
+}
+
+// getSetupSecretCheck reports whether the secret the setup guide's first step
+// generates exists yet and holds usable keys, so the guide can advance before
+// any RenovateJob references it. Only booleans leave the server, never secret
+// values, and only for as long as the guide is actually on screen: an auth
+// provider, a finished setup or an unreadable state all answer 404. A
+// finished first run closes the endpoint for the life of the install — it
+// must not linger as a secret existence oracle once nothing consults it.
+func (s *Server) getSetupSecretCheck(w http.ResponseWriter, r *http.Request) {
+	if !s.setupGuideAvailable() {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	// Visible and unfinished is exactly the window the guide polls in. An
+	// unreadable state reports neither, and closes the probe with it.
+	if status := s.setupStatus(r.Context()); !status.Visible || status.Complete {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	namespace := r.URL.Query().Get("namespace")
+	name := r.URL.Query().Get("name")
+	if namespace == "" || name == "" {
+		badRequestError(w, nil, "missing parameters")
+		return
+	}
+
+	if !s.setupSecretNamespaceAllowed(r.Context(), namespace) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	result := struct {
+		Found bool `json:"found"`
+		// HasToken: a value at one of Renovate's well-known token keys.
+		HasToken bool `json:"hasToken"`
+		// HasGithubAppKeys: the key names the guide's GitHub App template uses.
+		HasGithubAppKeys bool `json:"hasGithubAppKeys"`
+		HasAllowRefLabel bool `json:"hasAllowRefLabel"`
+	}{}
+
+	if s.setup.SecretReader != nil {
+		secret := &corev1.Secret{}
+		if err := s.setup.SecretReader.Get(r.Context(), client.ObjectKey{Name: name, Namespace: namespace}, secret); err == nil {
+			result.Found = true
+			for _, key := range gitProviderClientFactory.WellKnownTokenKeys {
+				if len(secret.Data[key]) > 0 {
+					result.HasToken = true
+					break
+				}
+			}
+			result.HasGithubAppKeys = len(secret.Data["APP_ID"]) > 0 &&
+				len(secret.Data["INSTALL_ID"]) > 0 &&
+				len(secret.Data["PEM"]) > 0
+			result.HasAllowRefLabel = secret.Labels[api.LabelAllowRef] == "true"
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}
+
+// setupSecretNamespaceAllowed limits the probe to the namespaces the guide has
+// a reason to look in: the operator's own, and any that already holds a
+// RenovateJob. This endpoint answers without a session (it only exists while
+// no auth provider is configured) and the operator's ClusterRole can read
+// secrets in every namespace, so an unrestricted namespace parameter would
+// turn it into a cluster-wide "does secret X exist" oracle. Names outside
+// those namespaces answer 404 — indistinguishable from a disabled guide.
+func (s *Server) setupSecretNamespaceAllowed(ctx context.Context, namespace string) bool {
+	if s.setup.OwnNamespace != "" && namespace == s.setup.OwnNamespace {
+		return true
+	}
+
+	jobs, err := s.manager.ListRenovateJobsFull(ctx)
+	if err != nil {
+		s.logger.Error(err, "failed to list renovatejobs to check the setup secret namespace")
+		return false
+	}
+	for i := range jobs {
+		if jobs[i].Namespace == namespace {
+			return true
+		}
+	}
+
+	if s.setup.OwnNamespace == "" {
+		// Neither POD_NAMESPACE nor a service account namespace: the operator
+		// does not run as a pod, so there is no own namespace to compare
+		// against and the check stays closed rather than opening up.
+		s.logger.Info("the setup guide's secret check is disabled: the operator's own namespace is unknown "+
+			"(no POD_NAMESPACE and no service account namespace — set POD_NAMESPACE for a local run)",
+			"namespace", namespace)
+		return false
+	}
+
+	s.logger.Info("setup guide asked about a secret outside the operator's namespace, refused",
+		"namespace", namespace, "ownNamespace", s.setup.OwnNamespace)
+	return false
+}
+
+func (s *Server) computeSetupStatus(ctx context.Context) SetupStatus {
+	jobs, err := s.manager.ListRenovateJobsFull(ctx)
+	if err != nil {
+		// Without the list every claim below would be a guess. Hide the guide
+		// for this cache period; the dashboard's own job fetch surfaces the error.
+		s.logger.Error(err, "failed to list renovatejobs for setup status")
+		return SetupStatus{}
+	}
+
+	// A finished setup stays finished while any job exists: the guide is
+	// hidden then, so checking every project and credential secret per cache
+	// period would be pure overhead on the steady state. Deleting every job
+	// is the admin starting over, and resets the latch.
+	if s.setupComplete.Load() {
+		if len(jobs) > 0 {
+			return SetupStatus{Visible: true, Complete: true, Hints: s.setupHints(), Namespace: s.setup.OwnNamespace}
+		}
+		s.setupComplete.Store(false)
+	}
+
+	credentialsStep := SetupStep{ID: "credentials", State: setupStatePending}
+	jobStep := SetupStep{ID: "renovatejob", State: setupStatePending}
+	acceptedStep := SetupStep{ID: "accepted", State: setupStatePending}
+	discoveryStep := SetupStep{ID: "discovery", State: setupStatePending}
+
+	if len(jobs) > 0 {
+		jobStep.State = setupStateDone
+		credentialsStep = s.credentialsSetupStep(ctx, jobs)
+		acceptedStep = acceptedSetupStep(jobs)
+		discoveryStep = s.discoverySetupStep(ctx, jobs)
+	}
+
+	// Discovery succeeding is the proof the guide is after: credentials work,
+	// the job is accepted and repositories are found. The runs themselves are
+	// the dashboard's business, so they are deliberately not a setup step.
+	steps := []SetupStep{credentialsStep, jobStep, acceptedStep, discoveryStep}
+
+	complete := true
+	for _, step := range steps {
+		if step.State != setupStateDone {
+			complete = false
+			break
+		}
+	}
+	if complete {
+		s.setupComplete.Store(true)
+	}
+
+	return SetupStatus{
+		Visible:   true,
+		Complete:  complete,
+		Steps:     steps,
+		Hints:     s.setupHints(),
+		Namespace: s.setup.OwnNamespace,
+	}
+}
+
+func (s *Server) setupHints() []SetupHint {
+	return []SetupHint{
+		{ID: "auth", Done: s.auth != nil},
+		{ID: "policy", Done: s.setup.PolicyEnabled},
+		{ID: "logStorage", Done: s.setup.LogStorageConfigured},
+	}
+}
+
+// credentialsSetupStep verifies each job's credential reference: the reference
+// exists, the secret exists, and it holds a token at a key Renovate reads.
+// Verification needs a job that references the secret, so with no problems and
+// at least one verified job the step is done.
+func (s *Server) credentialsSetupStep(ctx context.Context, jobs []api.RenovateJob) SetupStep {
+	var problems []string
+
+	for i := range jobs {
+		job := &jobs[i]
+		name := job.Namespace + "/" + job.Name
+
+		switch {
+		case job.Spec.GithubAppReference != nil:
+			if problem := s.checkGithubAppSecret(ctx, job); problem != "" {
+				problems = append(problems, name+": "+problem)
+			}
+		case job.Spec.SecretRef != "":
+			if problem := s.checkCredentialSecret(ctx, job); problem != "" {
+				problems = append(problems, name+": "+problem)
+			}
+		default:
+			problems = append(problems, name+": references no credentials (set spec.secretRef or spec.githubAppReference)")
+		}
+	}
+
+	if len(problems) > 0 {
+		// The detail is rendered to the admin; keep it short when many jobs
+		// share the same misconfiguration.
+		const maxProblems = 3
+		if len(problems) > maxProblems {
+			problems = append(problems[:maxProblems], fmt.Sprintf("and %d more", len(problems)-maxProblems))
+		}
+		return SetupStep{ID: "credentials", State: setupStateBlocked, Detail: strings.Join(problems, "; ")}
+	}
+
+	return SetupStep{ID: "credentials", State: setupStateDone}
+}
+
+// checkCredentialSecret reports why a job's spec.secretRef is unusable, or ""
+// when it looks fine. A nil SecretReader accepts the reference as-is.
+func (s *Server) checkCredentialSecret(ctx context.Context, job *api.RenovateJob) string {
+	if s.setup.SecretReader == nil {
+		return ""
+	}
+
+	secret := &corev1.Secret{}
+	if err := s.setup.SecretReader.Get(ctx, client.ObjectKey{Name: job.Spec.SecretRef, Namespace: job.Namespace}, secret); err != nil {
+		return fmt.Sprintf("secret %q not found in namespace %q", job.Spec.SecretRef, job.Namespace)
+	}
+
+	for _, key := range gitProviderClientFactory.WellKnownTokenKeys {
+		if len(secret.Data[key]) > 0 {
+			return ""
+		}
+	}
+	return fmt.Sprintf("secret %q holds no platform token (expected one of: %s)",
+		job.Spec.SecretRef, strings.Join(gitProviderClientFactory.WellKnownTokenKeys, ", "))
+}
+
+// checkGithubAppSecret reports why a job's spec.githubAppReference is
+// unusable, or "" when it looks fine. Only the referenced secret is checked;
+// the operator-managed token secret is its own reconcile concern.
+func (s *Server) checkGithubAppSecret(ctx context.Context, job *api.RenovateJob) string {
+	if s.setup.SecretReader == nil {
+		return ""
+	}
+
+	ref := job.Spec.GithubAppReference
+	secret := &corev1.Secret{}
+	if err := s.setup.SecretReader.Get(ctx, client.ObjectKey{Name: ref.SecretName, Namespace: job.Namespace}, secret); err != nil {
+		return fmt.Sprintf("GitHub App secret %q not found in namespace %q", ref.SecretName, job.Namespace)
+	}
+
+	var missing []string
+	for _, key := range []string{ref.AppIdSecretKey, ref.InstallationIdSecretKey, ref.PemSecretKey} {
+		if len(secret.Data[key]) == 0 {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Sprintf("GitHub App secret %q is missing key(s): %s", ref.SecretName, strings.Join(missing, ", "))
+	}
+	return ""
+}
+
+// acceptedSetupStep folds the jobs' Accepted conditions into one step. A job
+// without the condition counts as accepted, matching acceptedState.
+func acceptedSetupStep(jobs []api.RenovateJob) SetupStep {
+	for i := range jobs {
+		if accepted, message := acceptedState(&jobs[i]); !accepted {
+			detail := jobs[i].Namespace + "/" + jobs[i].Name + ": halted by the operator's policy"
+			if message != "" {
+				detail += " — " + message
+			}
+			return SetupStep{ID: "accepted", State: setupStateBlocked, Detail: detail}
+		}
+	}
+	return SetupStep{ID: "accepted", State: setupStateDone}
+}
+
+// discoverySetupStep is done as soon as any project exists — repositories
+// were found, so the whole chain provably works.
+func (s *Server) discoverySetupStep(ctx context.Context, jobs []api.RenovateJob) SetupStep {
+	step := SetupStep{ID: "discovery", State: setupStatePending}
+
+	totalProjects := 0
+	for i := range jobs {
+		jobId := crdmanager.RenovateJobIdentifier{Name: jobs[i].Name, Namespace: jobs[i].Namespace}
+		projects, err := s.manager.GetProjectsForRenovateJob(ctx, jobId)
+		if err != nil {
+			s.logger.Error(err, "failed to get projects for setup status", "job", jobs[i].Name, "namespace", jobs[i].Namespace)
+			continue
+		}
+		totalProjects += len(projects)
+	}
+
+	if totalProjects > 0 {
+		step.State = setupStateDone
+		step.Detail = fmt.Sprintf("%d project(s) discovered", totalProjects)
+	} else if s.anyDiscoveryRunning(ctx, jobs) {
+		step.Detail = "discovery is running"
+	}
+
+	return step
+}
+
+func (s *Server) anyDiscoveryRunning(ctx context.Context, jobs []api.RenovateJob) bool {
+	for i := range jobs {
+		if status, err := s.discovery.GetDiscoveryJobStatus(ctx, &jobs[i]); err == nil && status == api.JobStatusRunning {
+			return true
+		}
+	}
+	return false
+}

--- a/src/ui/setup_test.go
+++ b/src/ui/setup_test.go
@@ -1,0 +1,649 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	api "renovate-operator/api/v1alpha1"
+	crdmanager "renovate-operator/internal/crdManager"
+)
+
+func secretReaderWith(t *testing.T, objects ...client.Object) client.Reader {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func stepByID(t *testing.T, status SetupStatus, id string) SetupStep {
+	t.Helper()
+	for _, step := range status.Steps {
+		if step.ID == id {
+			return step
+		}
+	}
+	t.Fatalf("step %q not found in %+v", id, status.Steps)
+	return SetupStep{}
+}
+
+func TestGetSetupStatus_HiddenWhenAuthConfigured(t *testing.T) {
+	// The guide is a first-run aid and disappears entirely once an auth
+	// provider is configured — even for a session matching the operator-wide
+	// admin defaults.
+	server := &Server{
+		manager:        &mockRenovateJobManager{},
+		logger:         logr.Discard(),
+		auth:           &OIDCAuth{},
+		accessDefaults: AccessDefaults{AdminUsers: []string{"admin@example.com"}},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/status", nil)
+	req = req.WithContext(context.WithValue(req.Context(), sessionContextKey,
+		&sessionData{Email: "admin@example.com", EmailVerified: true}))
+	w := httptest.NewRecorder()
+	server.getSetupStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	var status SetupStatus
+	if err := json.NewDecoder(w.Body).Decode(&status); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if status.Visible {
+		t.Error("setup status must not be visible to non-admins")
+	}
+	if len(status.Steps) != 0 || len(status.Hints) != 0 {
+		t.Errorf("hidden setup status must carry no steps or hints, got %+v", status)
+	}
+}
+
+func TestComputeSetupStatus_NoJobs(t *testing.T) {
+	server := &Server{
+		manager: &mockRenovateJobManager{},
+		logger:  logr.Discard(),
+	}
+
+	status := server.computeSetupStatus(context.Background())
+
+	if !status.Visible {
+		t.Fatal("expected visible status")
+	}
+	if status.Complete {
+		t.Error("empty install must not be complete")
+	}
+	for _, id := range []string{"credentials", "renovatejob", "accepted", "discovery"} {
+		if step := stepByID(t, status, id); step.State != setupStatePending {
+			t.Errorf("step %q = %q, want pending", id, step.State)
+		}
+	}
+}
+
+func TestComputeSetupStatus_CredentialChecks(t *testing.T) {
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "renovate-secret", Namespace: "default"},
+		Data:       map[string][]byte{"GITHUB_COM_TOKEN": []byte("token")},
+	}
+	keylessSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "keyless", Namespace: "default"},
+		Data:       map[string][]byte{"SOMETHING_ELSE": []byte("x")},
+	}
+	appSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "gh-app", Namespace: "default"},
+		Data: map[string][]byte{
+			"APP_ID":     []byte("1"),
+			"INSTALL_ID": []byte("2"),
+			"PEM":        []byte("key"),
+		},
+	}
+
+	jobWithSecret := func(secretRef string) api.RenovateJob {
+		return api.RenovateJob{Name: "job1", Namespace: "default", Spec: api.RenovateJobSpec{SecretRef: secretRef}}
+	}
+
+	tests := []struct {
+		name       string
+		job        api.RenovateJob
+		wantState  string
+		wantDetail string
+	}{
+		{
+			name:      "secret with well-known token key verifies",
+			job:       jobWithSecret("renovate-secret"),
+			wantState: setupStateDone,
+		},
+		{
+			name:       "missing secret is blocked",
+			job:        jobWithSecret("does-not-exist"),
+			wantState:  setupStateBlocked,
+			wantDetail: `secret "does-not-exist" not found`,
+		},
+		{
+			name:       "secret without a token key is blocked",
+			job:        jobWithSecret("keyless"),
+			wantState:  setupStateBlocked,
+			wantDetail: "holds no platform token",
+		},
+		{
+			name:       "job without any credential reference is blocked",
+			job:        api.RenovateJob{Name: "job1", Namespace: "default"},
+			wantState:  setupStateBlocked,
+			wantDetail: "references no credentials",
+		},
+		{
+			name: "github app reference with all keys verifies",
+			job: api.RenovateJob{Name: "job1", Namespace: "default", Spec: api.RenovateJobSpec{
+				GithubAppReference: &api.GithubAppReference{
+					SecretName: "gh-app", AppIdSecretKey: "APP_ID", InstallationIdSecretKey: "INSTALL_ID", PemSecretKey: "PEM",
+				},
+			}},
+			wantState: setupStateDone,
+		},
+		{
+			name: "github app reference with a missing key is blocked",
+			job: api.RenovateJob{Name: "job1", Namespace: "default", Spec: api.RenovateJobSpec{
+				GithubAppReference: &api.GithubAppReference{
+					SecretName: "gh-app", AppIdSecretKey: "APP_ID", InstallationIdSecretKey: "INSTALL_ID", PemSecretKey: "WRONG_KEY",
+				},
+			}},
+			wantState:  setupStateBlocked,
+			wantDetail: "missing key(s): WRONG_KEY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jobs := []api.RenovateJob{tt.job}
+			server := &Server{
+				manager:   &mockRenovateJobManager{listRenovateJobsFullFunc: func(ctx context.Context) ([]api.RenovateJob, error) { return jobs, nil }},
+				discovery: &mockDiscoveryAgent{},
+				logger:    logr.Discard(),
+				setup:     SetupEnvironment{SecretReader: secretReaderWith(t, tokenSecret, keylessSecret, appSecret)},
+			}
+
+			status := server.computeSetupStatus(context.Background())
+			step := stepByID(t, status, "credentials")
+			if step.State != tt.wantState {
+				t.Errorf("credentials state = %q (detail %q), want %q", step.State, step.Detail, tt.wantState)
+			}
+			if tt.wantDetail != "" && !strings.Contains(step.Detail, tt.wantDetail) {
+				t.Errorf("credentials detail = %q, want it to contain %q", step.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestComputeSetupStatus_ProgressAndCompletion(t *testing.T) {
+	acceptedFalse := api.RenovateJob{
+		Name: "job1", Namespace: "default",
+		Spec: api.RenovateJobSpec{SecretRef: "renovate-secret"},
+		Status: api.RenovateJobStatus{Conditions: []metav1.Condition{{
+			Type: api.ConditionAccepted, Status: metav1.ConditionFalse, Reason: "HostNotAllowed", Message: "host evil.example is not allowed",
+		}}},
+	}
+	acceptedJob := api.RenovateJob{
+		Name: "job1", Namespace: "default",
+		Spec: api.RenovateJobSpec{SecretRef: "renovate-secret"},
+	}
+
+	project := func(status api.RenovateProjectStatus) crdmanager.RenovateProjectStatus {
+		return crdmanager.RenovateProjectStatus{
+			Name: "org/repo", Namespace: "default",
+			RenovateProjectState: api.RenovateProjectState{Status: status},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		job             api.RenovateJob
+		projects        []crdmanager.RenovateProjectStatus
+		discoveryStatus api.RenovateProjectStatus
+		wantAccepted    string
+		wantDiscovery   string
+		wantComplete    bool
+	}{
+		{
+			name:          "policy refusal blocks the accepted step",
+			job:           acceptedFalse,
+			wantAccepted:  setupStateBlocked,
+			wantDiscovery: setupStatePending,
+		},
+		{
+			name:            "running discovery is reported while no project exists",
+			job:             acceptedJob,
+			discoveryStatus: api.JobStatusRunning,
+			wantAccepted:    setupStateDone,
+			wantDiscovery:   setupStatePending,
+		},
+		{
+			// The runs themselves are the dashboard's business: a discovered
+			// project completes the setup regardless of its run status.
+			name:          "a discovered project completes the setup",
+			job:           acceptedJob,
+			projects:      []crdmanager.RenovateProjectStatus{project(api.JobStatusScheduled)},
+			wantAccepted:  setupStateDone,
+			wantDiscovery: setupStateDone,
+			wantComplete:  true,
+		},
+	}
+
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "renovate-secret", Namespace: "default"},
+		Data:       map[string][]byte{"RENOVATE_TOKEN": []byte("token")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jobs := []api.RenovateJob{tt.job}
+			server := &Server{
+				manager: &mockRenovateJobManager{
+					listRenovateJobsFullFunc: func(ctx context.Context) ([]api.RenovateJob, error) { return jobs, nil },
+					getProjectsForRenovateJobFunc: func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier) ([]crdmanager.RenovateProjectStatus, error) {
+						return tt.projects, nil
+					},
+				},
+				discovery: &mockDiscoveryAgent{
+					getDiscoveryJobStatusFunc: func(ctx context.Context, job *api.RenovateJob) (api.RenovateProjectStatus, error) {
+						if tt.discoveryStatus != "" {
+							return tt.discoveryStatus, nil
+						}
+						return api.JobStatusScheduled, nil
+					},
+				},
+				logger: logr.Discard(),
+				setup:  SetupEnvironment{SecretReader: secretReaderWith(t, tokenSecret)},
+			}
+
+			status := server.computeSetupStatus(context.Background())
+
+			if got := stepByID(t, status, "renovatejob").State; got != setupStateDone {
+				t.Errorf("renovatejob state = %q, want done", got)
+			}
+			if got := stepByID(t, status, "accepted").State; got != tt.wantAccepted {
+				t.Errorf("accepted state = %q, want %q", got, tt.wantAccepted)
+			}
+			if got := stepByID(t, status, "discovery").State; got != tt.wantDiscovery {
+				t.Errorf("discovery state = %q, want %q", got, tt.wantDiscovery)
+			}
+			if status.Complete != tt.wantComplete {
+				t.Errorf("complete = %v, want %v", status.Complete, tt.wantComplete)
+			}
+		})
+	}
+}
+
+func TestComputeSetupStatus_Hints(t *testing.T) {
+	server := &Server{
+		manager: &mockRenovateJobManager{},
+		logger:  logr.Discard(),
+		auth:    &OIDCAuth{},
+		setup:   SetupEnvironment{PolicyEnabled: true, LogStorageConfigured: false},
+	}
+
+	status := server.computeSetupStatus(context.Background())
+
+	want := map[string]bool{"auth": true, "policy": true, "logStorage": false}
+	if len(status.Hints) != len(want) {
+		t.Fatalf("expected %d hints, got %+v", len(want), status.Hints)
+	}
+	for _, hint := range status.Hints {
+		expected, ok := want[hint.ID]
+		if !ok {
+			t.Errorf("unexpected hint %q", hint.ID)
+			continue
+		}
+		if hint.Done != expected {
+			t.Errorf("hint %q done = %v, want %v", hint.ID, hint.Done, expected)
+		}
+	}
+}
+
+func TestGetSetupSecretCheck(t *testing.T) {
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "renovate-secret", Namespace: "default"},
+		Data:       map[string][]byte{"GITHUB_COM_TOKEN": []byte("token")},
+	}
+	appSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gh-app", Namespace: "default",
+			Labels: map[string]string{api.LabelAllowRef: "true"},
+		},
+		Data: map[string][]byte{
+			"APP_ID":     []byte("1"),
+			"INSTALL_ID": []byte("2"),
+			"PEM":        []byte("key"),
+		},
+	}
+
+	server := &Server{
+		logger:    logr.Discard(),
+		manager:   &mockRenovateJobManager{},
+		discovery: &mockDiscoveryAgent{},
+		setup: SetupEnvironment{
+			OwnNamespace: "default",
+			SecretReader: secretReaderWith(t, tokenSecret, appSecret),
+		},
+	}
+
+	get := func(query string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/secret"+query, nil)
+		w := httptest.NewRecorder()
+		server.getSetupSecretCheck(w, req)
+		return w
+	}
+
+	type checkResult struct {
+		Found            bool `json:"found"`
+		HasToken         bool `json:"hasToken"`
+		HasGithubAppKeys bool `json:"hasGithubAppKeys"`
+		HasAllowRefLabel bool `json:"hasAllowRefLabel"`
+	}
+	decode := func(t *testing.T, w *httptest.ResponseRecorder) checkResult {
+		t.Helper()
+		var result checkResult
+		if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		return result
+	}
+
+	t.Run("missing parameters", func(t *testing.T) {
+		if w := get(""); w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("token secret", func(t *testing.T) {
+		w := get("?namespace=default&name=renovate-secret")
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		result := decode(t, w)
+		if !result.Found || !result.HasToken || result.HasGithubAppKeys || result.HasAllowRefLabel {
+			t.Errorf("unexpected result %+v", result)
+		}
+	})
+
+	t.Run("github app secret with allow-ref label", func(t *testing.T) {
+		result := decode(t, get("?namespace=default&name=gh-app"))
+		if !result.Found || result.HasToken || !result.HasGithubAppKeys || !result.HasAllowRefLabel {
+			t.Errorf("unexpected result %+v", result)
+		}
+	})
+
+	t.Run("missing secret", func(t *testing.T) {
+		result := decode(t, get("?namespace=default&name=nope"))
+		if result.Found || result.HasToken || result.HasGithubAppKeys || result.HasAllowRefLabel {
+			t.Errorf("unexpected result %+v", result)
+		}
+	})
+
+	t.Run("foreign namespace is refused", func(t *testing.T) {
+		// Nothing about secrets outside the operator's namespace and the
+		// namespaces of existing RenovateJobs may leak: the endpoint answers
+		// without a session, so an arbitrary namespace would make it a
+		// cluster-wide secret existence oracle.
+		if w := get("?namespace=kube-system&name=renovate-secret"); w.Code != http.StatusNotFound {
+			t.Errorf("expected 404 for a foreign namespace, got %d", w.Code)
+		}
+	})
+
+	t.Run("namespace of an existing job is allowed", func(t *testing.T) {
+		jobServer := &Server{
+			logger:    logr.Discard(),
+			discovery: &mockDiscoveryAgent{},
+			manager: &mockRenovateJobManager{
+				listRenovateJobsFullFunc: func(context.Context) ([]api.RenovateJob, error) {
+					return []api.RenovateJob{{
+						ObjectMeta: metav1.ObjectMeta{Name: "renovate", Namespace: "team-a"},
+					}}, nil
+				},
+			},
+			setup: SetupEnvironment{
+				OwnNamespace: "renovate-operator",
+				SecretReader: secretReaderWith(t, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "renovate-secret", Namespace: "team-a"},
+					Data:       map[string][]byte{"RENOVATE_TOKEN": []byte("token")},
+				}),
+			},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/secret?namespace=team-a&name=renovate-secret", nil)
+		w := httptest.NewRecorder()
+		jobServer.getSetupSecretCheck(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200 for a job namespace, got %d", w.Code)
+		}
+		if result := decode(t, w); !result.Found || !result.HasToken {
+			t.Errorf("unexpected result %+v", result)
+		}
+	})
+
+	t.Run("refused without a known own namespace", func(t *testing.T) {
+		// An unresolved own namespace must not widen the probe: with no jobs
+		// to compare against either, every namespace is refused rather than
+		// allowed.
+		blindServer := &Server{
+			logger:    logr.Discard(),
+			manager:   &mockRenovateJobManager{},
+			discovery: &mockDiscoveryAgent{},
+			setup:     SetupEnvironment{SecretReader: secretReaderWith(t, tokenSecret)},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/secret?namespace=default&name=renovate-secret", nil)
+		w := httptest.NewRecorder()
+		blindServer.getSetupSecretCheck(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404 without a known own namespace, got %d", w.Code)
+		}
+	})
+
+	t.Run("closed once setup is complete", func(t *testing.T) {
+		// The probe exists for the guide's first step. Once the first run is
+		// finished nothing consults it, so it must not stay reachable.
+		doneServer := &Server{
+			logger:    logr.Discard(),
+			discovery: &mockDiscoveryAgent{},
+			manager: &mockRenovateJobManager{
+				listRenovateJobsFullFunc: func(context.Context) ([]api.RenovateJob, error) {
+					return []api.RenovateJob{{
+						ObjectMeta: metav1.ObjectMeta{Name: "renovate", Namespace: "default"},
+					}}, nil
+				},
+			},
+			setup: SetupEnvironment{
+				OwnNamespace: "default",
+				SecretReader: secretReaderWith(t, tokenSecret),
+			},
+		}
+		doneServer.setupComplete.Store(true)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/secret?namespace=default&name=renovate-secret", nil)
+		w := httptest.NewRecorder()
+		doneServer.getSetupSecretCheck(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404 once setup is complete, got %d", w.Code)
+		}
+	})
+
+	t.Run("closed when the state is unreadable", func(t *testing.T) {
+		// No job list means no verdict on whether setup is finished; the probe
+		// closes rather than answering on an unknown state.
+		blindServer := &Server{
+			logger:    logr.Discard(),
+			discovery: &mockDiscoveryAgent{},
+			manager: &mockRenovateJobManager{
+				listRenovateJobsFullFunc: func(context.Context) ([]api.RenovateJob, error) {
+					return nil, errors.New("api down")
+				},
+			},
+			setup: SetupEnvironment{
+				OwnNamespace: "default",
+				SecretReader: secretReaderWith(t, tokenSecret),
+			},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/secret?namespace=default&name=renovate-secret", nil)
+		w := httptest.NewRecorder()
+		blindServer.getSetupSecretCheck(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404 with an unreadable state, got %d", w.Code)
+		}
+	})
+
+	t.Run("hidden when auth is configured", func(t *testing.T) {
+		authServer := &Server{
+			logger:    logr.Discard(),
+			discovery: &mockDiscoveryAgent{},
+			auth:      &OIDCAuth{},
+			setup:     SetupEnvironment{SecretReader: secretReaderWith(t, tokenSecret)},
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/setup/secret?namespace=default&name=renovate-secret", nil)
+		w := httptest.NewRecorder()
+		authServer.getSetupSecretCheck(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("expected 404 with auth configured, got %d", w.Code)
+		}
+	})
+}
+
+func TestComputeSetupStatus_CompletionLatchesAndResets(t *testing.T) {
+	projectCalls := 0
+	jobs := []api.RenovateJob{{Name: "job1", Namespace: "default", Spec: api.RenovateJobSpec{SecretRef: "renovate-secret"}}}
+	tokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "renovate-secret", Namespace: "default"},
+		Data:       map[string][]byte{"RENOVATE_TOKEN": []byte("token")},
+	}
+
+	server := &Server{
+		manager: &mockRenovateJobManager{
+			listRenovateJobsFullFunc: func(ctx context.Context) ([]api.RenovateJob, error) {
+				return jobs, nil
+			},
+			getProjectsForRenovateJobFunc: func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier) ([]crdmanager.RenovateProjectStatus, error) {
+				projectCalls++
+				return []crdmanager.RenovateProjectStatus{{
+					Name: "org/repo", Namespace: "default",
+					RenovateProjectState: api.RenovateProjectState{Status: api.JobStatusCompleted},
+				}}, nil
+			},
+		},
+		discovery: &mockDiscoveryAgent{},
+		logger:    logr.Discard(),
+		setup:     SetupEnvironment{SecretReader: secretReaderWith(t, tokenSecret)},
+	}
+
+	first := server.computeSetupStatus(context.Background())
+	if !first.Complete {
+		t.Fatalf("expected complete status, got %+v", first)
+	}
+
+	second := server.computeSetupStatus(context.Background())
+	if !second.Complete || !second.Visible {
+		t.Fatalf("latched status must stay visible and complete, got %+v", second)
+	}
+	if projectCalls != 1 {
+		t.Errorf("expected the completion latch to skip project checks, got %d calls", projectCalls)
+	}
+	if len(second.Hints) == 0 {
+		t.Error("latched status must still carry hints")
+	}
+
+	// Deleting every job means starting over: the latch resets and the guide
+	// reports a fresh install again.
+	jobs = nil
+	third := server.computeSetupStatus(context.Background())
+	if third.Complete || !third.Visible {
+		t.Fatalf("deleting every job must reset the latch, got %+v", third)
+	}
+	if step := stepByID(t, third, "renovatejob"); step.State != setupStatePending {
+		t.Errorf("renovatejob step = %q after reset, want pending", step.State)
+	}
+}
+
+func TestDetectLockedOutJobs(t *testing.T) {
+	jobWithoutAccess := api.RenovateJob{Name: "job1", Namespace: "default"}
+	jobWithAccess := api.RenovateJob{Name: "job2", Namespace: "default", Spec: api.RenovateJobSpec{
+		Access: &api.RenovateJobAccess{AdminUsers: []string{"admin@example.com"}},
+	}}
+
+	tests := []struct {
+		name       string
+		provider   AuthProvider
+		defaults   AccessDefaults
+		jobs       []api.RenovateJob
+		wantLocked []string
+	}{
+		{
+			name: "no auth provider - nothing locked out",
+			jobs: []api.RenovateJob{jobWithoutAccess},
+		},
+		{
+			name:     "authorization disabled - nothing locked out",
+			provider: &OIDCAuth{},
+			defaults: AccessDefaults{AuthorizationDisabled: true},
+			jobs:     []api.RenovateJob{jobWithoutAccess},
+		},
+		{
+			name:       "job without access and empty defaults is locked out",
+			provider:   &OIDCAuth{},
+			jobs:       []api.RenovateJob{jobWithoutAccess, jobWithAccess},
+			wantLocked: []string{"default/job1"},
+		},
+		{
+			name:     "operator-wide admin users unlock jobs without own access",
+			provider: &OIDCAuth{},
+			defaults: AccessDefaults{AdminUsers: []string{"admin@example.com"}},
+			jobs:     []api.RenovateJob{jobWithoutAccess},
+		},
+		{
+			name:     "anonymous read default unlocks jobs without own access",
+			provider: &OIDCAuth{},
+			defaults: AccessDefaults{AnonymousRead: true},
+			jobs:     []api.RenovateJob{jobWithoutAccess},
+		},
+		{
+			name:     "no jobs - no warning even with empty defaults",
+			provider: &OIDCAuth{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verdict, locked := detectLockedOutJobs(tt.provider, tt.defaults, tt.jobs)
+
+			if len(tt.wantLocked) == 0 {
+				if verdict != nil {
+					t.Fatalf("expected no warning, got %+v (locked %v)", verdict, locked)
+				}
+				return
+			}
+
+			if verdict == nil {
+				t.Fatal("expected a warning, got none")
+			}
+			if verdict.Reason != ReasonNoAccessRules {
+				t.Errorf("reason = %q, want %q", verdict.Reason, ReasonNoAccessRules)
+			}
+			if len(locked) != len(tt.wantLocked) {
+				t.Fatalf("locked jobs = %v, want %v", locked, tt.wantLocked)
+			}
+			for i, want := range tt.wantLocked {
+				if locked[i] != want {
+					t.Errorf("locked[%d] = %q, want %q", i, locked[i], want)
+				}
+			}
+		})
+	}
+}

--- a/src/ui/ui.go
+++ b/src/ui/ui.go
@@ -14,6 +14,10 @@ func (s *Server) registerUiRoutes(router *mux.Router) {
 		s.serveHTML(w, r, "./static/pages/logs.html")
 	}).Methods("GET")
 
+	router.HandleFunc("/setup", func(w http.ResponseWriter, r *http.Request) {
+		s.serveHTML(w, r, "./static/pages/setup.html")
+	}).Methods("GET")
+
 	fileServer := http.FileServer(http.Dir("./static/"))
 	base := BasePath()
 	router.PathPrefix("/").Handler(cacheControl(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Added

- A guided first-run setup on its own `/setup` page: step-by-step credentials secret, RenovateJob and discovery, with copy-paste YAML and a ready-to-run `Copy kubectl` command per step (works in fish, bash and zsh).
- Automatic detection of the credentials secret before any RenovateJob references it, including GitHub App keys. The probing endpoint is limited to the operator's own namespace and namespaces that already hold a RenovateJob, and closes for good once the first setup is complete.
- A success card that ends the guide once discovery has run.
- One shared `Spinner` component, used by every control that stays busy: the setup guide's discovery button, the dashboard's discovery, trigger, trigger-all and cancel buttons, the logs loading state, and a project's status badge while it is running.
- A warning banner when RenovateJobs exist that the access rules hide from everyone.

## Changed

- The setup guide moved out of the dashboard onto `/setup`; the dashboard links there while the install is incomplete.
- Setup steps stay ticked while the status cache turns over, and the latch resets when every job is deleted.
- The shared footer is now a slim link bar with icons.
- The discovery button stays visible and disabled while discovery runs instead of vanishing, and it reacts to the click immediately rather than waiting for the next status poll.
- The client provider resolves the kubeconfig through client-go's own loading rules, so `KUBECONFIG` may name a precedence list of files, merged the way kubectl does.

Screenshots to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)