### PR TITLE
Fix/626 trigger filtered projects

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -684,6 +684,10 @@
             .filter((job) => job.projects.length > 0);
         }, [filteredJobs, searchTerm]);
 
+        // The stat badges and the search box narrow every card's project list, but a
+        // card cannot tell a filtered list from a short one — so App states it.
+        const projectListIsFiltered = Boolean(selectedStatFilter) || searchTerm.trim() !== "";
+
         const searchFilteredProjectCount = useMemo(() => {
           return searchFilteredJobs.reduce(
             (total, job) => total + (Array.isArray(job.projects) ? job.projects.length : 0),
@@ -969,7 +973,10 @@
           }
         };
 
-        const triggerAllRenovate = async (job, executionOptions = {}) => {
+        // `projects` is the list the caller wants run — the rows a card currently
+        // shows. Left null it is omitted from the request, which is what tells the
+        // operator to take every project of that job (issue #626).
+        const triggerAllRenovate = async (job, executionOptions = {}, projects = null) => {
           if (job.triggeringAll) return;
 
           setJobs((prev) =>
@@ -987,6 +994,7 @@
               body: JSON.stringify({
                 renovateJob: job.name,
                 namespace: job.namespace,
+                projects: projects && projects.length > 0 ? projects : undefined,
                 executionOptions: Object.keys(executionOptions).length > 0 ? executionOptions : undefined,
               }),
             });
@@ -994,8 +1002,10 @@
             if (response.ok) {
               addToast(
                 "success",
-                "All Triggered",
-                `All projects triggered for ${job.name}`
+                projects ? "Filtered Projects Triggered" : "All Triggered",
+                projects
+                  ? `${projects.length} ${projects.length === 1 ? "project" : "projects"} triggered for ${job.name}`
+                  : `All projects triggered for ${job.name}`
               );
             } else {
               const errorText = await response.text();
@@ -1401,6 +1411,7 @@
                       onTriggerRenovate={triggerRenovate}
                       onTriggerAllRenovate={triggerAllRenovate}
                       onCancelRenovate={cancelRenovate}
+                      projectListIsFiltered={projectListIsFiltered}
                       authInfo={authInfo}
                     />
                   ))}
@@ -1962,7 +1973,7 @@
         );
       }
 
-      function JobCard({ job, expanded, onToggleExpanded, onRunDiscovery, onTriggerRenovate, onTriggerAllRenovate, onCancelRenovate, authInfo }) {
+      function JobCard({ job, expanded, onToggleExpanded, onRunDiscovery, onTriggerRenovate, onTriggerAllRenovate, onCancelRenovate, projectListIsFiltered, authInfo }) {
         const [sortConfig, setSortConfig] = useState({
           key: "status",
           direction: "asc",
@@ -2039,6 +2050,21 @@
           return sorted;
         }, [job.projects, sortConfig, hiddenStatuses, hideNoPRs, hideNoIssues]);
         const hasActiveFilters = hiddenStatuses.length > 0 || hideNoPRs || hideNoIssues;
+        // The bulk trigger acts on the rows this card shows and on nothing else:
+        // queued runs cannot be taken back, so triggering repositories a filter hid
+        // is not recoverable (issue #626). Only an unfiltered list is sent as "all",
+        // leaving it to the operator to include whatever it has discovered since.
+        const triggerScopeIsFiltered = projectListIsFiltered || hasActiveFilters;
+        const projectsToTrigger = useMemo(
+          () => sortedProjects.map((project) => project.name),
+          [sortedProjects]
+        );
+        const triggerScopeLabel = triggerScopeIsFiltered
+          ? `Trigger ${projectsToTrigger.length}`
+          : "Trigger All";
+        const triggerScopeDescription = triggerScopeIsFiltered
+          ? `Trigger ${projectsToTrigger.length} filtered ${projectsToTrigger.length === 1 ? "project" : "projects"} for ${job.name}`
+          : `Trigger all projects for ${job.name}`;
         const open = expanded;
         useEffect(() => {
           if (hasActiveFilters && sortedProjects.length === 0 && expanded) {
@@ -2327,17 +2353,22 @@
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      onTriggerAllRenovate(job);
+                      onTriggerAllRenovate(
+                        job,
+                        {},
+                        triggerScopeIsFiltered ? projectsToTrigger : null
+                      );
                     }}
-                    disabled={job.triggeringAll || !job.projects || job.projects.length === 0 || !!triggerAllBlocked}
-                    title={triggerAllBlocked}
+                    data-testid="trigger-all"
+                    disabled={job.triggeringAll || projectsToTrigger.length === 0 || !!triggerAllBlocked}
+                    title={triggerAllBlocked || triggerScopeDescription}
                     className="bg-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed text-white px-2 sm:px-3 py-1.5 font-semibold text-[0.813rem] hover:shadow-md active:scale-98 transition-all flex items-center justify-center gap-1.5"
                     aria-label={
                       triggerAllBlocked
                         ? triggerAllBlocked
                         : job.triggeringAll
                           ? "Triggering all projects"
-                          : `Trigger all projects for ${job.name}`
+                          : triggerScopeDescription
                     }
                   >
                     {job.triggeringAll ? (
@@ -2356,18 +2387,23 @@
                       </svg>
                     )}
                     <span className="hidden sm:inline">
-                      {job.triggeringAll ? "Triggering..." : "Trigger All"}
+                      {job.triggeringAll ? "Triggering..." : triggerScopeLabel}
                     </span>
                   </button>
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      onTriggerAllRenovate(job, { debug: true });
+                      onTriggerAllRenovate(
+                        job,
+                        { debug: true },
+                        triggerScopeIsFiltered ? projectsToTrigger : null
+                      );
                     }}
-                    disabled={job.triggeringAll || !job.projects || job.projects.length === 0 || !!triggerAllBlocked}
-                    title={triggerAllBlocked || "Trigger all in debug mode"}
+                    data-testid="trigger-all-debug"
+                    disabled={job.triggeringAll || projectsToTrigger.length === 0 || !!triggerAllBlocked}
+                    title={triggerAllBlocked || `${triggerScopeDescription} in debug mode`}
                     className="bg-gray-600 hover:bg-amber-600 disabled:opacity-60 disabled:cursor-not-allowed text-amber-400 hover:text-white px-2 py-1.5 text-[0.813rem] transition-all border-l border-white/10 flex items-center"
-                    aria-label={triggerAllBlocked || `Trigger all projects in debug mode for ${job.name}`}
+                    aria-label={triggerAllBlocked || `${triggerScopeDescription} in debug mode`}
                   >
                     <BugIcon className="w-3.5 h-3.5" />
                   </button>
@@ -2535,7 +2571,10 @@
                                 >
                                   <td className="px-3 xl:px-6 py-3">
                               <div className="flex items-center gap-2 w-full justify-between">
-                                <span className={`font-medium min-w-0 [overflow-wrap:anywhere] ${project.renovateResultStatus && project.renovateResultStatus !== "done" ? "text-gray-500 dark:text-slate-400" : "text-gray-900 dark:text-slate-100"}`}>
+                                <span
+                                  data-testid="project-name"
+                                  className={`font-medium min-w-0 [overflow-wrap:anywhere] ${project.renovateResultStatus && project.renovateResultStatus !== "done" ? "text-gray-500 dark:text-slate-400" : "text-gray-900 dark:text-slate-100"}`}
+                                >
                                   {project.name}
                                 </span>
                                 {project.renovateResultStatus && project.renovateResultStatus !== "done" && (

--- a/src/ui/renovateController.go
+++ b/src/ui/renovateController.go
@@ -534,8 +534,13 @@ func (s *Server) cancelRenovateForProject(w http.ResponseWriter, r *http.Request
 
 func (s *Server) runRenovateForAllProjects(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		RenovateJob      string                        `json:"renovateJob"`
-		Namespace        string                        `json:"namespace"`
+		RenovateJob string `json:"renovateJob"`
+		Namespace   string `json:"namespace"`
+		// Projects narrows the run to the named projects. The dashboard sends the
+		// ones its filters left on screen; an absent or empty list keeps the
+		// original meaning of "every project this job has", so a caller that never
+		// filters — and a project discovered after the page loaded — is unaffected.
+		Projects         []string                      `json:"projects,omitempty"`
 		ExecutionOptions *api.RenovateExecutionOptions `json:"executionOptions,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -557,9 +562,19 @@ func (s *Server) runRenovateForAllProjects(w http.ResponseWriter, r *http.Reques
 		Namespace: body.Namespace,
 	}
 
+	requestedProjects := make(map[string]struct{}, len(body.Projects))
+	for _, project := range body.Projects {
+		requestedProjects[project] = struct{}{}
+	}
+
 	err := s.manager.UpdateProjectStatusBatched(
 		r.Context(),
 		func(p crdmanager.RenovateProjectStatus) bool {
+			if len(requestedProjects) > 0 {
+				if _, requested := requestedProjects[p.Name]; !requested {
+					return false
+				}
+			}
 			return p.Status != api.JobStatusRunning && p.Status != api.JobStatusScheduled
 		},
 		jobIdentifier,
@@ -570,8 +585,14 @@ func (s *Server) runRenovateForAllProjects(w http.ResponseWriter, r *http.Reques
 		},
 	)
 	if err != nil {
-		s.logger.Error(err, "Failed to trigger all projects", "renovateJob", body.RenovateJob, "namespace", body.Namespace)
+		s.logger.Error(err, "Failed to trigger all projects", "renovateJob", body.RenovateJob, "namespace", body.Namespace, "requestedProjects", len(requestedProjects))
 		internalServerError(w, err, "failed to trigger all projects")
+		return
+	}
+
+	if len(requestedProjects) > 0 {
+		writeSuccess(w, SuccessResult{Message: "Selected projects triggered"})
+		s.logger.V(2).Info("Successfully triggered selected projects", "renovateJob", body.RenovateJob, "namespace", body.Namespace, "requestedProjects", len(requestedProjects))
 		return
 	}
 

--- a/src/ui/renovateController_test.go
+++ b/src/ui/renovateController_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -27,14 +28,15 @@ import (
 
 // Mock RenovateJobManager
 type mockRenovateJobManager struct {
-	listRenovateJobsFunc          func(ctx context.Context) ([]crdmanager.RenovateJobIdentifier, error)
-	listRenovateJobsFullFunc      func(ctx context.Context) ([]api.RenovateJob, error)
-	getProjectsForRenovateJobFunc func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier) ([]crdmanager.RenovateProjectStatus, error)
-	streamLogsForProjectFunc      func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier, project string) (io.ReadCloser, error)
-	updateProjectStatusFunc       func(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error
-	getRenovateJobFunc            func(ctx context.Context, name, namespace string) (*api.RenovateJob, error)
-	reconcileProjectsFunc         func(ctx context.Context, jobId *api.RenovateJob, projects []string) error
-	cancelProjectJobFunc          func(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier) error
+	listRenovateJobsFunc           func(ctx context.Context) ([]crdmanager.RenovateJobIdentifier, error)
+	listRenovateJobsFullFunc       func(ctx context.Context) ([]api.RenovateJob, error)
+	getProjectsForRenovateJobFunc  func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier) ([]crdmanager.RenovateProjectStatus, error)
+	streamLogsForProjectFunc       func(ctx context.Context, jobId crdmanager.RenovateJobIdentifier, project string) (io.ReadCloser, error)
+	updateProjectStatusFunc        func(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error
+	getRenovateJobFunc             func(ctx context.Context, name, namespace string) (*api.RenovateJob, error)
+	reconcileProjectsFunc          func(ctx context.Context, jobId *api.RenovateJob, projects []string) error
+	cancelProjectJobFunc           func(ctx context.Context, project string, jobId crdmanager.RenovateJobIdentifier) error
+	updateProjectStatusBatchedFunc func(ctx context.Context, fn func(p crdmanager.RenovateProjectStatus) bool, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error
 }
 
 func (m *mockRenovateJobManager) ListRenovateJobs(ctx context.Context) ([]crdmanager.RenovateJobIdentifier, error) {
@@ -112,6 +114,9 @@ func (m *mockRenovateJobManager) GetProjectsByStatus(ctx context.Context, job cr
 }
 
 func (m *mockRenovateJobManager) UpdateProjectStatusBatched(ctx context.Context, fn func(p crdmanager.RenovateProjectStatus) bool, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
+	if m.updateProjectStatusBatchedFunc != nil {
+		return m.updateProjectStatusBatchedFunc(ctx, fn, jobId, status)
+	}
 	return nil
 }
 
@@ -1086,6 +1091,116 @@ func TestRunRenovateForAllProjects_Authorization(t *testing.T) {
 
 			if w.Code != tt.wantStatusCode {
 				t.Errorf("Expected status %d, got %d", tt.wantStatusCode, w.Code)
+			}
+		})
+	}
+}
+
+// TestRunRenovateForAllProjects_ProjectScope pins what the "projects" field in the
+// request body does: the dashboard sends the projects its filters left visible, and
+// only a request without that field means every project of the job (issue #626).
+func TestRunRenovateForAllProjects_ProjectScope(t *testing.T) {
+	existingProjects := []crdmanager.RenovateProjectStatus{
+		{Name: "acme/platform/api-gateway", RenovateProjectState: api.RenovateProjectState{Status: api.JobStatusCompleted}},
+		{Name: "acme/platform/api-docs", RenovateProjectState: api.RenovateProjectState{Status: api.JobStatusFailed}},
+		{Name: "acme/platform/web-ui", RenovateProjectState: api.RenovateProjectState{Status: api.JobStatusCompleted}},
+		{Name: "acme/tooling/cli", RenovateProjectState: api.RenovateProjectState{Status: api.JobStatusRunning}},
+	}
+
+	tests := []struct {
+		name            string
+		requestBody     map[string]any
+		wantTriggered   []string
+		wantSuccessText string
+	}{
+		{
+			name: "no project list triggers every project that is not already running",
+			requestBody: map[string]any{
+				"renovateJob": "job1",
+				"namespace":   "default",
+			},
+			wantTriggered:   []string{"acme/platform/api-gateway", "acme/platform/api-docs", "acme/platform/web-ui"},
+			wantSuccessText: "All projects triggered",
+		},
+		{
+			name: "a project list triggers only those projects",
+			requestBody: map[string]any{
+				"renovateJob": "job1",
+				"namespace":   "default",
+				"projects":    []string{"acme/platform/api-gateway", "acme/platform/api-docs"},
+			},
+			wantTriggered:   []string{"acme/platform/api-gateway", "acme/platform/api-docs"},
+			wantSuccessText: "Selected projects triggered",
+		},
+		{
+			name: "an empty project list is treated as no list at all",
+			requestBody: map[string]any{
+				"renovateJob": "job1",
+				"namespace":   "default",
+				"projects":    []string{},
+			},
+			wantTriggered:   []string{"acme/platform/api-gateway", "acme/platform/api-docs", "acme/platform/web-ui"},
+			wantSuccessText: "All projects triggered",
+		},
+		{
+			name: "a running project stays untouched even when it is listed",
+			requestBody: map[string]any{
+				"renovateJob": "job1",
+				"namespace":   "default",
+				"projects":    []string{"acme/tooling/cli", "acme/platform/web-ui"},
+			},
+			wantTriggered:   []string{"acme/platform/web-ui"},
+			wantSuccessText: "Selected projects triggered",
+		},
+		{
+			name: "a project the job does not have triggers nothing else",
+			requestBody: map[string]any{
+				"renovateJob": "job1",
+				"namespace":   "default",
+				"projects":    []string{"acme/never/discovered"},
+			},
+			wantTriggered:   []string{},
+			wantSuccessText: "Selected projects triggered",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			triggered := []string{}
+			mockManager := &mockRenovateJobManager{
+				getRenovateJobFunc: func(ctx context.Context, name, namespace string) (*api.RenovateJob, error) {
+					return &api.RenovateJob{Name: "job1", Namespace: "default"}, nil
+				},
+				updateProjectStatusBatchedFunc: func(ctx context.Context, fn func(p crdmanager.RenovateProjectStatus) bool, jobId crdmanager.RenovateJobIdentifier, status *types.RenovateStatusUpdate) error {
+					for _, project := range existingProjects {
+						if fn(project) {
+							triggered = append(triggered, project.Name)
+						}
+					}
+					return nil
+				},
+			}
+
+			server := &Server{manager: mockManager, logger: logr.Discard()}
+
+			jsonBody, err := json.Marshal(tt.requestBody)
+			if err != nil {
+				t.Fatalf("failed to marshal request body: %v", err)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/renovate/all", bytes.NewReader(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			server.runRenovateForAllProjects(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("Expected status %d, got %d", http.StatusOK, w.Code)
+			}
+			if !slices.Equal(triggered, tt.wantTriggered) {
+				t.Errorf("Expected %v to be triggered, got %v", tt.wantTriggered, triggered)
+			}
+			if !strings.Contains(w.Body.String(), tt.wantSuccessText) {
+				t.Errorf("Expected response to mention %q, got %s", tt.wantSuccessText, w.Body.String())
 			}
 		})
 	}

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -77,8 +77,14 @@ tests/ui/
 └── specs/
     ├── jobCardExpansion.spec.mjs
     ├── stickyToolbar.spec.mjs
+    ├── triggerAllScope.spec.mjs
     └── logsFiltering.spec.mjs
 ```
+
+`dashboardFixture.mjs` records every POST to `/api/v1/renovate/all` in
+`dashboard.triggerAllRequests` rather than only acknowledging it, because which
+projects the page names in that body is the behaviour `triggerAllScope.spec.mjs`
+is about.
 
 `staticFrontendServer.mjs` mirrors `serveHTML` and `registerUiRoutes` in
 `src/ui/ui.go`, including its `<base>` and `window.__BASE_PATH__` injection. Keep

--- a/tests/ui/fixtures/dashboardFixture.mjs
+++ b/tests/ui/fixtures/dashboardFixture.mjs
@@ -25,6 +25,8 @@ export { expect };
 class DashboardPage {
   constructor(page) {
     this.page = page;
+    /** Bodies the page POSTed to /api/v1/renovate/all, oldest first. */
+    this.triggerAllRequests = [];
   }
 
   async stubApi(renovateJobs) {
@@ -38,6 +40,12 @@ class DashboardPage {
     await this.page.route("**/api/v1/renovatejobs", (route) =>
       route.fulfill({ json: renovateJobs }),
     );
+    // Recorded rather than only acknowledged: which projects the page names in the
+    // body is the whole point of the trigger-scope spec.
+    await this.page.route("**/api/v1/renovate/all", (route) => {
+      this.triggerAllRequests.push(JSON.parse(route.request().postData() || "{}"));
+      return route.fulfill({ json: { message: "All projects triggered" } });
+    });
   }
 
   /**
@@ -237,6 +245,44 @@ class DashboardPage {
   async closeExecutionOptions(jobName) {
     await this.page.mouse.click(5, 5);
     await expect(this.executionOptionsPopover(jobName)).toBeHidden();
+  }
+
+  /**
+   * The card a job's title row belongs to — the header's parent, which also holds
+   * the project table below it.
+   */
+  jobCard(jobName) {
+    return this.jobCardHeader(jobName).locator("xpath=..");
+  }
+
+  /** The project names one card currently lists, in render order. */
+  async projectNamesInJob(jobName) {
+    return this.jobCard(jobName)
+      .locator('table tbody [data-testid="project-name"]')
+      .allTextContents();
+  }
+
+  /** The main half of the split trigger button in a job card's title row. */
+  triggerAllButton(jobName) {
+    return this.jobCardHeader(jobName).getByTestId("trigger-all");
+  }
+
+  /** The bug-icon half of it, which triggers the same scope in debug mode. */
+  triggerAllDebugButton(jobName) {
+    return this.jobCardHeader(jobName).getByTestId("trigger-all-debug");
+  }
+
+  /**
+   * Clicks the trigger button and resolves once the page has posted, so a spec
+   * never reads triggerAllRequests before the request left the browser.
+   */
+  async triggerAll(jobName, { debug = false } = {}) {
+    const sent = this.page.waitForRequest(
+      (request) =>
+        request.method() === "POST" && request.url().includes("/api/v1/renovate/all"),
+    );
+    await (debug ? this.triggerAllDebugButton(jobName) : this.triggerAllButton(jobName)).click();
+    await sent;
   }
 
   /** What the job card persisted for its "Hide Projects" selection. */

--- a/tests/ui/fixtures/renovateJobsFixture.mjs
+++ b/tests/ui/fixtures/renovateJobsFixture.mjs
@@ -414,6 +414,14 @@ const REMAINING_VARIANT_KEYS = PROJECT_STATE_VARIANTS.map((variant) => variant.k
   (key) => !VARIANT_KEYS_IN_EVERY_JOB.includes(key),
 );
 
+/**
+ * ui.accessDecision.permissions() for an admin, which is also what every request
+ * gets when auth is disabled. The UI gates each control on one of these strings
+ * rather than on `role`, so a job payload without them renders read-only.
+ */
+export const ADMIN_PERMISSIONS = ["logs", "trigger", "triggerAll", "cancel", "discovery"];
+export const READER_PERMISSIONS = ["logs"];
+
 export function buildRenovateJob({
   name,
   namespace = "renovate",
@@ -423,6 +431,9 @@ export function buildRenovateJob({
   platform = "github",
   platformEndpoint = "https://api.github.com",
   debug = false,
+  accepted = true,
+  role = "admin",
+  permissions = ADMIN_PERMISSIONS,
 } = {}) {
   return {
     name,
@@ -434,6 +445,9 @@ export function buildRenovateJob({
     platform,
     platformEndpoint,
     executionOptions: { debug },
+    accepted,
+    role,
+    permissions,
   };
 }
 
@@ -477,6 +491,34 @@ export function buildDashboardWithEveryProjectState({ jobName = "job-all-states"
       projects: PROJECT_STATE_VARIANTS.map((variant) =>
         buildProjectInState(`acme/${variant.key}`, variant.key),
       ),
+    }),
+  ];
+}
+
+/**
+ * Two jobs whose projects live in nested group paths — the shape the search box is
+ * used on in practice, where a term like "platform/api" names a strict subset of a
+ * single job. Every project is completed, so nothing is skipped for being mid-run
+ * and the trigger scope is decided by the filters alone.
+ */
+export function buildDashboardWithNestedProjectPaths() {
+  const completed = (name) => buildProject({ name, status: PROJECT_STATUSES.completed });
+  return [
+    buildRenovateJob({
+      name: "team-platform",
+      projects: [
+        completed("acme/platform/api-gateway"),
+        completed("acme/platform/api-docs"),
+        completed("acme/platform/web-ui"),
+        completed("acme/tooling/cli"),
+      ],
+    }),
+    buildRenovateJob({
+      name: "team-payments",
+      projects: [
+        completed("acme/payments/ledger"),
+        completed("acme/payments/api-billing"),
+      ],
     }),
   ];
 }

--- a/tests/ui/specs/triggerAllScope.spec.mjs
+++ b/tests/ui/specs/triggerAllScope.spec.mjs
@@ -1,0 +1,143 @@
+// Covers which projects the job card's trigger button acts on.
+//
+// The button is the only bulk action on the dashboard, and the list it sits above
+// is filterable three ways: the stat badges and the search box in the toolbar both
+// narrow every card, and each card's "Hide Projects" menu narrows its own rows.
+// Triggering more repositories than the filtered list shows is not recoverable —
+// the runs are already queued — so the scope has to be the rows on screen
+// (mogenius/renovate-operator#626).
+//
+// The page therefore names the projects it means in the request body. Only when
+// nothing is filtered does it leave them out, which is what tells the operator to
+// take every project it knows of, including ones discovered after this page load.
+
+import { test, expect } from "../fixtures/dashboardFixture.mjs";
+import {
+  buildDashboardWithEveryProjectState,
+  buildDashboardWithNestedProjectPaths,
+} from "../fixtures/renovateJobsFixture.mjs";
+
+test.describe("trigger all scope", () => {
+  test("triggers every project when nothing is filtered", async ({ dashboard }) => {
+    await dashboard.open(buildDashboardWithNestedProjectPaths());
+
+    await dashboard.triggerAll("team-platform");
+
+    // No project list at all: the operator decides what "all" means, so a project
+    // discovered since this page loaded is not silently left out.
+    expect(dashboard.triggerAllRequests).toEqual([
+      { renovateJob: "team-platform", namespace: "renovate" },
+    ]);
+    await expect(dashboard.triggerAllButton("team-platform")).toHaveText("Trigger All");
+  });
+
+  test("triggers only the projects the search box left visible", async ({ dashboard }) => {
+    // Both jobs hold a project matching "api", but only team-platform has the path.
+    await dashboard.open(buildDashboardWithNestedProjectPaths(), {
+      search: "platform/api",
+      expectedJobCount: 1,
+    });
+
+    const visible = await dashboard.projectNamesInJob("team-platform");
+    expect(visible).toEqual(["acme/platform/api-docs", "acme/platform/api-gateway"]);
+
+    await dashboard.triggerAll("team-platform");
+
+    expect(dashboard.triggerAllRequests).toEqual([
+      {
+        renovateJob: "team-platform",
+        namespace: "renovate",
+        projects: visible,
+      },
+    ]);
+  });
+
+  test("triggers only the projects the stat filter left visible", async ({ dashboard }) => {
+    await dashboard.open(buildDashboardWithEveryProjectState(), { statFilter: "failed" });
+
+    const visible = await dashboard.projectNamesInJob("job-all-states");
+    expect(visible).toEqual(["acme/failed-with-errors"]);
+
+    await dashboard.triggerAll("job-all-states");
+
+    expect(dashboard.triggerAllRequests).toEqual([
+      {
+        renovateJob: "job-all-states",
+        namespace: "renovate",
+        projects: ["acme/failed-with-errors"],
+      },
+    ]);
+  });
+
+  test("leaves out the projects a card's Hide Projects menu removed", async ({ dashboard }) => {
+    await dashboard.open(buildDashboardWithEveryProjectState());
+
+    await dashboard.hideProjects("job-all-states", ["Disabled", "No Config"]);
+
+    const visible = await dashboard.projectNamesInJob("job-all-states");
+    expect(visible).not.toContain("acme/disabled");
+    expect(visible).not.toContain("acme/no-config");
+    expect(visible).toContain("acme/completed-quiet");
+
+    await dashboard.triggerAll("job-all-states");
+
+    expect(dashboard.triggerAllRequests).toEqual([
+      {
+        renovateJob: "job-all-states",
+        namespace: "renovate",
+        projects: visible,
+      },
+    ]);
+  });
+
+  test("says how many projects it will trigger while a filter is active", async ({ dashboard }) => {
+    await dashboard.open(buildDashboardWithNestedProjectPaths(), {
+      search: "platform/api",
+      expectedJobCount: 1,
+    });
+
+    // The label is the only warning a user gets before an unrecoverable bulk action,
+    // so it has to state the narrowed scope rather than keep saying "All".
+    const triggerButton = dashboard.triggerAllButton("team-platform");
+    await expect(triggerButton).toHaveText("Trigger 2");
+    await expect(triggerButton).toHaveAttribute(
+      "aria-label",
+      "Trigger 2 filtered projects for team-platform",
+    );
+
+    await dashboard.searchInput.fill("");
+    await expect(triggerButton).toHaveText("Trigger All");
+  });
+
+  test("keeps the debug half of the button on the same scope", async ({ dashboard }) => {
+    await dashboard.open(buildDashboardWithNestedProjectPaths(), {
+      search: "tooling/",
+      expectedJobCount: 1,
+    });
+
+    await dashboard.triggerAll("team-platform", { debug: true });
+
+    expect(dashboard.triggerAllRequests).toEqual([
+      {
+        renovateJob: "team-platform",
+        namespace: "renovate",
+        projects: ["acme/tooling/cli"],
+        executionOptions: { debug: true },
+      },
+    ]);
+  });
+
+  test("cannot be pressed when a filter leaves a job without projects", async ({ dashboard }) => {
+    await dashboard.open(buildDashboardWithEveryProjectState());
+
+    // "Onboarding Closed", "Disabled" and "No Config" are the only checkboxes, so
+    // the emptiest a card gets this way still leaves rows — drive it from the search
+    // box instead, which can empty a card completely.
+    await dashboard.searchInput.fill("acme/disabled");
+    await expect(dashboard.triggerAllButton("job-all-states")).toHaveText("Trigger 1");
+
+    await dashboard.searchInput.fill("acme/nothing-matches-this");
+    await expect(dashboard.jobHeadings).toHaveCount(0);
+    expect(dashboard.triggerAllRequests).toEqual([]);
+  });
+});


### PR DESCRIPTION
# fix(ui): trigger only the projects the dashboard's filters left visible

Closes #626.

## What

Filter the dashboard by name or path — `a/b/c` — and press **Trigger All**, and the
operator queues a run for *every* discovered repository. The filters only ever existed
in the browser: the request named no projects at all, so the handler updated every
project of the job.

The button now acts on the rows the card shows. Queued runs cannot be taken back, which
is what makes the old behaviour worth a fix rather than a docs note.

## The change

**Frontend** (`src/static/index.html`)

- `triggerAllRenovate(job, executionOptions, projects)` puts the visible project names
  in the request body.
- The scope covers all three filters the page offers: the stat badges and the search box
  (a new `projectListIsFiltered` prop from `App`) and the card's own **Hide Projects**
  menu, which a card already applies to its rows.
- The label states the scope — `Trigger All` becomes `Trigger 2` while a filter is
  active, with a matching `aria-label` and tooltip — so the narrowed action is visible
  *before* the click. The debug half of the split button follows the same scope, and the
  disabled state now keys off the filtered list rather than the raw one.

**Backend** (`src/ui/renovateController.go`)

- `POST /api/v1/renovate/all` accepts an optional `projects: []string` and restricts the
  batch update to those names.

```jsonc
// filtered — only these two are scheduled
{"renovateJob": "team-platform", "namespace": "renovate",
 "projects": ["acme/platform/api-docs", "acme/platform/api-gateway"]}

// unfiltered — unchanged meaning: every project the job has
{"renovateJob": "team-platform", "namespace": "renovate"}
```

## Compatibility

- **An absent or empty list keeps the old meaning.** Only an unfiltered dashboard omits
  the field, so "all" still includes repositories discovered *after* the page loaded,
  and any other API caller is unaffected.
- **No new access surface.** `triggerAll` is still required, and a named subset is
  strictly less than what that permission already grants. Names the job does not have
  are ignored rather than erroring — the list is a filter, not a create.
- **The running/scheduled skip is untouched**: a listed project that is already running
  stays untouched, as before.
- No CRD, Helm value, config option or user-facing setting changes.

## Tests

| test | what it pins |
|---|---|
| `tests/ui/specs/triggerAllScope.spec.mjs` (7) | unfiltered sends no list; search, stat filter and "Hide Projects" each scope the request to the visible rows; the label states the count; the debug button matches; a filter that empties a card disables it |
| `TestRunRenovateForAllProjects_ProjectScope` (5) | no list triggers everything; a list triggers only those; an empty list is treated as no list; a listed running project stays untouched; an unknown name triggers nothing else |

The specs have teeth: `just test-ui-baseline HEAD --grep "trigger all scope"` fails 7/7
against the pages as they are on `main`, and the Go table test fails 3/5 against the
unpatched handler.

**One fixture gap fixed along the way.** `buildRenovateJob` omitted `permissions`, `role`
and `accepted`, so every card the existing specs render was read-only with its action
buttons disabled — a spec could not have clicked one. It now mirrors `ui.RenovateJobInfo`
as `tests/ui/README.md` requires, and the project-name cell carries the `data-testid` the
fixture's own helper already expected.

## Verification

```
just check     # golangci-lint 0 issues, CRDs unchanged,
               # 1043 Go tests (2 skipped), helm-unittest 8 suites / 77 tests
just test-ui   # 23/23
```

## Commits

Two, so the fix can be cherry-picked without the tests:

- `fix(ui): trigger only the projects the filters left visible` — production code only
  (`index.html`, `renovateController.go`). Verified to build and pass `go test ./ui/` on
  its own.
- `chore(tests): cover the scope of the dashboard's trigger button` — specs, fixtures,
  `tests/ui/README.md`, Go handler test.


## Not in this PR

- **No `docs/` change.** The dashboard has no page of its own there, so there is nothing
  that describes the trigger button to correct. Happy to add one if you want the UI
  documented.

## Checklist

- [x] One logical change
- [x] Title follows Conventional Commits
- [x] Branch prefixed with the change type — `fix/626-trigger-filtered-projects`
- [x] Every commit carries a `Signed-off-by` (DCO)
- [x] AI-assisted commits carry a `Co-Authored-By` naming the model
- [x] `just check` passes locally
- [x] New behaviour covered by unit tests, both sides of the HTTP boundary
