### PR TITLE
ci(justfile): use full GOPATH for controller-gen and add install-crds target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,10 @@ set dotenv-load
 default:
     just --list --unsorted
 
+# Install CRDs into the current kubectl context
+install-crds: generate
+    kubectl apply -f charts/renovate-operator/crd/
+
 # Run the application with flags similar to the production build
 run *args: build jsInstall
     cd src && ../dist/native/renovate-operator {{args}}
@@ -37,7 +41,7 @@ _install_controller_gen:
 
 # Execute go generate
 generate: _install_controller_gen
-    controller-gen crd paths=./src/... output:crd:dir=charts/renovate-operator/crd
+    $(go env GOPATH)/bin/controller-gen crd paths=./src/... output:crd:dir=charts/renovate-operator/crd
 
 # Run tests and linters for quick iteration locally.
 check: generate golangci-lint test-unit test-helm


### PR DESCRIPTION
## Summary

- Fixes `generate` recipe to use `$(go env GOPATH)/bin/controller-gen` so it works when the GOPATH bin dir is not in `PATH`
- Adds an `install-crds` target that runs `generate` then applies the generated CRDs into the current kubectl context

## Test plan

- [ ] Run `just generate` — should succeed without `controller-gen` in PATH
- [ ] Run `just install-crds` — should apply CRDs to the connected cluster