### PR TITLE
fix: the redis/ valkey cache secret attaches to job lifecycle

### DIFF
--- a/docs/operations/valkey.md
+++ b/docs/operations/valkey.md
@@ -51,6 +51,8 @@ Host, port, and username can each be set as a clear Helm value or sourced from t
 
 The server certificate of a TLS-enabled Valkey must chain to a publicly trusted CA — there is currently no option to supply a custom CA bundle. Note that the executor jobs receive the same URL, so Renovate's containers must be able to verify the certificate too.
 
+When forwarding is enabled, the operator creates one Secret per Renovate Job (`<job-name>-redis`, labeled `app.kubernetes.io/component=renovate-valkey-cache`) carrying the cache URL. The secret is rewritten from the operator's current configuration on every dispatch and is owned by the Job, so Kubernetes garbage collection deletes it when the Job is cleaned up. To propagate rotated Valkey credentials, restart the operator (it reads its own configuration at startup); the next run of each job then receives the new credentials.
+
 ## Deploying with the bundled Helm chart
 
 The chart includes an optional single-node Valkey instance (via the [official Valkey Helm chart](https://github.com/valkey-io/valkey-helm)):

--- a/src/internal/renovate/discoveryAgent.go
+++ b/src/internal/renovate/discoveryAgent.go
@@ -208,7 +208,8 @@ func (e *discoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api
 		return "", nil
 	}
 
-	if err := ensureRedisURLSecret(ctx, e.client, renovateJob.Namespace); err != nil {
+	redisSecretName := discoveryRedisSecretName(&renovateJob)
+	if err := ensureRedisURLSecret(ctx, e.client, renovateJob.Namespace, redisSecretName); err != nil {
 		return "", fmt.Errorf("failed to ensure redis url secret: %w", err)
 	}
 
@@ -232,6 +233,12 @@ func (e *discoveryAgent) CreateDiscoveryJob(ctx context.Context, renovateJob api
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create discovery job: %w", err)
+	}
+
+	// Ownership failure leaves the secret behind until the next discovery
+	// re-upserts it; not worth failing the dispatch over.
+	if err := ownRedisURLSecret(ctx, e.client, renovateJob.Namespace, redisSecretName, discoveryJob); err != nil {
+		log.FromContext(ctx).Error(err, "failed to own redis url secret", "job", discoveryJob.Name)
 	}
 
 	metricStore.IncJobDispatched(ctx, renovateJob.Namespace, renovateJob.Name, "discovery")

--- a/src/internal/renovate/discoveryAgent_test.go
+++ b/src/internal/renovate/discoveryAgent_test.go
@@ -409,33 +409,3 @@ func TestProcessDiscoveryJobResult_RunningJob(t *testing.T) {
 		t.Fatalf("expected nil error for running job, got: %v", err)
 	}
 }
-
-func TestEnsureRedisURLSecret(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := api.AddToScheme(scheme); err != nil {
-		t.Fatalf("failed to add api scheme: %v", err)
-	}
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("failed to add core scheme: %v", err)
-	}
-
-	_ = config.InitializeConfigModule([]config.ConfigItemDescription{
-		{Key: "VALKEY_URL", Optional: true, Default: "redis://redis.svc.cluster.local:6379/0"},
-		{Key: "VALKEY_HOST", Optional: true, Default: ""},
-		{Key: "VALKEY_PORT", Optional: true, Default: "6379"},
-		{Key: "VALKEY_PASSWORD", Optional: true, Default: ""},
-	})
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	if err := ensureRedisURLSecret(context.Background(), cl, "ns"); err != nil {
-		t.Fatalf("ensureRedisURLSecret returned error: %v", err)
-	}
-
-	secret := &corev1.Secret{}
-	if err := cl.Get(context.Background(), client.ObjectKey{Name: redisURLSecretName, Namespace: "ns"}, secret); err != nil {
-		t.Fatalf("expected secret to be created: %v", err)
-	}
-	if got := string(secret.Data["redis-url"]); got != "redis://redis.svc.cluster.local:6379/1" {
-		t.Fatalf("expected redis-url secret data, got %q", got)
-	}
-}

--- a/src/internal/renovate/executor.go
+++ b/src/internal/renovate/executor.go
@@ -402,18 +402,6 @@ func (e *renovateExecutor) dispatchScheduled(ctx context.Context, renovateJobs [
 		return candidates[i].jobOldestWait.Before(candidates[j].jobOldestWait)
 	})
 
-	// Ensure the Redis URL secret exists in each namespace that has candidates,
-	// once per namespace instead of once per candidate.
-	seenNamespaces := make(map[string]struct{}, len(renovateJobs))
-	for _, c := range candidates {
-		seenNamespaces[c.renovateJob.Namespace] = struct{}{}
-	}
-	for ns := range seenNamespaces {
-		if err := ensureRedisURLSecret(ctx, e.client, ns); err != nil {
-			return fmt.Errorf("failed to ensure redis url secret: %w", err)
-		}
-	}
-
 	for _, candidate := range candidates {
 		renovateJob := candidate.renovateJob
 		project := candidate.project
@@ -429,6 +417,11 @@ func (e *renovateExecutor) dispatchScheduled(ctx context.Context, renovateJobs [
 		// Skip this candidate if its job has reached its per-job limit.
 		if perJobRunning[key] >= int(renovateJob.Spec.Parallelism) {
 			continue
+		}
+
+		redisSecretName := executorRedisSecretName(renovateJob, project.Name)
+		if err := ensureRedisURLSecret(ctx, e.client, renovateJob.Namespace, redisSecretName); err != nil {
+			return fmt.Errorf("failed to ensure redis url secret: %w", err)
 		}
 
 		carrier := propagation.MapCarrier{}
@@ -454,6 +447,12 @@ func (e *renovateExecutor) dispatchScheduled(ctx context.Context, renovateJobs [
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create RenovateJob for project %s: %w", project.Name, err)
+		}
+
+		// Ownership failure leaves the secret behind until the next dispatch of
+		// the same project re-upserts it; not worth failing the dispatch over.
+		if err := ownRedisURLSecret(ctx, e.client, renovateJob.Namespace, redisSecretName, k8sJob); err != nil {
+			log.FromContext(ctx).Error(err, "failed to own redis url secret", "job", k8sJob.Name)
 		}
 
 		metricStore.IncJobDispatched(ctx, renovateJob.Namespace, renovateJob.Name, "executor")

--- a/src/internal/renovate/jobDefinitions.go
+++ b/src/internal/renovate/jobDefinitions.go
@@ -17,7 +17,7 @@ import (
 
 // create job spec for a discovery job
 func newDiscoveryJob(job *api.RenovateJob, carrier propagation.MapCarrier) *batchv1.Job {
-	predefinedEnvVars := getDefaultEnvVars(job)
+	predefinedEnvVars := getDefaultEnvVars(job, discoveryRedisSecretName(job))
 	predefinedEnvVars = append(predefinedEnvVars, otelEnvVarsForJobs()...)
 	predefinedEnvVars = append(predefinedEnvVars, traceCarrierEnvVars(carrier)...)
 
@@ -113,7 +113,7 @@ func newDiscoveryJob(job *api.RenovateJob, carrier propagation.MapCarrier) *batc
 
 // create a Job spec for renovate run on project...
 func newRenovateJob(job *api.RenovateJob, project string, executionOptions *api.RenovateExecutionOptions, carrier propagation.MapCarrier) *batchv1.Job {
-	predefinedEnvVars := getDefaultEnvVars(job)
+	predefinedEnvVars := getDefaultEnvVars(job, executorRedisSecretName(job, project))
 	predefinedEnvVars = append(predefinedEnvVars, otelEnvVarsForJobs()...)
 	predefinedEnvVars = append(predefinedEnvVars, traceCarrierEnvVars(carrier)...)
 
@@ -200,7 +200,7 @@ func newRenovateJob(job *api.RenovateJob, project string, executionOptions *api.
 	return batchJob
 }
 
-func getDefaultEnvVars(job *api.RenovateJob) []v1.EnvVar {
+func getDefaultEnvVars(job *api.RenovateJob, redisSecretName string) []v1.EnvVar {
 
 	predefinedEnvVars := []v1.EnvVar{
 		{
@@ -244,12 +244,12 @@ func getDefaultEnvVars(job *api.RenovateJob) []v1.EnvVar {
 		})
 	}
 
-	if config.GetValue("VALKEY_FORWARD_CACHE_TO_JOBS") == "true" && getRenovateCacheURL() != "" {
+	if redisCacheForwardingEnabled() {
 		predefinedEnvVars = append(predefinedEnvVars, v1.EnvVar{
 			Name: "RENOVATE_REDIS_URL",
 			ValueFrom: &v1.EnvVarSource{
 				SecretKeyRef: &v1.SecretKeySelector{
-					Name: redisURLSecretName,
+					Name: redisSecretName,
 					Key:  "redis-url",
 				},
 			},

--- a/src/internal/renovate/jobDefinitions_test.go
+++ b/src/internal/renovate/jobDefinitions_test.go
@@ -205,7 +205,7 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	expectEnvVar(t, djContainer, "RENOVATE_ENDPOINT", "gitlab.example.com")
 	expectEnvVar(t, djContainer, "RENOVATE_PLATFORM", "gitlab")
 	expectEnvFromSecret(t, djContainer, "sref")
-	expectEnvVarFromSecretKey(t, djContainer, "RENOVATE_REDIS_URL", redisURLSecretName, "redis-url")
+	expectEnvVarFromSecretKey(t, djContainer, "RENOVATE_REDIS_URL", "rj-discovery-6987b484-redis", "redis-url")
 
 	// volumes
 	expectVolumeMounts(t, djContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})
@@ -238,7 +238,7 @@ func TestNewJobs_WithSettings(t *testing.T) {
 	// env vars
 	expectEnvVar(t, rjContainer, "RENOVATE_LOG_FORMAT", "console")
 	expectEnvVar(t, rjContainer, "RENOVATE_LOG_LEVEL", "debug")
-	expectEnvVarFromSecretKey(t, rjContainer, "RENOVATE_REDIS_URL", redisURLSecretName, "redis-url")
+	expectEnvVarFromSecretKey(t, rjContainer, "RENOVATE_REDIS_URL", "rj-proj-701b9b0a-redis", "redis-url")
 	expectEnvFromSecret(t, rjContainer, "sref")
 	// volumes
 	expectVolumeMounts(t, rjContainer, []v1.VolumeMount{{Name: "tmp", MountPath: "/tmp"}, {Name: "extra-vol", MountPath: "/extra"}})

--- a/src/internal/renovate/redisSecret.go
+++ b/src/internal/renovate/redisSecret.go
@@ -1,49 +1,70 @@
 package renovate
 
 import (
-	context "context"
+	"context"
 	"fmt"
 
 	api "renovate-operator/api/v1alpha1"
 	"renovate-operator/config"
 	"renovate-operator/internal/kvstore"
+	"renovate-operator/internal/utils"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const redisURLSecretName = "renovate-operator-job-redis-cache"
+// Deterministic per-Job secret names: a re-dispatch upserts the same object
+// instead of piling up orphans while Job creation keeps failing.
+func executorRedisSecretName(job *api.RenovateJob, project string) string {
+	return utils.ExecutorJobName(job, project) + "-redis"
+}
+
+func discoveryRedisSecretName(job *api.RenovateJob) string {
+	return utils.DiscoveryJobName(job) + "-redis"
+}
 
 func getRenovateCacheURL() string {
 	cfg := kvstore.ConfigFromEnv(config.GetValue)
 	return cfg.URLForUsage(kvstore.UsageRenovateCache)
 }
 
-func ensureRedisURLSecret(ctx context.Context, c client.Client, namespace string) error {
-	valkeyURL := getRenovateCacheURL()
+func redisCacheForwardingEnabled() bool {
+	return config.GetValue("VALKEY_FORWARD_CACHE_TO_JOBS") == "true" && getRenovateCacheURL() != ""
+}
 
-	if valkeyURL == "" {
-		return nil
-	}
-
-	secret := &corev1.Secret{
-		Name:      redisURLSecretName,
-		Namespace: namespace,
-		Labels: map[string]string{
-			api.LabelAppManagedBy: api.LabelValueManagedBy,
-			api.LabelAppComponent: api.LabelValueComponentValkeyCache,
+func newRedisURLSecret(namespace, name, valkeyURL string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				api.LabelAppManagedBy: api.LabelValueManagedBy,
+				api.LabelAppComponent: api.LabelValueComponentValkeyCache,
+			},
 		},
 		Data: map[string][]byte{
 			"redis-url": []byte(valkeyURL),
 		},
 	}
+}
+
+// ensureRedisURLSecret upserts the per-job secret holding the forwarded Valkey
+// cache URL; a no-op when forwarding is disabled or no cache is configured.
+// Upserting on every dispatch is what propagates credential rotation.
+func ensureRedisURLSecret(ctx context.Context, c client.Client, namespace, name string) error {
+	if !redisCacheForwardingEnabled() {
+		return nil
+	}
+	valkeyURL := getRenovateCacheURL()
 
 	existing := &corev1.Secret{}
-	err := c.Get(ctx, client.ObjectKey{Name: redisURLSecretName, Namespace: namespace}, existing)
+	err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, existing)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if err := c.Create(ctx, secret); err != nil {
+			if err := c.Create(ctx, newRedisURLSecret(namespace, name, valkeyURL)); err != nil {
 				return fmt.Errorf("creating redis url secret: %w", err)
 			}
 			return nil
@@ -55,9 +76,52 @@ func ensureRedisURLSecret(ctx context.Context, c client.Client, namespace string
 		return nil
 	}
 
-	secret.ResourceVersion = existing.ResourceVersion
-	if err := c.Update(ctx, secret); err != nil {
+	// Update in place: a fresh literal would drop the owner reference pointing
+	// at the Job that currently owns the secret.
+	existing.Data = map[string][]byte{"redis-url": []byte(valkeyURL)}
+	if err := c.Update(ctx, existing); err != nil {
 		return fmt.Errorf("updating redis url secret: %w", err)
+	}
+	return nil
+}
+
+// ownRedisURLSecret makes the created Job the secret's sole owner so garbage
+// collection deletes the secret together with the Job (TTL cleanup or explicit
+// deletion). A plain owner reference, not controllerutil.SetControllerReference:
+// blockOwnerDeletion would require update rights on jobs/finalizers, which the
+// chart deliberately does not grant.
+func ownRedisURLSecret(ctx context.Context, c client.Client, namespace, name string, job *batchv1.Job) error {
+	if !redisCacheForwardingEnabled() {
+		return nil
+	}
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: batchv1.SchemeGroupVersion.String(),
+		Kind:       "Job",
+		Name:       job.Name,
+		UID:        job.UID,
+	}
+
+	secret := &corev1.Secret{}
+	err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("reading redis url secret: %w", err)
+		}
+		// Garbage collection can win this race when a previous generation's Job
+		// still owned the secret. Recreate it already owned, or the new Job's
+		// pods cannot start.
+		secret = newRedisURLSecret(namespace, name, getRenovateCacheURL())
+		secret.OwnerReferences = []metav1.OwnerReference{ownerRef}
+		if err := c.Create(ctx, secret); err != nil {
+			return fmt.Errorf("recreating redis url secret: %w", err)
+		}
+		return nil
+	}
+
+	secret.OwnerReferences = []metav1.OwnerReference{ownerRef}
+	if err := c.Update(ctx, secret); err != nil {
+		return fmt.Errorf("owning redis url secret: %w", err)
 	}
 	return nil
 }

--- a/src/internal/renovate/redisSecret_test.go
+++ b/src/internal/renovate/redisSecret_test.go
@@ -1,0 +1,259 @@
+package renovate
+
+import (
+	"context"
+	"testing"
+
+	api "renovate-operator/api/v1alpha1"
+	"renovate-operator/config"
+	crdManager "renovate-operator/internal/crdManager"
+	"renovate-operator/internal/types"
+	"renovate-operator/internal/utils"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func valkeyForwardConfig(t *testing.T) {
+	t.Helper()
+	if err := config.InitializeConfigModule([]config.ConfigItemDescription{
+		{Key: "VALKEY_URL", Optional: true, Default: "redis://redis.svc.cluster.local:6379/0"},
+		{Key: "VALKEY_HOST", Optional: true, Default: ""},
+		{Key: "VALKEY_PORT", Optional: true, Default: "6379"},
+		{Key: "VALKEY_PASSWORD", Optional: true, Default: ""},
+		{Key: "VALKEY_FORWARD_CACHE_TO_JOBS", Optional: true, Default: "true"},
+	}); err != nil {
+		t.Fatalf("failed to init config: %v", err)
+	}
+}
+
+func getSecret(t *testing.T, c client.Client, namespace, name string) *corev1.Secret {
+	t.Helper()
+	secret := &corev1.Secret{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		t.Fatalf("expected secret %s/%s: %v", namespace, name, err)
+	}
+	return secret
+}
+
+func listSecrets(t *testing.T, c client.Client) []corev1.Secret {
+	t.Helper()
+	list := &corev1.SecretList{}
+	if err := c.List(context.Background(), list); err != nil {
+		t.Fatalf("failed to list secrets: %v", err)
+	}
+	return list.Items
+}
+
+func TestEnsureRedisURLSecretCreatesPerJobSecret(t *testing.T) {
+	valkeyForwardConfig(t)
+	scheme := policyScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	if err := ensureRedisURLSecret(context.Background(), c, "ns", "rj-proj-701b9b0a-redis"); err != nil {
+		t.Fatalf("ensureRedisURLSecret returned error: %v", err)
+	}
+
+	stored := getSecret(t, c, "ns", "rj-proj-701b9b0a-redis")
+	if got := string(stored.Data["redis-url"]); got != "redis://redis.svc.cluster.local:6379/1" {
+		t.Errorf("expected redis-url with cache db offset, got %q", got)
+	}
+	if got := stored.Labels[api.LabelAppManagedBy]; got != api.LabelValueManagedBy {
+		t.Errorf("expected managed-by label %q, got %q", api.LabelValueManagedBy, got)
+	}
+	if got := stored.Labels[api.LabelAppComponent]; got != api.LabelValueComponentValkeyCache {
+		t.Errorf("expected component label %q, got %q", api.LabelValueComponentValkeyCache, got)
+	}
+}
+
+func TestEnsureRedisURLSecretUpdatesRotatedURL(t *testing.T) {
+	valkeyForwardConfig(t)
+	scheme := policyScheme(t)
+	stale := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "rj-proj-701b9b0a-redis", Namespace: "ns"},
+		Data:       map[string][]byte{"redis-url": []byte("redis://:old-password@redis.svc.cluster.local:6379/1")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stale).Build()
+
+	if err := ensureRedisURLSecret(context.Background(), c, "ns", "rj-proj-701b9b0a-redis"); err != nil {
+		t.Fatalf("ensureRedisURLSecret returned error: %v", err)
+	}
+
+	stored := getSecret(t, c, "ns", "rj-proj-701b9b0a-redis")
+	if got := string(stored.Data["redis-url"]); got != "redis://redis.svc.cluster.local:6379/1" {
+		t.Errorf("expected rotated redis-url, got %q", got)
+	}
+}
+
+func TestEnsureRedisURLSecretSkippedWithoutForwardFlag(t *testing.T) {
+	if err := config.InitializeConfigModule([]config.ConfigItemDescription{
+		{Key: "VALKEY_URL", Optional: true, Default: "redis://redis.svc.cluster.local:6379/0"},
+		{Key: "VALKEY_FORWARD_CACHE_TO_JOBS", Optional: true, Default: "false"},
+	}); err != nil {
+		t.Fatalf("failed to init config: %v", err)
+	}
+	scheme := policyScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	if err := ensureRedisURLSecret(context.Background(), c, "ns", "rj-proj-701b9b0a-redis"); err != nil {
+		t.Fatalf("ensureRedisURLSecret returned error: %v", err)
+	}
+	if secrets := listSecrets(t, c); len(secrets) != 0 {
+		t.Errorf("expected no secrets created, got %d", len(secrets))
+	}
+}
+
+func TestEnsureRedisURLSecretSkippedWithoutValkey(t *testing.T) {
+	if err := config.InitializeConfigModule([]config.ConfigItemDescription{
+		{Key: "VALKEY_URL", Optional: true, Default: ""},
+		{Key: "VALKEY_HOST", Optional: true, Default: ""},
+		{Key: "VALKEY_FORWARD_CACHE_TO_JOBS", Optional: true, Default: "true"},
+	}); err != nil {
+		t.Fatalf("failed to init config: %v", err)
+	}
+	scheme := policyScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	if err := ensureRedisURLSecret(context.Background(), c, "ns", "rj-proj-701b9b0a-redis"); err != nil {
+		t.Fatalf("ensureRedisURLSecret returned error: %v", err)
+	}
+	if secrets := listSecrets(t, c); len(secrets) != 0 {
+		t.Errorf("expected no secrets created, got %d", len(secrets))
+	}
+}
+
+func TestOwnRedisURLSecret(t *testing.T) {
+	valkeyForwardConfig(t)
+	scheme := policyScheme(t)
+	stored := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "rj-proj-701b9b0a-redis", Namespace: "ns"},
+		Data:       map[string][]byte{"redis-url": []byte("redis://redis.svc.cluster.local:6379/1")},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stored).Build()
+
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "rj-proj-701b9b0a-abcde", Namespace: "ns", UID: "uid-123"}}
+	if err := ownRedisURLSecret(context.Background(), c, "ns", "rj-proj-701b9b0a-redis", job); err != nil {
+		t.Fatalf("ownRedisURLSecret returned error: %v", err)
+	}
+
+	secret := getSecret(t, c, "ns", "rj-proj-701b9b0a-redis")
+	if len(secret.OwnerReferences) != 1 {
+		t.Fatalf("expected exactly one owner reference, got %+v", secret.OwnerReferences)
+	}
+	owner := secret.OwnerReferences[0]
+	if owner.Kind != "Job" || owner.Name != job.Name || owner.UID != job.UID {
+		t.Errorf("expected owner reference to the job, got %+v", owner)
+	}
+	// A controller reference would set blockOwnerDeletion, which requires
+	// jobs/finalizers RBAC the chart deliberately does not grant.
+	if owner.Controller != nil && *owner.Controller {
+		t.Errorf("expected a plain owner reference, got controller reference")
+	}
+	if owner.BlockOwnerDeletion != nil && *owner.BlockOwnerDeletion {
+		t.Errorf("expected blockOwnerDeletion to be unset")
+	}
+}
+
+func TestOwnRedisURLSecretRecreatesCollectedSecret(t *testing.T) {
+	valkeyForwardConfig(t)
+	scheme := policyScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "rj-proj-701b9b0a-abcde", Namespace: "ns", UID: "uid-123"}}
+	if err := ownRedisURLSecret(context.Background(), c, "ns", "rj-proj-701b9b0a-redis", job); err != nil {
+		t.Fatalf("ownRedisURLSecret returned error: %v", err)
+	}
+
+	secret := getSecret(t, c, "ns", "rj-proj-701b9b0a-redis")
+	if got := string(secret.Data["redis-url"]); got != "redis://redis.svc.cluster.local:6379/1" {
+		t.Errorf("expected redis-url data on recreated secret, got %q", got)
+	}
+	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].Name != job.Name {
+		t.Errorf("expected recreated secret owned by the job, got %+v", secret.OwnerReferences)
+	}
+}
+
+func TestDispatchScheduledCreatesOwnedRedisSecret(t *testing.T) {
+	valkeyForwardConfig(t)
+	scheme := policyScheme(t)
+
+	renovateJob := policyJob("allowed", "")
+	renovateJob.Spec.Parallelism = 1
+	projectCRD := &api.RenovateProject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.RenovateProjectCRDName(renovateJob.Name, "org/b"),
+			Namespace: renovateJob.Namespace,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(projectCRD).Build()
+
+	mgr := &fakeJobManager{
+		getProjectsByStatusFn: func(_ context.Context, _ crdManager.RenovateJobIdentifier, status api.RenovateProjectStatus) ([]crdManager.RenovateProjectStatus, error) {
+			if status == api.JobStatusScheduled {
+				return []crdManager.RenovateProjectStatus{{Name: "org/b", Status: api.JobStatusScheduled}}, nil
+			}
+			return nil, nil
+		},
+		updateProjectStatusFn: func(_ context.Context, _ string, _ crdManager.RenovateJobIdentifier, _ *types.RenovateStatusUpdate) error {
+			return nil
+		},
+	}
+
+	e := &renovateExecutor{client: c, scheme: scheme, logger: testLogger, policy: gatePolicy(), manager: mgr}
+
+	if err := e.dispatchScheduled(context.Background(), []api.RenovateJob{renovateJob}, 0, map[string]int{}, executionOptions{}); err != nil {
+		t.Fatalf("dispatchScheduled returned error: %v", err)
+	}
+
+	jobs := createdJobs(t, c)
+	if len(jobs) != 1 {
+		t.Fatalf("expected one Kubernetes Job, got %d", len(jobs))
+	}
+
+	secretName := executorRedisSecretName(&renovateJob, "org/b")
+	secret := getSecret(t, c, renovateJob.Namespace, secretName)
+	if got := string(secret.Data["redis-url"]); got != "redis://redis.svc.cluster.local:6379/1" {
+		t.Errorf("expected redis-url with cache db offset, got %q", got)
+	}
+	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].Name != jobs[0].Name {
+		t.Errorf("expected secret owned by the created job %s, got %+v", jobs[0].Name, secret.OwnerReferences)
+	}
+	if secrets := listSecrets(t, c); len(secrets) != 1 {
+		t.Errorf("expected exactly one secret (no shared namespace secret), got %d", len(secrets))
+	}
+
+	container := expectContainer(t, &jobs[0])
+	expectEnvVarFromSecretKey(t, container, "RENOVATE_REDIS_URL", secretName, "redis-url")
+}
+
+func TestCreateDiscoveryJobCreatesOwnedRedisSecret(t *testing.T) {
+	valkeyForwardConfig(t)
+	scheme := policyScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	da := NewDiscoveryAgent(scheme, c, testLogger, nil, nil, gatePolicy())
+	renovateJob := policyJob("job1", "")
+	if _, err := da.CreateDiscoveryJob(context.Background(), renovateJob, DiscoveryJobOptions{}); err != nil {
+		t.Fatalf("CreateDiscoveryJob returned error: %v", err)
+	}
+
+	jobs := createdJobs(t, c)
+	if len(jobs) != 1 {
+		t.Fatalf("expected one Kubernetes Job, got %d", len(jobs))
+	}
+
+	secretName := discoveryRedisSecretName(&renovateJob)
+	secret := getSecret(t, c, renovateJob.Namespace, secretName)
+	if got := string(secret.Data["redis-url"]); got != "redis://redis.svc.cluster.local:6379/1" {
+		t.Errorf("expected redis-url with cache db offset, got %q", got)
+	}
+	if len(secret.OwnerReferences) != 1 || secret.OwnerReferences[0].Name != jobs[0].Name {
+		t.Errorf("expected secret owned by the created job %s, got %+v", jobs[0].Name, secret.OwnerReferences)
+	}
+
+	container := expectContainer(t, &jobs[0])
+	expectEnvVarFromSecretKey(t, container, "RENOVATE_REDIS_URL", secretName, "redis-url")
+}


### PR DESCRIPTION
Fixes #644 

Instead of one global redis url for all jobs, we can instead use the job lifecycle and give each job its own secret, which gets garbage collected as soon as the job is cleaned up.