### PR TITLE
style(ui): gofmt renovateController.go

### DIFF
--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -33,12 +33,12 @@ type RenovateJobInfo struct {
 	// Accepted is false when the operator's policy refuses this job, in which case
 	// nothing runs for it and AcceptedMessage says what to fix. Jobs reconciled by an
 	// older operator have no condition yet and are reported as accepted.
-	Accepted        bool     `json:"accepted"`
-	AcceptedMessage string   `json:"acceptedMessage,omitempty"`
-	Role              string   `json:"role,omitempty"`
-	Permissions       []string `json:"permissions"`
-	DiscoveryFilters  []string `json:"discoveryFilters,omitempty"`
-	DiscoverTopics    []string `json:"discoverTopics,omitempty"`
+	Accepted         bool     `json:"accepted"`
+	AcceptedMessage  string   `json:"acceptedMessage,omitempty"`
+	Role             string   `json:"role,omitempty"`
+	Permissions      []string `json:"permissions"`
+	DiscoveryFilters []string `json:"discoveryFilters,omitempty"`
+	DiscoverTopics   []string `json:"discoverTopics,omitempty"`
 }
 
 func (s *Server) decideJobAccess(r *http.Request, job *api.RenovateJob) accessDecision {


### PR DESCRIPTION
## What

`gofmt -l src/ui/renovateController.go` flags it on `main`. The struct field alignment was not redone when #652 added `DiscoveryFilters` and `DiscoverTopics`, which are longer than the fields above them.

```
$ cd src && gofmt -l ui/renovateController.go
ui/renovateController.go
```

golangci-lint reports it as `File is not properly formatted (gofmt)` and exits 1, so `just check` fails on a clean checkout:

```
ui/renovateController.go:36:1: File is not properly formatted (gofmt)
1 issues:
* gofmt: 1
```

CI does not catch it because the lint action runs with `only-new-issues`, which skips anything already on `main`.

Whitespace inside one struct, no behaviour change. With it, `just check` is green again: 0 lint issues, 1002 tests, 77 helm tests.
